### PR TITLE
add fast path for specific assigns

### DIFF
--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -134,13 +134,8 @@ namespace xt
         template <class S>
         const_stepper stepper_end(const S& shape, layout_type l) const noexcept;
 
-        template <class E>
-        std::enable_if_t<xt::is_xscalar<CT>::value, void> assign_to(xexpression<E>& e) const
-        {
-            auto& ed = e.derived_cast();
-            ed.resize(m_shape);
-            std::fill(ed.begin(), ed.end(), m_e());
-        }
+        template <class E, class XCT = CT, class = std::enable_if_t<xt::is_xscalar<XCT>::value>>
+        void assign_to(xexpression<E>& e) const;
 
     private:
 
@@ -372,6 +367,15 @@ namespace xt
     {
         // Could check if (broadcastable(shape, m_shape)
         return m_e.stepper_end(shape, l);
+    }
+
+    template <class CT, class X>
+    template <class E, class XCT, class>
+    inline void xbroadcast<CT, X>::assign_to(xexpression<E>& e) const
+    {
+        auto& ed = e.derived_cast();
+        ed.resize(m_shape);
+        std::fill(ed.begin(), ed.end(), m_e());
     }
 }
 


### PR DESCRIPTION
this should considerably speed up `xt::zeros` and `xt::ones`

I would like to use the same methods for assigning reducers (and accumulators, should we ever have lazy ones :)

What do you think @JohanMabille @SylvainCorlay @ukoethe ?