### PR TITLE
Build with mingw

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,27 +24,21 @@ init:
   - ps: if($env:Platform -eq "x86"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86.exe' C:\Miniconda.exe; echo "Done"}
   - cmd: C:\Miniconda.exe /S /D=C:\xtensor-conda
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"
+  - set MINGW_PATH=%MINICONDA%\\Library\\mingw-w64\\bin
+  - "set PATH=%PATH%;%MINGW_PATH%"
 
 install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda install gtest=1.8.0 cmake -c conda-forge
+  - conda install gtest=1.8.1 cmake -c conda-forge
   - conda install xtl==0.4.16 -c QuantStack
+  - conda install m2w64-gcc m2w64-make m2w64-toolchain m2-libbz2 posix
   - conda install xsimd -c QuantStack
   - conda install nlohmann_json -c QuantStack
-    #- cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DXTENSOR_USE_XSIMD=ON -DDISABLE_VS2017=ON .
-    #- cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON .
-    #- if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" if "%PLATFORM%" == "x64" cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DXTENSOR_USE_XSIMD=ON .
-    #- if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" if "%PLATFORM%" == "x86" cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON .
-    #- if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Previous Visual Studio 2017" cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON .
-  - ps: if($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015" -And $env:Platform -eq "x64") {
-        cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DXTENSOR_USE_XSIMD=ON .
-        }
-        else {
-        cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON .
-        }
-  - nmake test_xtensor_lib
+  - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+  - cmake -G "MinGW Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DCMAKE_PREFIX_PATH=%MINGW_PATH% -DDOWNLOAD_GTEST=ON -DDISABLE_VS2017=ON .
+  - cmake --build .
   - cd test
 
 build_script:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,9 +23,8 @@ include(CheckCXXCompilerFlag)
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR (CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND NOT WIN32))
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Wunused-variable")
-    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion")
     CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
 
     if (HAS_CPP14_FLAG)

--- a/test/downloadGTest.cmake.in
+++ b/test/downloadGTest.cmake.in
@@ -10,15 +10,22 @@ cmake_minimum_required(VERSION 2.8.2)
 
 project(googletest-download NONE)
 
-include(ExternalProject)
+include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
+
+IF(WIN32)
+  # Disabling pthreads on windows + mingw
+  SET(GTEST_DISABLE_PTHREADS ON)
+ENDIF()
+
 ExternalProject_Add(googletest
     GIT_REPOSITORY    https://github.com/google/googletest.git
-    GIT_TAG           release-1.8.0
+    GIT_TAG           release-1.8.1
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
     BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""
     BUILD_COMMAND     ""
     INSTALL_COMMAND   ""
     TEST_COMMAND      ""
+    CMAKE_ARGS        -DGTEST_DISABLE_PTHREADS=${GTEST_DISABLE_PTHREADS}
 )
 


### PR DESCRIPTION
Test mingw builds on windows.
- Mingw requires gtest 1.8.1.
- Resulting build gives `STATUS_HEAP_CORRUPTION` at runtime.