### PR TITLE
Implement concatenation of fixed-shape tensors.

### DIFF
--- a/include/xtensor/xshape.hpp
+++ b/include/xtensor/xshape.hpp
@@ -340,6 +340,9 @@ namespace xt
         using only_fixed = std::integral_constant<bool, xtl::disjunction<is_fixed<S>...>::value &&
                                                         xtl::conjunction<xtl::disjunction<is_fixed<S>, is_scalar_shape<S>>...>::value>;
 
+        template <class... S>
+        using all_fixed = xtl::conjunction<is_fixed<S>...>;
+
         // The promote_index meta-function returns std::vector<promoted_value_type> in the
         // general case and an array of the promoted value type and maximal size if all
         // arguments are of type std::array

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -1581,10 +1581,18 @@ namespace xt
 #endif
         using value_type = std::size_t;
         using size_type = std::size_t;
+        using const_iterator = typename cast_type::const_iterator;
 
         constexpr static std::size_t size()
         {
             return sizeof...(X);
+        }
+
+        template <std::size_t idx>
+        constexpr static auto get()
+        {
+            using cast_type = std::array<std::size_t, sizeof...(X)>;
+            return std::get<idx>(cast_type{X...});
         }
 
         XTENSOR_FIXED_SHAPE_CONSTEXPR operator cast_type() const


### PR DESCRIPTION
This PR addresses #1750 by implementing a `concatenate_fixed` method for tensors with fixed shapes. The output shape is calculated at compile time, with `axis` passed as a template parameter.

Not sure if this is a good way to handle the original issue -- feedback is very much welcome.