### PR TITLE
Have xtensor container reshape method return a reference to self

### DIFF
--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -279,10 +279,10 @@ namespace xt
         void resize(S&& shape, const strides_type& strides);
 
         template <class S = shape_type>
-        void reshape(S&& shape, layout_type layout = base_type::static_layout);
+        auto& reshape(S&& shape, layout_type layout = base_type::static_layout) &;
 
         template <class T>
-        void reshape(std::initializer_list<T> shape, layout_type layout = base_type::static_layout);
+        auto& reshape(std::initializer_list<T> shape, layout_type layout = base_type::static_layout) &;
 
         layout_type layout() const noexcept;
         bool is_contiguous() const noexcept;
@@ -981,19 +981,21 @@ namespace xt
      */
     template <class D>
     template <class S>
-    inline void xstrided_container<D>::reshape(S&& shape, layout_type layout)
+    inline auto& xstrided_container<D>::reshape(S&& shape, layout_type layout) &
     {
         reshape_impl(std::forward<S>(shape), std::is_signed<std::decay_t<typename std::decay_t<S>::value_type>>(), std::forward<layout_type>(layout));
+        return *this;
     }
 
     template <class D>
     template <class T>
-    inline void xstrided_container<D>::reshape(std::initializer_list<T> shape, layout_type layout)
+    inline auto& xstrided_container<D>::reshape(std::initializer_list<T> shape, layout_type layout) &
     {
         using sh_type = rebind_container_t<T, shape_type>;
         sh_type sh = xtl::make_sequence<sh_type>(shape.size());
         std::copy(shape.begin(), shape.end(), sh.begin());
         reshape_impl(std::move(sh), std::is_signed<T>(), std::forward<layout_type>(layout));
+        return *this;
     }
 
     template <class D>

--- a/include/xtensor/xfixed.hpp
+++ b/include/xtensor/xfixed.hpp
@@ -348,7 +348,7 @@ namespace xt
         void resize(ST&& shape, const strides_type& strides) const;
 
         template <class ST = std::array<std::size_t, N>>
-        void reshape(ST&& shape, layout_type layout = L) const;
+        auto const& reshape(ST&& shape, layout_type layout = L) const;
 
         template <class ST>
         bool broadcast_shape(ST& s, bool reuse_cache = false) const;
@@ -481,7 +481,7 @@ namespace xt
         void resize(ST&& shape, const strides_type& strides) const;
 
         template <class ST = std::array<std::size_t, N>>
-        void reshape(ST&& shape, layout_type layout = L) const;
+        const auto& reshape(ST&& shape, layout_type layout = L) const;
 
         template <class ST>
         bool broadcast_shape(ST& s, bool reuse_cache = false) const;
@@ -699,12 +699,13 @@ namespace xt
      */
     template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline void xfixed_container<ET, S, L, SH, Tag>::reshape(ST&& shape, layout_type layout) const
+    inline auto const& xfixed_container<ET, S, L, SH, Tag>::reshape(ST&& shape, layout_type layout) const
     {
         if (!(std::equal(shape.begin(), shape.end(), m_shape.begin()) && shape.size() == m_shape.size() && layout == L))
         {
             XTENSOR_THROW(std::runtime_error, "Trying to reshape xtensor_fixed with different shape or layout.");
         }
+        return *this;
     }
 
     template <class ET, class S, layout_type L, bool SH, class Tag>
@@ -883,12 +884,13 @@ namespace xt
      */
     template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline void xfixed_adaptor<ET, S, L, SH, Tag>::reshape(ST&& shape, layout_type layout) const
+    inline auto const& xfixed_adaptor<ET, S, L, SH, Tag>::reshape(ST&& shape, layout_type layout) const
     {
         if (!(std::equal(shape.begin(), shape.end(), m_shape.begin()) && shape.size() == m_shape.size() && layout == L))
         {
             XTENSOR_THROW(std::runtime_error, "Trying to reshape xtensor_fixed with different shape or layout.");
         }
+        return *this;
     }
 
     template <class ET, class S, layout_type L, bool SH, class Tag>

--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -492,7 +492,7 @@ namespace xt
         auto resize(S&& shape, const strides_type& strides);
 
         template <class S = shape_type>
-        auto reshape(S&& shape, layout_type layout = base_type::static_layout);
+        auto & reshape(S&& shape, layout_type layout = base_type::static_layout) &;
 
     private:
 
@@ -1413,9 +1413,10 @@ namespace xt
 
     template <class F, class CT>
     template <class S>
-    auto xfunctor_adaptor<F, CT>::reshape(S&& shape, layout_type layout)
+    auto & xfunctor_adaptor<F, CT>::reshape(S&& shape, layout_type layout) &
     {
         this->m_e.reshape(std::forward<S>(shape), layout);
+        return *this;
     }
 
     /************************************

--- a/include/xtensor/xoptional_assembly_base.hpp
+++ b/include/xtensor/xoptional_assembly_base.hpp
@@ -130,10 +130,10 @@ namespace xt
         void resize(const S& shape, const strides_type& strides);
 
         template <class S = shape_type>
-        void reshape(const S& shape, layout_type layout = static_layout);
+        auto & reshape(const S& shape, layout_type layout = static_layout) &;
 
         template <class T>
-        void reshape(std::initializer_list<T> shape, layout_type layout = static_layout);
+        auto & reshape(std::initializer_list<T> shape, layout_type layout = static_layout) &;
 
         layout_type layout() const noexcept;
         bool is_contiguous() const noexcept;
@@ -418,18 +418,20 @@ namespace xt
      */
     template <class D>
     template <class S>
-    inline void xoptional_assembly_base<D>::reshape(const S& shape, layout_type layout)
+    inline auto & xoptional_assembly_base<D>::reshape(const S& shape, layout_type layout) &
     {
         value().reshape(shape, layout);
         has_value().reshape(shape, layout);
+        return *this;
     }
 
     template <class D>
     template <class T>
-    inline void xoptional_assembly_base<D>::reshape(std::initializer_list<T> shape, layout_type layout)
+    inline auto & xoptional_assembly_base<D>::reshape(std::initializer_list<T> shape, layout_type layout) &
     {
         value().reshape(shape, layout);
         has_value().reshape(shape, layout);
+        return *this;
     }
 
     /**

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -239,9 +239,12 @@ namespace xt
             vec.reshape({ 3, -1, 4 }, layout_type::row_major);
             compare_shape(vec, rm);
 
+            auto & vec_ref = vec.reshape({ 3, -1, 4 }, layout_type::row_major);
+            compare_shape(vec_ref, rm);
+
             shape = rm.m_shape;
             shape.front() += 123;
-            XT_EXPECT_THROW(vec.reshape(shape), std::runtime_error);
+            XT_EXPECT_THROW(vec_ref.reshape(shape), std::runtime_error);
         }
     }
 


### PR DESCRIPTION
This provides an API more consistent with Numpy usage.

Fix #1795