### PR TITLE
Allow use of cmake add_subdirectory(xtensor) by checking for xtl target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,18 @@ message(STATUS "Building xtensor v${${PROJECT_NAME}_VERSION}")
 # ============
 
 set(xtl_REQUIRED_VERSION 0.6.9)
-find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
-message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
+if(TARGET xtl)
+    set(xtl_VERSION ${XTL_VERSION_MAJOR}.${XTL_VERSION_MINOR}.${XTL_VERSION_PATCH})
+    # Note: This is not SEMVER compatible comparison
+    if( NOT ${xtl_VERSION} VERSION_GREATER_EQUAL ${xtl_REQUIRED_VERSION})
+        message(ERROR "Mismatch xtl versions. Found '${xtl_VERSION}' but requires: '${xtl_REQUIRED_VERSION}'")
+    else()
+        message(STATUS "Found xtl v${xtl_VERSION}")
+    endif()
+else(TARGET xtl)
+    find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
+    message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
+endif(TARGET xtl)
 
 find_package(nlohmann_json 3.1.1 QUIET)
 


### PR DESCRIPTION
This is currently limited to just the `xtl` target as I hadn't gotten around to using `xsimd`, but it could perhaps be handled similarly.

In the notice about version checking, I couldn't find CMake's implementation for VERSION_GREATER_EQUAL and assume that `v1.0 > v0.6.9` evaluates true.

related #1692 