### PR TITLE
Pass all unittest in MSVC Debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ OPTION(DEFAULT_COLUMN_MAJOR "set default layout to column major" OFF)
 OPTION(DISABLE_VS2017 "disables the compilation of some test with Visual Studio 2017" OFF)
 OPTION(CPP17 "enables C++17" OFF)
 OPTION(XTENSOR_DISABLE_EXCEPTIONS "Disable C++ exceptions" OFF)
+OPTION(DISABLE_MSVC_ITERATOR_CHECK "Disable the MVSC iterator check" ON)
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     set(BUILD_TESTS ON)
@@ -207,6 +208,10 @@ endif()
 
 if(DISABLE_VS2017)
     add_definitions(-DDISABLE_VS2017)
+endif()
+
+if(MSVC AND DISABLE_MSVC_ITERATOR_CHECK)
+    add_compile_definitions($<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>)
 endif()
 
 if(BUILD_TESTS)


### PR DESCRIPTION
The standard library of microsoft contains in the default debug configuration
a iterator-check. This check is not compatible with the iterator design choice
of xtensor. The check should be disabled for MSVC Debug.

The check is easily disabled with the define "_ITERATOR_DEBUG_LEVEL=0"
A new option "DISABLE_MSVC_ITERATOR_CHECK" is created to control this behaviour.
The default value of the option is "ON".

With this solution, the unittest can also be executed in debug mode on a windows
machine.

**Please check if your PR fulfills these requirements**

- The title and the commit message(s) are descriptive
- Small commits made to fix your PR have been squashed to avoid history pollution
- Tests have been added for new features or bug fixes
- API of new functions and classes are documented
- If you PR introduces backward incompatible changes, update the version number
in both docs/source/changelog.rst and include/xtensor/xtensor_config.hpp according
to the following rules:
    - if XTENSOR_VERSION_PATCH is already 0-dev, you have nothing to do
    - otherwise, set XTENSOR_VERSION_PATCH to 0-dev and increase XTENSOR_VERSION_MINOR by 1
