### PR TITLE
Add row and col facade for 2 dim container

### DIFF
--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -1669,7 +1669,7 @@ namespace xt
 
     namespace detail
     {
-        class RowImpl
+        class row_impl
         {
         public:
             template<class E>
@@ -1696,7 +1696,7 @@ namespace xt
             }
         };
 
-        class ColumnImpl
+        class column_impl
         {
         public:
             template<class E>
@@ -1724,16 +1724,32 @@ namespace xt
         };
     }
 
+    /**
+     * Constructs and returns a row (sliced view) on the specified expression.
+     * Users should not directly construct the slices but call helper functions
+     * instead. This function is only allowed on expressions with two dimensions.
+     * @param e the xexpression to adapt
+     * @param index 0-based index of the row
+     * @throws std::invalid_argument if the expression has more than 2 dimensions.
+     */
     template <class E>
-    inline auto row(E&& e, const int index)
+    inline auto row(E&& e, int index)
     {
-        return detail::RowImpl::make(e, index);
+        return detail::row_impl::make(e, index);
     }
 
+    /**
+     * Constructs and returns a column (sliced view) on the specified expression.
+     * Users should not directly construct the slices but call helper functions
+     * instead. This function is only allowed on expressions with two dimensions.
+     * @param e the xexpression to adapt
+     * @param index 0-based index of the column
+     * @throws std::invalid_argument if the expression has more than 2 dimensions.
+     */
     template <class E>
-    inline auto col(E&& e, const int index)
+    inline auto col(E&& e, int index)
     {
-        return detail::ColumnImpl::make(e, index);
+        return detail::column_impl::make(e, index);
     }
 
     /***************

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -1675,8 +1675,10 @@ namespace xt
             template<class E>
             static inline auto make(E&& e, const int index)
             {
-                check_dimension(e.shape());
-                return view(e, index, xt::all());
+                const auto shape = e.shape();
+                check_dimension(shape);
+                const int non_negative_index = index < 0 ? static_cast<int>(index + shape[0]) : index;
+                return view(e, non_negative_index, xt::all());
             }
 
         private:
@@ -1702,8 +1704,10 @@ namespace xt
             template<class E>
             static inline auto make(E&& e, const int index)
             {
-                check_dimension(e.shape());
-                return view(e, xt::all(), index);
+                const auto shape = e.shape();
+                check_dimension(shape);
+                const int non_negative_index = index < 0 ? static_cast<int>(index + shape[1]) : index;
+                return view(e, xt::all(), non_negative_index);
             }
 
         private:
@@ -1729,7 +1733,8 @@ namespace xt
      * Users should not directly construct the slices but call helper functions
      * instead. This function is only allowed on expressions with two dimensions.
      * @param e the xexpression to adapt
-     * @param index 0-based index of the row
+     * @param index 0-based index of the row, negative indices will return the
+     * last rows in reverse order.
      * @throws std::invalid_argument if the expression has more than 2 dimensions.
      */
     template <class E>
@@ -1743,7 +1748,8 @@ namespace xt
      * Users should not directly construct the slices but call helper functions
      * instead. This function is only allowed on expressions with two dimensions.
      * @param e the xexpression to adapt
-     * @param index 0-based index of the column
+     * @param index 0-based index of the column, negative indices will return the
+     * last columns in reverse order.
      * @throws std::invalid_argument if the expression has more than 2 dimensions.
      */
     template <class E>

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -1547,7 +1547,7 @@ namespace xt
             { { 5, 6 }, { 7, 8 } },
         };
 
-        ASSERT_THROW(
+        XT_ASSERT_THROW(
             const auto row = xt::row(arr, 0),
             std::invalid_argument
         );
@@ -1608,7 +1608,7 @@ namespace xt
             { { 5, 6 }, { 7, 8 } },
         };
 
-        ASSERT_THROW(
+        XT_ASSERT_THROW(
             const auto col = xt::col(arr, 0),
             std::invalid_argument
         );

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -1489,4 +1489,136 @@ namespace xt
         EXPECT_FALSE(a(1, 0));
         EXPECT_FALSE(a(1, 1));
     }
+
+    TEST(xview, row_on_2dim_xarray)
+    {
+        xt::xarray<int> array{
+            { 1, 2 },
+            { 3, 4 },
+        };
+
+        const auto row0 = xt::row(array, 0);
+        const auto row1 = xt::row(array, 1);
+
+        EXPECT_EQ(row0(0), 1);
+        EXPECT_EQ(row0(1), 2);
+        EXPECT_EQ(row1(0), 3);
+        EXPECT_EQ(row1(1), 4);
+    }
+
+    TEST(xiew, row_on_2dim_xtensor)
+    {
+        xt::xtensor<int, 2> tensor{
+            { 1, 2 },
+            { 3, 4 },
+        };
+
+        std::cout << tensor.shape().size() << std::endl;
+
+        const auto row0 = xt::row(tensor, 0);
+        const auto row1 = xt::row(tensor, 1);
+
+        EXPECT_EQ(row0(0), 1);
+        EXPECT_EQ(row0(1), 2);
+        EXPECT_EQ(row1(0), 3);
+        EXPECT_EQ(row1(1), 4);
+    }
+
+    TEST(xiew, row_on_2dim_xtensor_fixed)
+    {
+        xt::xtensor_fixed<int, xshape<2, 2>> tensor_fixed{
+            { 1, 2 },
+            { 3, 4 },
+        };
+
+        const auto row0 = xt::row(tensor_fixed, 0);
+        const auto row1 = xt::row(tensor_fixed, 1);
+
+        EXPECT_EQ(row0(0), 1);
+        EXPECT_EQ(row0(1), 2);
+        EXPECT_EQ(row1(0), 3);
+        EXPECT_EQ(row1(1), 4);
+    }
+
+    TEST(xview, row_on_3dim_array)
+    {
+        xt::xarray<int> arr{
+            { { 1, 2 }, { 3, 4 } },
+            { { 5, 6 }, { 7, 8 } },
+        };
+
+        ASSERT_THROW(
+            const auto row = xt::row(arr, 0),
+            std::invalid_argument
+        );
+    }
+
+    TEST(xview, col_on_2dim_xarray)
+    {
+        xt::xarray<int> array{
+            { 1, 2 },
+            { 3, 4 },
+        };
+
+        const auto col0 = xt::col(array, 0);
+        const auto col1 = xt::col(array, 1);
+
+        EXPECT_EQ(col0(0), 1);
+        EXPECT_EQ(col0(1), 3);
+        EXPECT_EQ(col1(0), 2);
+        EXPECT_EQ(col1(1), 4);
+    }
+
+    TEST(xview, col_on_2dim_xtensor)
+    {
+        xt::xtensor<int, 2> tensor{
+            { 1, 2 },
+            { 3, 4 },
+        };
+
+        const auto col0 = xt::col(tensor, 0);
+        const auto col1 = xt::col(tensor, 1);
+
+        EXPECT_EQ(col0(0), 1);
+        EXPECT_EQ(col0(1), 3);
+        EXPECT_EQ(col1(0), 2);
+        EXPECT_EQ(col1(1), 4);
+    }
+
+    TEST(xview, col_on_2dim_xtensor_fixed)
+    {
+        xt::xtensor_fixed<int, xshape<2, 2>> tensor_fixed{
+            { 1, 2 },
+            { 3, 4 },
+        };
+
+        const auto col0 = xt::col(tensor_fixed, 0);
+        const auto col1 = xt::col(tensor_fixed, 1);
+
+        EXPECT_EQ(col0(0), 1);
+        EXPECT_EQ(col0(1), 3);
+        EXPECT_EQ(col1(0), 2);
+        EXPECT_EQ(col1(1), 4);
+    }
+
+    TEST(xview, col_on_3dim_array)
+    {
+        xt::xarray<int> arr{
+            { { 1, 2 }, { 3, 4 } },
+            { { 5, 6 }, { 7, 8 } },
+        };
+
+        ASSERT_THROW(
+            const auto col = xt::col(arr, 0),
+            std::invalid_argument
+        );
+    }
+
+    // This code should not compile!
+    //TEST(xview, col_on_3dim_xtensor)
+    //{
+    //    xt::xtensor<int, 3> tensor;
+    //    xt::row(tensor, 0);
+    //    xt::col(tensor, 0);
+    //}
 }

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -1490,20 +1490,37 @@ namespace xt
         EXPECT_FALSE(a(1, 1));
     }
 
-    TEST(xview, row_on_2dim_xarray)
+    TEST(xview, first_rows_on_2dim_xarray)
     {
         xt::xarray<int> array{
             { 1, 2 },
             { 3, 4 },
         };
 
-        const auto row0 = xt::row(array, 0);
-        const auto row1 = xt::row(array, 1);
+        const auto first_row = xt::row(array, 0);
+        const auto second_row = xt::row(array, 1);
 
-        EXPECT_EQ(row0(0), 1);
-        EXPECT_EQ(row0(1), 2);
-        EXPECT_EQ(row1(0), 3);
-        EXPECT_EQ(row1(1), 4);
+        EXPECT_EQ(first_row(0), 1);
+        EXPECT_EQ(first_row(1), 2);
+        EXPECT_EQ(second_row(0), 3);
+        EXPECT_EQ(second_row(1), 4);
+    }
+
+    TEST(xview, last_rows_on_2dim_xarray)
+    {
+        xt::xarray<int> array{
+            { 1, 2 },
+            { 3, 4 },
+            { 5, 6 },
+        };
+
+        const auto last_row = xt::row(array, -1);
+        const auto second_last_row = xt::row(array, -2);
+
+        EXPECT_EQ(last_row(0), 5);
+        EXPECT_EQ(last_row(1), 6);
+        EXPECT_EQ(second_last_row(0), 3);
+        EXPECT_EQ(second_last_row(1), 4);
     }
 
     TEST(xiew, row_on_2dim_xtensor)
@@ -1553,20 +1570,36 @@ namespace xt
         );
     }
 
-    TEST(xview, col_on_2dim_xarray)
+    TEST(xview, first_cols_on_2dim_xarray)
     {
         xt::xarray<int> array{
             { 1, 2 },
             { 3, 4 },
         };
 
-        const auto col0 = xt::col(array, 0);
-        const auto col1 = xt::col(array, 1);
+        const auto first_col = xt::col(array, 0);
+        const auto second_col = xt::col(array, 1);
 
-        EXPECT_EQ(col0(0), 1);
-        EXPECT_EQ(col0(1), 3);
-        EXPECT_EQ(col1(0), 2);
-        EXPECT_EQ(col1(1), 4);
+        EXPECT_EQ(first_col(0), 1);
+        EXPECT_EQ(first_col(1), 3);
+        EXPECT_EQ(second_col(0), 2);
+        EXPECT_EQ(second_col(1), 4);
+    }
+
+    TEST(xview, last_cols_on_2dim_xarray)
+    {
+        xt::xarray<int> array{
+            { 1, 2, 3 },
+            { 4, 5, 6 },
+        };
+
+        const auto last_col = xt::col(array, -1);
+        const auto second_last_col = xt::col(array, -2);
+
+        EXPECT_EQ(last_col(0), 3);
+        EXPECT_EQ(last_col(1), 6);
+        EXPECT_EQ(second_last_col(0), 2);
+        EXPECT_EQ(second_last_col(1), 5);
     }
 
     TEST(xview, col_on_2dim_xtensor)


### PR DESCRIPTION
This pull request is related to #1189.
Row and col shortcuts for two-dimensional containers make the code more  readable.

The implementation is straight forward. The row and col function can only be called on a two-dimensional container. If the functions are called on a container with other dimension an error occurs.
If the container has compile-constant dimensions, a static_assert will fail the build.
If the container has runtime-specific dimensions, a std::invalid_argument exception is thrown.

**Please check if your PR fulfills these requirements**

- The title and the commit message(s) are descriptive
- Small commits made to fix your PR have been squashed to avoid history pollution
- Tests have been added for new features or bug fixes
- API of new functions and classes are documented
- If you PR introduces backward incompatible changes, update the version number
in both docs/source/changelog.rst and include/xtensor/xtensor_config.hpp according
to the following rules:
    - if XTENSOR_VERSION_PATCH is already 0-dev, you have nothing to do
    - otherwise, set XTENSOR_VERSION_PATCH to 0-dev and increase XTENSOR_VERSION_MINOR by 1
