### PR TITLE
Fix reshape return

### DIFF
--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -984,7 +984,7 @@ namespace xt
     inline auto& xstrided_container<D>::reshape(S&& shape, layout_type layout) &
     {
         reshape_impl(std::forward<S>(shape), std::is_signed<std::decay_t<typename std::decay_t<S>::value_type>>(), std::forward<layout_type>(layout));
-        return *this;
+        return this->derived_cast();
     }
 
     template <class D>
@@ -995,7 +995,7 @@ namespace xt
         sh_type sh = xtl::make_sequence<sh_type>(shape.size());
         std::copy(shape.begin(), shape.end(), sh.begin());
         reshape_impl(std::move(sh), std::is_signed<T>(), std::forward<layout_type>(layout));
-        return *this;
+        return this->derived_cast();
     }
 
     template <class D>

--- a/test/test_xarray.cpp
+++ b/test/test_xarray.cpp
@@ -323,4 +323,15 @@ namespace xt
         using array_type = xarray<int>;
         test_iterator_types<array_type, int*, const int*>();
     }
+
+    auto test_reshape_compile() {
+        xt::xarray<double> a = xt::zeros<double>({5, 5});
+        return a.reshape({1, 25});
+    }
+
+    TEST(xarray, reshape_return)
+    {
+        auto a = test_reshape_compile();
+        EXPECT_EQ(a.shape(), std::vector<std::size_t>({1, 25}));
+    }
 }


### PR DESCRIPTION
cc @JohanMabille 

this was causing issues in the benchmarking code because the `xstrided_container` constructor and destructor are protected. If we return derived_cast it seems fine.
What do you think?