### PR TITLE
Add implementation of repeat (similar to numpy)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE_DIR}/xtensor/xpad.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xrandom.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xreducer.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xrepeat.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xscalar.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xsemantic.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xshape.hpp

--- a/include/xtensor/xmanipulation.hpp
+++ b/include/xtensor/xmanipulation.hpp
@@ -861,7 +861,8 @@ namespace xt
     template <class E>
     inline auto repeat(E&& e, std::ptrdiff_t repeats, std::ptrdiff_t axis)
     {
-        std::vector<std::ptrdiff_t> broadcasted_repeats(e.shape(axis));
+        const auto casted_axis = static_cast<typename std::decay_t<E>::size_type>(axis);
+        std::vector<std::ptrdiff_t> broadcasted_repeats(e.shape(casted_axis));
         std::fill(broadcasted_repeats.begin(), broadcasted_repeats.end(), repeats);
         return repeat(std::forward<E>(e), std::forward<std::vector<std::ptrdiff_t>>(broadcasted_repeats), axis);
     }
@@ -869,11 +870,12 @@ namespace xt
     template <class E>
     inline auto repeat(E&& e, std::vector<std::ptrdiff_t>&& repeats, std::ptrdiff_t axis)
     {
-        if (repeats.size() != e.shape(axis))
+        const auto casted_axis = static_cast<typename std::decay_t<E>::size_type>(axis);
+        if (repeats.size() != e.shape(casted_axis))
         {
-            XTENSOR_THROW(std::invalid_argument, "repeats and axes must have the same size");
+            XTENSOR_THROW(std::invalid_argument, "repeats must have the same size as the specified axis");
         }
-        return xrepeat<E>(std::forward<E>(e), std::forward<std::vector<std::ptrdiff_t>>(repeats), axis);
+        return xrepeat<E>(std::forward<E>(e), std::forward<std::vector<std::ptrdiff_t>>(repeats), casted_axis);
     }
 }
 

--- a/include/xtensor/xmanipulation.hpp
+++ b/include/xtensor/xmanipulation.hpp
@@ -89,13 +89,10 @@ namespace xt
     auto roll(E&& e, std::ptrdiff_t shift, std::ptrdiff_t axis);
 
     template<class E>
-    auto repeat(E&& e, std::ptrdiff_t repeats);
+    auto repeat(E&& e, std::ptrdiff_t repeats, std::ptrdiff_t axis);
 
     template<class E>
-    auto repeat(E&& e, std::ptrdiff_t repeats, std::vector<std::ptrdiff_t>&& axes);
-
-    template<class E>
-    auto repeat(E&& e, std::vector<std::ptrdiff_t>&& repeats, std::vector<std::ptrdiff_t>&& axes);
+    auto repeat(E&& e, std::vector<std::ptrdiff_t>&& repeats, std::ptrdiff_t axis);
 
     /****************************
      * transpose implementation *
@@ -861,50 +858,22 @@ namespace xt
     /****************************
      * repeat implementation    *
      ****************************/
-
     template <class E>
-    inline auto repeat(E&& e, std::ptrdiff_t repeats)
+    inline auto repeat(E&& e, std::ptrdiff_t repeats, std::ptrdiff_t axis)
     {
-        std::vector<std::ptrdiff_t> axes(e.dimension());
-        std::iota(axes.begin(), axes.end(), 0);
-        return repeat(
-            std::forward<E>(e),
-            repeats,
-            std::forward<std::vector<std::ptrdiff_t>>(axes)
-        );
+        std::vector<std::ptrdiff_t> broadcasted_repeats(e.shape(axis));
+        std::fill(broadcasted_repeats.begin(), broadcasted_repeats.end(), repeats);
+        return repeat(std::forward<E>(e), std::forward<std::vector<std::ptrdiff_t>>(broadcasted_repeats), axis);
     }
 
     template <class E>
-    inline auto repeat(E&& e, std::ptrdiff_t repeats, std::vector<std::ptrdiff_t>&& axes)
+    inline auto repeat(E&& e, std::vector<std::ptrdiff_t>&& repeats, std::ptrdiff_t axis)
     {
-        if (axes.size() > 0)
-        {
-            std::vector<std::ptrdiff_t> broadcasted_repeats(axes.size());
-            std::fill(broadcasted_repeats.begin(), broadcasted_repeats.end(), repeats);
-            return repeat(
-                std::forward<E>(e),
-                std::forward<std::vector<std::ptrdiff_t>>(broadcasted_repeats),
-                std::forward<std::vector<std::ptrdiff_t>>(axes)
-            );
-        }
-        else
-        {
-            return repeat(std::forward<E>(e), repeats);
-        }
-    }
-
-    template <class E>
-    inline auto repeat(E&& e, std::vector<std::ptrdiff_t>&& repeats, std::vector<std::ptrdiff_t>&& axes)
-    {
-        if (axes.size() > 0 && repeats.size() != axes.size())
+        if (repeats.size() != e.shape(axis))
         {
             XTENSOR_THROW(std::invalid_argument, "repeats and axes must have the same size");
         }
-        return xrepeat<E>(
-            std::forward<E>(e),
-            std::forward<std::vector<std::ptrdiff_t>>(repeats),
-            std::forward<std::vector<std::ptrdiff_t>>(axes)
-        );
+        return xrepeat<E>(std::forward<E>(e), std::forward<std::vector<std::ptrdiff_t>>(repeats), axis);
     }
 }
 

--- a/include/xtensor/xrepeat.hpp
+++ b/include/xtensor/xrepeat.hpp
@@ -146,12 +146,22 @@ namespace xt
         using xexpression_type = std::decay_t<CT>;
         using value_type = typename xexpression_type::value_type;
         using shape_type = typename xexpression_type::shape_type;
+
+        using container_type = xcontainer_inner_types<xrepeat<CT>>;
+        using reference = typename container_type::reference;
+        using const_reference = typename container_type::const_reference;
+        using size_type = typename container_type::size_type;
+        using temporary_type = typename container_type::temporary_type;
+
         static constexpr layout_type static_layout = xexpression_type::static_layout;
         using bool_load_type = typename xexpression_type::bool_load_type;
         using pointer = typename xexpression_type::pointer;
         using const_pointer = typename xexpression_type::const_pointer;
         using difference_type = typename xexpression_type::difference_type;
-        using stepper = xiterable<xrepeat<CT>>::stepper;
+
+        using iterable_type = xiterable<xrepeat<CT>>;
+        using stepper = typename iterable_type::stepper;
+        using const_stepper = typename iterable_type::stepper;
 
         template<class CTA>
         explicit xrepeat(CTA&& e,
@@ -164,7 +174,7 @@ namespace xt
         template <class... Args>
         const_reference operator()(Args... args) const;
 
-        const inner_shape_type& shape() const noexcept;
+        const shape_type& shape() const noexcept;
 
         template <class It>
         reference element(It first, It last);
@@ -179,7 +189,7 @@ namespace xt
     private:
         CT m_e;
         std::vector<std::ptrdiff_t> m_repeat_lookup;
-        inner_shape_type m_shape;
+        shape_type m_shape;
 
         reference access();
 
@@ -257,7 +267,7 @@ namespace xt
     }
 
     template <class CT>
-    inline auto xrepeat<CT>::shape() const noexcept -> const inner_shape_type&
+    inline auto xrepeat<CT>::shape() const noexcept -> const shape_type&
     {
         return m_shape;
     }

--- a/include/xtensor/xrepeat.hpp
+++ b/include/xtensor/xrepeat.hpp
@@ -92,7 +92,7 @@ namespace xt
         S m_substepper;
         const shape_type& m_shape;
 
-        size_type m_repeating_steps;
+        std::ptrdiff_t m_repeating_steps;
         std::vector<size_type> m_positions;
         size_type m_subposition;
 
@@ -428,7 +428,7 @@ namespace xt
         if (dim == m_repeating_axis)
         {
             m_subposition = m_repeats.size() - 1;
-            m_repeating_steps = m_repeats.back() - 1;
+            m_repeating_steps = static_cast<std::ptrdiff_t>(m_repeats.back()) - 1;
         }
     }
 
@@ -474,10 +474,10 @@ namespace xt
             if (dim == m_repeating_axis)
             {
                 size_type subposition = m_subposition;
-                m_repeating_steps += steps_to_go;
-                while (m_repeating_steps >= m_repeats[subposition])
+                m_repeating_steps += static_cast<std::ptrdiff_t>(steps_to_go);
+                while (m_repeating_steps >= static_cast<ptrdiff_t>(m_repeats[subposition]))
                 {
-                    m_repeating_steps -= m_repeats[subposition];
+                    m_repeating_steps -= static_cast<ptrdiff_t>(m_repeats[subposition]);
                     ++subposition;
                 }
                 m_substepper.step(dim, subposition - m_subposition);
@@ -499,11 +499,11 @@ namespace xt
             if (dim == m_repeating_axis)
             {
                 size_type subposition = m_subposition;
-                m_repeating_steps -= steps_to_go;
-                while (m_repeating_steps > m_repeats[subposition])
+                m_repeating_steps -= static_cast<std::ptrdiff_t>(steps_to_go);
+                while (m_repeating_steps < 0)
                 {
                     --subposition;
-                    m_repeating_steps += m_repeats[subposition];
+                    m_repeating_steps += static_cast<ptrdiff_t>(m_repeats[subposition]);
                 }
                 m_substepper.step_back(dim, m_subposition - subposition);
                 m_subposition = subposition;
@@ -543,13 +543,13 @@ namespace xt
     template<class S, class R>
     inline auto xrepeat_stepper<S, R>::get_next_positions_back(const size_type dim, const size_type steps_to_go) const -> std::vector<size_type>
     {
-        size_type next_position_for_dim = m_positions[dim] - steps_to_go;
+        auto next_position_for_dim = static_cast<std::ptrdiff_t>(m_positions[dim] - steps_to_go);
         if (dim > 0)
         {
             size_type steps_in_previous_dim = 0;
-            while (next_position_for_dim >= m_shape[dim])
+            while (next_position_for_dim < 0)
             {
-                next_position_for_dim += m_shape[dim];
+                next_position_for_dim += static_cast<std::ptrdiff_t>(m_shape[dim]);
                 ++steps_in_previous_dim;
             }
             if (steps_in_previous_dim > 0)
@@ -560,7 +560,7 @@ namespace xt
             }
         }
         std::vector<size_type> next_positions = m_positions;
-        next_positions[dim] = next_position_for_dim;
+        next_positions[dim] = static_cast<size_type>(next_position_for_dim);
         return next_positions;
     }
 }

--- a/include/xtensor/xrepeat.hpp
+++ b/include/xtensor/xrepeat.hpp
@@ -1,0 +1,432 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_XREPEAT
+#define XTENSOR_XREPEAT
+
+#include <vector>
+#include <utility>
+
+#include "xaccessible.hpp"
+#include "xiterable.hpp"
+
+
+namespace xt
+{
+    template <class CT> class xrepeat;
+    template <class S> class xrepeat_stepper;
+
+    template <class CT>
+    struct xcontainer_inner_types<xrepeat<CT>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using reference = inner_reference_t<CT>;
+        using const_reference = typename xexpression_type::const_reference;
+        using size_type = typename xexpression_type::size_type;
+        using temporary_type = typename xexpression_type::temporary_type;
+
+        static constexpr bool is_const = std::is_const<std::remove_reference_t<CT>>::value;
+
+        using extract_storage_type = xtl::mpl::eval_if_t<has_data_interface<xexpression_type>,
+            detail::expr_storage_type<xexpression_type>,
+            make_invalid_type<>>;
+        using storage_type = std::conditional_t<is_const, const extract_storage_type, extract_storage_type>;
+    };
+
+    template <class CT>
+    struct xiterable_inner_types<xrepeat<CT>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using inner_shape_type = typename xexpression_type::inner_shape_type;
+        using stepper = xrepeat_stepper<typename xexpression_type::stepper>;
+        using const_stepper = xrepeat_stepper<typename xexpression_type::stepper>;
+    };
+
+    template <class S>
+    class xrepeat_stepper
+    {
+    public:
+        using storage_type = typename S::storage_type;
+        using subiterator_type = typename S::subiterator_type;
+        using subiterator_traits = typename S::subiterator_traits;
+        using value_type = typename subiterator_traits::value_type;
+        using reference = typename subiterator_traits::reference;
+        using pointer = typename subiterator_traits::pointer;
+        using difference_type = typename subiterator_traits::difference_type;
+        using size_type = typename storage_type::size_type;
+        using shape_type = typename storage_type::shape_type;
+        using simd_value_type = xt_simd::simd_type<value_type>;
+
+        template <class requested_type>
+        using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
+
+        xrepeat_stepper(S&& s, const std::vector<std::ptrdiff_t>& repeats);
+
+        reference operator*() const;
+
+        void step(size_type dim, size_type n = 1);
+        void step_back(size_type dim, size_type n = 1);
+        void reset(size_type dim);
+        void reset_back(size_type dim);
+
+        void to_begin();
+        void to_end(layout_type l);
+
+        template <class T>
+        simd_return_type<T> step_simd();
+
+        void step_leading();
+
+        template <class R>
+        void store_simd(const R& vec);
+
+        struct repeated_index
+        {
+            repeated_index(const std::ptrdiff_t repeats)
+                : m_repeats(repeats)
+                , m_index(0)
+            {}
+
+            size_type step(const size_type steps)
+            {
+                m_index += steps;
+                size_type inner_steps{ 0 };
+                while (m_index >= m_repeats)
+                {
+                    ++inner_steps;
+                    m_index -= m_repeats;
+                }
+                return inner_steps;
+            }
+
+            size_type step_back(const size_type steps)
+            {
+                m_index = m_index - steps;
+                size_type inner_steps{ 0 };
+                while (m_index < 0)
+                {
+                    ++inner_steps;
+                    m_index += m_repeats;
+                }
+                return inner_steps;
+            }
+
+            void reset()
+            {
+                m_index = 0;
+            }
+
+            void reset_back()
+            {
+                m_index = m_repeats - 1;
+            }
+
+        private:
+            const std::ptrdiff_t m_repeats;
+            std::ptrdiff_t m_index;
+        };
+
+    private:
+        S m_substepper;
+        std::vector<repeated_index> m_indicies;
+    };
+
+    template <class CT>
+    class xrepeat :
+        public xiterable<xrepeat<CT>>,
+        public xaccessible<xrepeat<CT>>
+    {
+    public:
+        using xexpression_type = std::decay_t<CT>;
+        using value_type = typename xexpression_type::value_type;
+        using shape_type = typename xexpression_type::shape_type;
+        static constexpr layout_type static_layout = xexpression_type::static_layout;
+        using bool_load_type = typename xexpression_type::bool_load_type;
+        using pointer = typename xexpression_type::pointer;
+        using const_pointer = typename xexpression_type::const_pointer;
+        using difference_type = typename xexpression_type::difference_type;
+        using stepper = xiterable<xrepeat<CT>>::stepper;
+
+        template<class CTA>
+        explicit xrepeat(CTA&& e,
+            std::vector<std::ptrdiff_t>&& repeats,
+            std::vector<std::ptrdiff_t>&& axes);
+
+        template <class... Args>
+        reference operator()(Args... args);
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+
+        const inner_shape_type& shape() const noexcept;
+
+        template <class It>
+        reference element(It first, It last);
+
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        stepper stepper_begin(const shape_type& s) const;
+
+        stepper stepper_end(const shape_type& s, const layout_type l) const;
+
+    private:
+        CT m_e;
+        std::vector<std::ptrdiff_t> m_repeat_lookup;
+        inner_shape_type m_shape;
+
+        reference access();
+
+        template <class Arg, class... Args>
+        reference access(Arg arg, Args... args);
+
+        const_reference access() const;
+
+        template <class Arg, class... Args>
+        const_reference access(Arg arg, Args... args) const;
+
+        template<typename std::decay_t<CT>::size_type I>
+        struct access_impl
+        {
+
+            template<class Arg, class... Args>
+            inline const_reference operator()(stepper& s, Arg arg, Args... args) const
+            {
+                s.step(I, arg);
+                const access_impl<I + 1> access_next_dimension;
+                return access_next_dimension(s, args...);
+            }
+
+            inline const_reference operator()(stepper& s) const
+            {
+                return *s;
+            }
+
+            template<class Arg, class... Args>
+            inline reference operator()(stepper& s, Arg arg, Args... args)
+            {
+                s.step(I, arg);
+                access_impl<I + 1> access_next_dimension;
+                return access_next_dimension(s, args...);
+            }
+
+            inline reference operator()(stepper& s)
+            {
+                return *s;
+            }
+        };
+
+        access_impl<0> m_access_impl;
+    };
+
+    template <class CT>
+    template <class CTA>
+    xrepeat<CT>::xrepeat(CTA&& e, std::vector<std::ptrdiff_t>&& repeats, std::vector<std::ptrdiff_t>&& axes)
+        : m_e(std::forward<CTA>(e))
+        , m_repeat_lookup(e.dimension())
+        , m_shape(e.shape())
+    {
+        std::fill(m_repeat_lookup.begin(), m_repeat_lookup.end(), 1);
+        for (auto index = 0; index < axes.size(); ++index)
+        {
+            const auto axis = axes.at(index);
+            const auto number_of_repeats = repeats.at(index);
+            m_repeat_lookup.at(axis) = number_of_repeats;
+            m_shape.at(axis) *= number_of_repeats;
+        }
+    }
+
+    template <class CT>
+    template <class... Args>
+    inline auto xrepeat<CT>::operator()(Args... args) -> reference
+    {
+        return access(args...);
+    }
+
+    template <class CT>
+    template <class... Args>
+    inline auto xrepeat<CT>::operator()(Args... args) const -> const_reference
+    {
+        return access(args...);
+    }
+
+    template <class CT>
+    inline auto xrepeat<CT>::shape() const noexcept -> const inner_shape_type&
+    {
+        return m_shape;
+    }
+
+    /**
+    * Returns a reference to the element at the specified position in the view.
+    * @param first iterator starting the sequence of indices
+    * @param last iterator ending the sequence of indices
+    * The number of indices in the sequence should be equal to or greater than the the number
+    * of dimensions of the view..
+    */
+    template <class ct>
+    template <class It>
+    inline auto xrepeat<ct>::element(It first, It last) -> reference
+    {
+        auto stepper = stepper_begin();
+        auto dimension = 0;
+        auto iter = first;
+        while (iter != last)
+        {
+            stepper.step(dimension, *iter);
+            ++dimension;
+            ++first;
+        }
+        return m_access_impl(stepper);
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the view.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the sequence should be equal to or greater than the the number
+     * of dimensions of the view..
+     */
+    template <class CT>
+    template <class It>
+    inline auto xrepeat<CT>::element(It first, It last) const -> const_reference
+    {
+        auto stepper = stepper_begin(m_e.shape());
+        auto dimension = 0;
+        It iter = first;
+        while (iter != last)
+        {
+            stepper.step(dimension, *iter);
+            ++dimension;
+            ++iter;
+        }
+        return m_access_impl(stepper);
+    }
+
+    template <class CT>
+    inline auto xrepeat<CT>::access() -> reference
+    {
+        return m_access_impl(stepper_begin(m_e.shape()));
+    }
+
+    template <class CT>
+    template <class Arg, class... Args>
+    inline auto xrepeat<CT>::access(Arg arg, Args... args) -> reference
+    {
+        constexpr size_t number_of_arguments = 1 + sizeof...(Args);
+        if (number_of_arguments > this->dimension())
+        {
+            return access(args...);
+        }
+        return m_access_impl(stepper_begin(m_e.shape()), arg, args...);
+    }
+
+    template <class CT>
+    inline auto xrepeat<CT>::access() const -> const_reference
+    {
+        return m_access_impl(stepper_begin(m_e.shape()));
+    }
+
+    template <class CT>
+    template <class Arg, class... Args>
+    inline auto xrepeat<CT>::access(Arg arg, Args... args) const -> const_reference
+    {
+        constexpr size_t number_of_arguments = 1 + sizeof...(Args);
+        if (number_of_arguments > this->dimension())
+        {
+            return access(args...);
+        }
+        return m_access_impl(stepper_begin(m_e.shape()), arg, args...);
+    }
+
+    template <class CT>
+    inline auto xrepeat<CT>::stepper_begin(const shape_type& s) const -> stepper
+    {
+        return stepper(m_e.stepper_begin(s), m_repeat_lookup);
+    }
+
+    template <class CT>
+    inline auto xrepeat<CT>::stepper_end(const shape_type& s, const layout_type l) const -> stepper
+    {
+        auto st = stepper(m_e.stepper_begin(s), m_repeat_lookup);
+        st.to_end(l);
+        return st;
+    }
+
+    template<class S>
+    xrepeat_stepper<S>::xrepeat_stepper(S&& s, const std::vector<std::ptrdiff_t>& repeats)
+        : m_substepper(std::forward<S>(s))
+    {
+        for (auto number_of_repeat : repeats)
+        {
+            m_indicies.emplace_back(number_of_repeat);
+        }
+    }
+
+    template<class S>
+    inline auto xrepeat_stepper<S>::operator*() const -> reference
+    {
+        return m_substepper.operator*();
+    }
+
+    template<class S>
+    inline void xrepeat_stepper<S>::step(size_type dim, size_type n)
+    {
+        size_type substeps = m_indicies.at(dim).step(n);
+        m_substepper.step(dim, substeps);
+    }
+
+    template<class S>
+    inline void xrepeat_stepper<S>::step_back(size_type dim, size_type n)
+    {
+        size_type substeps = m_indicies.at(dim).step_back(n);
+        m_substepper.step_back(dim, substeps);
+    }
+
+    template<class S>
+    inline void xrepeat_stepper<S>::reset(size_type dim)
+    {
+        m_substepper.reset(dim);
+        m_indicies.at(dim).reset();
+    }
+
+    template<class S>
+    inline void xrepeat_stepper<S>::reset_back(size_type dim)
+    {
+        m_substepper.reset_back(dim);
+        m_indicies.at(dim).reset_back();
+    }
+
+    template<class S>
+    inline void xrepeat_stepper<S>::to_begin()
+    {
+        m_substepper.to_begin();
+        for (auto index : m_indicies)
+        {
+            index.reset();
+        }
+    }
+
+    template<class S>
+    inline void xrepeat_stepper<S>::to_end(layout_type l)
+    {
+        m_substepper.to_end(l);
+        for (auto index : m_indicies)
+        {
+            index.reset_back();
+        }
+    }
+
+    template<class S>
+    inline void xrepeat_stepper<S>::step_leading()
+    {
+        m_substepper.step_leading();
+    }
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -193,6 +193,7 @@ set(XTENSOR_TESTS
     test_xoptional_assembly_adaptor.cpp
     test_xoptional_assembly_storage.cpp
     test_xrandom.cpp
+    test_xrepeat.cpp
     test_xsort.cpp
     test_xvectorize.cpp
     test_extended_xmath_interp.cpp

--- a/test/test_xmanipulation.cpp
+++ b/test/test_xmanipulation.cpp
@@ -396,55 +396,53 @@ namespace xt
         ASSERT_EQ(expected8, xt::roll(e2, -2, /*axis*/2));
     }
 
-    TEST(xmanipulation, repeat_axis0_2times)
+    TEST(xmanipulation, repeat_axis0_of_int_array_2times)
     {
-        xarray<double> array = {
+        xarray<int> array = {
             {1, 2, 3},
             {4, 5, 6},
             {7, 8, 9},
         };
-        const auto repeated_array = xt::repeat(array, 2, { 0 });
+        const auto repeated_array = xt::repeat(array, 2, {0});
         const auto result = xt::view(repeated_array, xt::all());
-        
-        xarray<double>::shape_type expected_shape{ 6, 3 };
-        xarray<double> expected_array = {
-            { 1, 2, 3 },
-            { 1, 2, 3 },
-            { 4, 5, 6 },
-            { 4, 5, 6 },
-            { 7, 8, 9 },
-            { 7, 8, 9 },
-        };
-        const auto expected = xt::view(expected_array, xt::all());
-        ASSERT_EQ(expected_shape, repeated_array.shape());
-        ASSERT_EQ(expected, result);
-    }
 
-    TEST(xmanipulation, repeat_axis1_2times)
-    {
-        xarray<double> array = {
+        xarray<int>::shape_type expected_shape{6, 3};
+        const auto expected = xt::view(xarray<int>{
+            {1, 2, 3},
             {1, 2, 3},
             {4, 5, 6},
+            {4, 5, 6},
             {7, 8, 9},
-        };
-
-        const auto repeated_array = xt::repeat(array, 2, { 1 });
-        const auto result = xt::view(repeated_array, xt::all());
-
-        xarray<double>::shape_type expected_shape{ 3, 6 };
-        xarray<double> expected_array = {
-            {1, 1, 2, 2, 3, 3},
-            {4, 4, 5, 5, 6, 6},
-            {7, 7, 8, 8, 9, 9},
-        };
-        const auto expected = xt::view(expected_array, xt::all());
+            {7, 8, 9},
+        }, xt::all());
         ASSERT_EQ(expected_shape, repeated_array.shape());
         ASSERT_EQ(expected, result);
     }
 
-    TEST(xmanipulation, repeat_allaxis_2times)
+    TEST(xmanipulation, repeat_axis1_of_double_array_2times)
     {
         xarray<double> array = {
+            {1.0, 2.0, 3.0},
+            {4.0, 5.0, 6.0},
+            {7.0, 8.0, 9.0},
+        };
+
+        const auto repeated_array = xt::repeat(array, 2, {1});
+        const auto result = xt::view(repeated_array, xt::all());
+
+        xarray<double>::shape_type expected_shape{3, 6};
+        const auto expected = xt::view(xarray<double>{
+            {1.0, 1.0, 2.0, 2.0, 3.0, 3.0},
+            {4.0, 4.0, 5.0, 5.0, 6.0, 6.0},
+            {7.0, 7.0, 8.0, 8.0, 9.0, 9.0},
+        }, xt::all());
+        ASSERT_EQ(expected_shape, repeated_array.shape());
+        ASSERT_EQ(expected, result);
+    }
+
+    TEST(xmanipulation, repeat_allaxis_of_size_t_array_2times)
+    {
+        xarray<size_t> array = {
             {1, 2, 3},
             {4, 5, 6},
             {7, 8, 9},
@@ -453,16 +451,15 @@ namespace xt
         const auto repeated_array = xt::repeat(array, 2, {});
         const auto result = xt::view(repeated_array, xt::all());
 
-        xarray<double>::shape_type expected_shape{ 6, 6 };
-        xarray<double> expected_array = {
+        xarray<size_t>::shape_type expected_shape{6, 6};
+        const auto expected = xt::view(xarray<size_t>{
             {1, 1, 2, 2, 3, 3},
             {1, 1, 2, 2, 3, 3},
             {4, 4, 5, 5, 6, 6},
             {4, 4, 5, 5, 6, 6},
             {7, 7, 8, 8, 9, 9},
             {7, 7, 8, 8, 9, 9},
-        };
-        const auto expected = xt::view(expected_array, xt::all());
+        }, xt::all());
         ASSERT_EQ(expected_shape, repeated_array.shape());
         ASSERT_EQ(expected, result);
     }

--- a/test/test_xmanipulation.cpp
+++ b/test/test_xmanipulation.cpp
@@ -472,7 +472,8 @@ namespace xt
             {7, 8, 9},
         };
 
-        const auto repeated_array = xt::repeat(array, {1, 2, 3}, 0);
+        const std::vector<std::size_t> repeats{1, 2, 3};
+        const auto repeated_array = xt::repeat(array, repeats, 0);
 
         ASSERT_EQ(1, repeated_array(0, 0));
         ASSERT_EQ(4, repeated_array(1, 0));

--- a/test/test_xmanipulation.cpp
+++ b/test/test_xmanipulation.cpp
@@ -396,14 +396,14 @@ namespace xt
         ASSERT_EQ(expected8, xt::roll(e2, -2, /*axis*/2));
     }
 
-    TEST(xmanipulation, repeat_axis0_of_int_array_2times)
+    TEST(xmanipulation, repeat_all_elements_of_axis_0_of_int_array_2_times)
     {
         xarray<int> array = {
             {1, 2, 3},
             {4, 5, 6},
             {7, 8, 9},
         };
-        const auto repeated_array = xt::repeat(array, 2, {0});
+        const auto repeated_array = xt::repeat(array, 2, 0);
         const auto result = xt::view(repeated_array, xt::all());
 
         xarray<int>::shape_type expected_shape{6, 3};
@@ -419,7 +419,7 @@ namespace xt
         ASSERT_EQ(expected, result);
     }
 
-    TEST(xmanipulation, repeat_axis1_of_double_array_2times)
+    TEST(xmanipulation, repeat_all_elements_of_axis_1_of_double_array_2_times)
     {
         xarray<double> array = {
             {1.0, 2.0, 3.0},
@@ -427,7 +427,7 @@ namespace xt
             {7.0, 8.0, 9.0},
         };
 
-        const auto repeated_array = xt::repeat(array, 2, {1});
+        const auto repeated_array = xt::repeat(array, 2, 1);
         const auto result = xt::view(repeated_array, xt::all());
 
         xarray<double>::shape_type expected_shape{3, 6};
@@ -440,7 +440,7 @@ namespace xt
         ASSERT_EQ(expected, result);
     }
 
-    TEST(xmanipulation, repeat_allaxis_of_size_t_array_2times)
+    TEST(xmanipulation, repeat_every_element_of_axis_0_123)
     {
         xarray<size_t> array = {
             {1, 2, 3},
@@ -448,17 +448,17 @@ namespace xt
             {7, 8, 9},
         };
 
-        const auto repeated_array = xt::repeat(array, 2, {});
+        const auto repeated_array = xt::repeat(array, {1, 2, 3}, 0);
         const auto result = xt::view(repeated_array, xt::all());
 
-        xarray<size_t>::shape_type expected_shape{6, 6};
+        xarray<size_t>::shape_type expected_shape{6, 3};
         const auto expected = xt::view(xarray<size_t>{
-            {1, 1, 2, 2, 3, 3},
-            {1, 1, 2, 2, 3, 3},
-            {4, 4, 5, 5, 6, 6},
-            {4, 4, 5, 5, 6, 6},
-            {7, 7, 8, 8, 9, 9},
-            {7, 7, 8, 8, 9, 9},
+            {1, 2, 3},
+            {4, 5, 6},
+            {4, 5, 6},
+            {7, 8, 9},
+            {7, 8, 9},
+            {7, 8, 9},
         }, xt::all());
         ASSERT_EQ(expected_shape, repeated_array.shape());
         ASSERT_EQ(expected, result);

--- a/test/test_xmanipulation.cpp
+++ b/test/test_xmanipulation.cpp
@@ -440,7 +440,7 @@ namespace xt
         ASSERT_EQ(expected, result);
     }
 
-    TEST(xmanipulation, repeat_every_element_of_axis_0_123)
+    TEST(xmanipulation, repeat_elements_of_axis_0_123)
     {
         xarray<size_t> array = {
             {1, 2, 3},
@@ -462,5 +462,23 @@ namespace xt
         }, xt::all());
         ASSERT_EQ(expected_shape, repeated_array.shape());
         ASSERT_EQ(expected, result);
+    }
+
+    TEST(xmanipulation, repeat_and_access_various_elements)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+
+        const auto repeated_array = xt::repeat(array, {1, 2, 3}, 0);
+
+        ASSERT_EQ(1, repeated_array(0, 0));
+        ASSERT_EQ(4, repeated_array(1, 0));
+        ASSERT_EQ(5, repeated_array(2, 1));
+        ASSERT_EQ(7, repeated_array(3, 0));
+        ASSERT_EQ(8, repeated_array(3, 1));
+        ASSERT_EQ(9, repeated_array(3, 2));
     }
 }

--- a/test/test_xmanipulation.cpp
+++ b/test/test_xmanipulation.cpp
@@ -395,4 +395,75 @@ namespace xt
         xarray<double> expected8 = {{{3, 1, 2}}, {{6, 4, 5}}, {{9, 7, 8}}};
         ASSERT_EQ(expected8, xt::roll(e2, -2, /*axis*/2));
     }
+
+    TEST(xmanipulation, repeat_axis0_2times)
+    {
+        xarray<double> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, { 0 });
+        const auto result = xt::view(repeated_array, xt::all());
+        
+        xarray<double>::shape_type expected_shape{ 6, 3 };
+        xarray<double> expected_array = {
+            { 1, 2, 3 },
+            { 1, 2, 3 },
+            { 4, 5, 6 },
+            { 4, 5, 6 },
+            { 7, 8, 9 },
+            { 7, 8, 9 },
+        };
+        const auto expected = xt::view(expected_array, xt::all());
+        ASSERT_EQ(expected_shape, repeated_array.shape());
+        ASSERT_EQ(expected, result);
+    }
+
+    TEST(xmanipulation, repeat_axis1_2times)
+    {
+        xarray<double> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+
+        const auto repeated_array = xt::repeat(array, 2, { 1 });
+        const auto result = xt::view(repeated_array, xt::all());
+
+        xarray<double>::shape_type expected_shape{ 3, 6 };
+        xarray<double> expected_array = {
+            {1, 1, 2, 2, 3, 3},
+            {4, 4, 5, 5, 6, 6},
+            {7, 7, 8, 8, 9, 9},
+        };
+        const auto expected = xt::view(expected_array, xt::all());
+        ASSERT_EQ(expected_shape, repeated_array.shape());
+        ASSERT_EQ(expected, result);
+    }
+
+    TEST(xmanipulation, repeat_allaxis_2times)
+    {
+        xarray<double> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+
+        const auto repeated_array = xt::repeat(array, 2, {});
+        const auto result = xt::view(repeated_array, xt::all());
+
+        xarray<double>::shape_type expected_shape{ 6, 6 };
+        xarray<double> expected_array = {
+            {1, 1, 2, 2, 3, 3},
+            {1, 1, 2, 2, 3, 3},
+            {4, 4, 5, 5, 6, 6},
+            {4, 4, 5, 5, 6, 6},
+            {7, 7, 8, 8, 9, 9},
+            {7, 7, 8, 8, 9, 9},
+        };
+        const auto expected = xt::view(expected_array, xt::all());
+        ASSERT_EQ(expected_shape, repeated_array.shape());
+        ASSERT_EQ(expected, result);
+    }
 }

--- a/test/test_xrepeat.cpp
+++ b/test/test_xrepeat.cpp
@@ -1,0 +1,375 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xrepeat.hpp"
+
+
+#include "xtensor/xview.hpp"
+#include "xtensor/xio.hpp"
+
+namespace xt
+{
+    TEST(xrepeat, stepper_begin)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        const auto stepper = repeated_array.stepper_begin();
+
+        ASSERT_EQ(1, *stepper);
+    }
+
+    TEST(xrepeat, stepper_end_row_major_with_repeat_1)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+
+        const auto repeated_array = xt::repeat(array, 1, 0);
+        auto stepper = repeated_array.stepper_end(xt::layout_type::row_major);
+
+        stepper.step_back(1, 1);
+        ASSERT_EQ(9, *stepper);
+    }
+
+    TEST(xrepeat, stepper_end_row_major_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_end(layout_type::row_major);
+
+        stepper.step_back(1, 1);
+        ASSERT_EQ(9, *stepper);
+    }
+
+    TEST(xrepeat, stepper_end_column_major_with_repeat_1)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+
+        const auto repeated_array = xt::repeat(array, 1, 0);
+        auto stepper = repeated_array.stepper_end(layout_type::column_major);
+
+        stepper.step_back(0, 1);
+        ASSERT_EQ(9, *stepper);
+    }
+
+    TEST(xrepeat, stepper_end_column_major_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_end(layout_type::column_major);
+
+        stepper.step_back(0, 1);
+        ASSERT_EQ(9, *stepper);
+    }
+
+    TEST(xrepeat_stepper, step_with_repeat_1)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 1, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.step(0, 2);
+        stepper.step(1, 2);
+
+        ASSERT_EQ(9, *stepper);
+    }
+
+    TEST(xrepeat_stepper, step_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.step(0, 2);
+        stepper.step(1, 2);
+
+        ASSERT_EQ(6, *stepper);
+    }
+
+    TEST(xrepeat_stepper, step_back_with_repeat_1)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 1, 0);
+        auto stepper = repeated_array.stepper_begin();
+        stepper.step(0, 2);
+        stepper.step(1, 2);
+
+        stepper.step_back(0, 1);
+        stepper.step_back(1, 1);
+
+        ASSERT_EQ(5, *stepper);
+    }
+
+    TEST(xrepeat_stepper, step_back_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_begin();
+        stepper.step(0, 2);
+        stepper.step(1, 2);
+
+        stepper.step_back(0, 1);
+        stepper.step_back(1, 1);
+
+        ASSERT_EQ(2, *stepper);
+    }
+
+    TEST(xrepeat_stepper, step_and_reset_with_repeat_1)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 1, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.step(0, 2);
+        stepper.step(1, 2);
+        stepper.reset(0);
+        stepper.reset(1);
+
+        ASSERT_EQ(1, *stepper);
+    }
+
+    TEST(xrepeat_stepper, step_and_reset_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.step(0, 5);
+        stepper.step(1, 2);
+        stepper.reset(0);
+        stepper.reset(1);
+
+        ASSERT_EQ(1, *stepper);
+    }
+
+    TEST(xrepeat_stepper, reset_back_with_repeat_1)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 1, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.reset_back(0);
+        stepper.reset_back(1);
+
+        ASSERT_EQ(9, *stepper);
+    }
+
+    TEST(xrepeat_stepper, reset_back_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper0 = repeated_array.stepper_begin();
+        auto stepper1 = repeated_array.stepper_begin();
+
+        stepper0.reset_back(0);
+        stepper1.reset_back(1);
+
+        ASSERT_EQ(7, *stepper0);
+        ASSERT_EQ(3, *stepper1);
+    }
+
+    TEST(xrepeat_stepper, reset_back_and_step_back_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.reset_back(0);
+        stepper.reset_back(1);
+        stepper.step_back(0, 1);
+        stepper.step_back(1, 1);
+
+        ASSERT_EQ(8, *stepper);
+    }
+
+    TEST(xrepeat_stepper, to_begin_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_end(layout_type::row_major);
+
+        stepper.to_begin();
+
+        ASSERT_EQ(1, *stepper);
+    }
+
+    TEST(xrepeat_stepper, to_begin_and_step_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_end(layout_type::row_major);
+
+        stepper.to_begin();
+        stepper.step(0, 1);
+        stepper.step(1, 1);
+
+        ASSERT_EQ(2, *stepper);
+    }
+
+    TEST(xrepeat_stepper, to_end_row_major_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.to_end(layout_type::row_major);
+        stepper.step_back(1, 2);
+
+        ASSERT_EQ(8, *stepper);
+    }
+
+    TEST(xrepeat_stepper, to_end_column_major_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.to_end(layout_type::column_major);
+        stepper.step_back(0, 2);
+
+        ASSERT_EQ(9, *stepper);
+    }
+
+    TEST(xrepeat_stepper, step_leading_with_repeat_1)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 1, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.step_leading();
+        stepper.step_leading();
+        stepper.step_leading();
+
+        ASSERT_EQ(4, *stepper);
+    }
+
+    TEST(xrepeat_stepper, step_leading_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.step_leading();
+        stepper.step_leading();
+        stepper.step_leading();
+
+        ASSERT_EQ(1, *stepper);
+    }
+
+    TEST(xrepeat_stepper, huge_step_with_repeat_1)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 1, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.step(1, 8);
+
+        ASSERT_EQ(9, *stepper);
+    }
+
+    TEST(xrepeat_stepper, huge_step_with_repeat_2)
+    {
+        xarray<size_t> array = {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9},
+        };
+        const auto repeated_array = xt::repeat(array, 2, 0);
+        auto stepper = repeated_array.stepper_begin();
+
+        stepper.step(1, 17);
+
+        ASSERT_EQ(9, *stepper);
+    }
+}


### PR DESCRIPTION
I implemented repeat similar to numpy.repeat (Feature request   #1383)

At the moment, all tests are fulfilled, but I'm not quite sure if the expression `xrepeat` fulfill all requirements for a `xexpression`.  Therefore, this pull request more like a draft pull request (is this feature not activated on this repo or do I just not find it?).

It would be very nice if you can give me feedback, hints and may better approaches how I can improve this first implementation.

For me there are still some open questions:

- What must be documented?
- Which primitive types should be used?
- How can I test if my expression fulfill all requirements?
- Which header should be used in the files?

Best regards