### PR TITLE
Set -march=native only if the user did not set another -march already

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -23,7 +23,10 @@ include(CheckCXXCompilerFlag)
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -O3 -g -Wunused-parameter -Wextra -Wreorder")
+    if(NOT CMAKE_CXX_FLAGS MATCHES "-march")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+    endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g -Wunused-parameter -Wextra -Wreorder")
     CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
 
     if (HAS_CPP14_FLAG)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,7 +53,10 @@ if(NOT _cxx_std_flag)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR (CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND NOT WIN32))
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_cxx_std_flag} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
+  if(NOT CMAKE_CXX_FLAGS MATCHES "-march")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_cxx_std_flag} -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Wunused-variable -ftemplate-backtrace-limit=0")
   if (XTENSOR_DISABLE_EXCEPTIONS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
@@ -70,7 +73,10 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if(NOT WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_cxx_std_flag} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
+    if(NOT CMAKE_CXX_FLAGS MATCHES "-march")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+    endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_cxx_std_flag} -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Wunused-variable")
     if (XTENSOR_DISABLE_EXCEPTIONS)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
@@ -126,8 +132,8 @@ find_package(Threads)
 
 include_directories(${GTEST_INCLUDE_DIRS} SYSTEM)
 
-# For unit test and coverity scan. 
-# The Coverity scanner takes time and it could cause build timeout(10mins) in Travis CI. 
+# For unit test and coverity scan.
+# The Coverity scanner takes time and it could cause build timeout(10mins) in Travis CI.
 # Therefore, we need keep this small but complete for analysis.
 set(TEST_HEADERS
     test_common.hpp
@@ -299,4 +305,3 @@ endif()
 
 target_link_libraries(test_xtensor_core_lib PRIVATE xtensor ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 add_custom_target(coverity COMMAND coverity_scan DEPENDS test_xtensor_core_lib)
-


### PR DESCRIPTION
Currently xtensor adds `-march=native` to  `CMAKE_CXX_FLAGS` unconditionally. There are certain scenarios where users need to override `-march`. For example in a virtual machine, not all available CPU features must be exposed to the guest. Or in case of a targeted build, the user may want to execute tests on behalf of the target OS, not the host OS.

This PR makes the setting of `-march` dependent on whether `CMAKE_CXX_FLAGS` already has `-march` set. This allows users to override `-march`.