### PR TITLE
benchmark/CMakeLists.txt: fixed a tiny spelling mistake

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -12,7 +12,7 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtensor-benchmark)
 
     find_package(xtensor REQUIRED CONFIG)
-    set(XTENSOR_INCLUDE_DIR ${xtensor_INCLUDE_DIR})
+    set(XTENSOR_INCLUDE_DIR ${xtensor_INCLUDE_DIRS})
 endif ()
 
 message(STATUS "Forcing tests build type to Release")


### PR DESCRIPTION
This PR fixes a tiny spelling mistake in `benchmark/CMakeLists.txt`: The variable `xtensor_INCLUDE_DIR` should most likely be named `xtensor_INCLUDE_DIRS`.