### PR TITLE
Add GoatCounter analytics for the documentation

### DIFF
--- a/docs/source/_static/goatcounter.js
+++ b/docs/source/_static/goatcounter.js
@@ -1,0 +1,9 @@
+(function() {
+  window.counter = 'https://xtensor_readthedocs_io.goatcounter.com/count'
+
+  var script = document.createElement('script');
+  script.async = 1;
+  script.src = '//gc.zgo.at/count.js';
+  var ins = document.getElementsByTagName('script')[0];
+  ins.parentNode.insertBefore(script, ins)
+})();

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,3 +36,6 @@ pygments_style = 'sphinx'
 todo_include_todos = False
 htmlhelp_basename = 'xtensordoc'
 
+html_js_files = [
+    'goatcounter.js'
+]


### PR DESCRIPTION
This will add GoatCounter data analytics to the documentation website.

See https://www.goatcounter.com

The data will be publicly available through this URL once merged: https://xtensor_readthedocs_io.goatcounter.com