### PR TITLE
xaxis_slice_iterator – Iterates over 1D slices oriented along the spe…

### DIFF
--- a/include/xtensor/xaxis_slice_iterator.hpp
+++ b/include/xtensor/xaxis_slice_iterator.hpp
@@ -1,0 +1,226 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_AXIS_SLICE_ITERATOR_HPP
+#define XTENSOR_AXIS_SLICE_ITERATOR_HPP
+
+#include "xstrided_view.hpp"
+
+namespace xt
+{
+
+    /************************
+     * xaxis_slice_iterator *
+     ************************/
+
+    template <class CT>
+    class xaxis_slice_iterator
+    {
+    public:
+
+        using self_type = xaxis_slice_iterator<CT>;
+
+        using xexpression_type = std::decay_t<CT>;
+        using size_type = typename xexpression_type::size_type;
+        using difference_type = typename xexpression_type::difference_type;
+        using shape_type = typename xexpression_type::shape_type;
+        using strides_type = typename xexpression_type::strides_type;
+        using value_type = xstrided_view<CT, shape_type>;
+        using reference = std::remove_reference_t<apply_cv_t<CT, value_type>>;
+        using pointer = xtl::xclosure_pointer<std::remove_reference_t<apply_cv_t<CT, value_type>>>;
+
+        using iterator_category = std::forward_iterator_tag;
+
+        template <class CTA>
+        xaxis_slice_iterator(CTA&& e, size_type axis);
+        template <class CTA>
+        xaxis_slice_iterator(CTA&& e, size_type axis, size_type index, size_type offset);
+
+        self_type& operator++();
+        self_type operator++(int);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        bool equal(const self_type& rhs) const;
+
+    private:
+
+        using storing_type = xtl::ptr_closure_type_t<CT>;
+        mutable storing_type p_expression;
+        size_type m_index;
+        size_type m_offset;
+        size_type m_axis_stride;
+        size_type m_lower_shape;
+        size_type m_upper_shape;
+        size_type m_iter_size;
+        bool m_is_target_axis;
+        value_type m_sv;
+
+        template <class T, class CTA>
+        std::enable_if_t<std::is_pointer<T>::value, T>
+            get_storage_init(CTA&& e) const;
+
+        template <class T, class CTA>
+        std::enable_if_t<!std::is_pointer<T>::value, T>
+            get_storage_init(CTA&& e) const;
+    };
+
+    template <class CT>
+    bool operator==(const xaxis_slice_iterator<CT>& lhs, const xaxis_slice_iterator<CT>& rhs);
+
+    template <class CT>
+    bool operator!=(const xaxis_slice_iterator<CT>& lhs, const xaxis_slice_iterator<CT>& rhs);
+
+    template <class E>
+    auto xaxis_slice_begin(E&& e);
+
+    template <class E>
+    auto xaxis_slice_begin(E&& e, typename std::decay_t<E>::size_type axis);
+
+    template <class E>
+    auto xaxis_slice_end(E&& e);
+
+    template <class E>
+    auto xaxis_slice_end(E&& e, typename std::decay_t<E>::size_type axis);
+
+    /***************************************
+     * xaxis_slice_iterator implementation *
+     ***************************************/
+
+    template <class CT>
+    template <class T, class CTA>
+    inline std::enable_if_t<std::is_pointer<T>::value, T>
+        xaxis_slice_iterator<CT>::get_storage_init(CTA&& e) const
+    {
+        return &e;
+    }
+
+    template <class CT>
+    template <class T, class CTA>
+    inline std::enable_if_t<!std::is_pointer<T>::value, T>
+        xaxis_slice_iterator<CT>::get_storage_init(CTA&& e) const
+    {
+        return e;
+    }
+
+    template <class CT>
+    template <class CTA>
+    inline xaxis_slice_iterator<CT>::xaxis_slice_iterator(CTA&& e, size_type axis)
+        : xaxis_slice_iterator(std::forward<CTA>(e), axis, 0, e.data_offset())
+    {
+    }
+
+    template <class CT>
+    template <class CTA>
+    inline xaxis_slice_iterator<CT>::xaxis_slice_iterator(CTA&& e, size_type axis, size_type index, size_type offset) :
+        p_expression(get_storage_init<storing_type>(std::forward<CTA>(e))), m_index(index),
+        m_offset(offset), m_axis_stride(e.strides()[axis] * (e.shape()[axis] - 1)),
+        m_lower_shape(0), m_upper_shape(0), m_iter_size(0), m_is_target_axis(false),
+        m_sv(strided_view(std::forward<CT>(e), std::forward<shape_type>({ e.shape()[axis] }),
+            std::forward<strides_type>({ e.strides()[axis] }), offset, e.layout()))
+    {
+        if (e.layout() == layout_type::row_major)
+        {
+            m_is_target_axis = axis == e.dimension() - 1;
+            m_lower_shape = std::accumulate(e.shape().begin() + axis + 1, e.shape().end(), static_cast<size_t>(1), std::multiplies<>());
+            m_iter_size = std::accumulate(e.shape().begin() + 1, e.shape().end(), static_cast<size_t>(1), std::multiplies<>());
+
+        }
+        else
+        {
+            m_is_target_axis = axis == 0;
+            m_lower_shape = std::accumulate(e.shape().begin(), e.shape().begin() + axis, static_cast<size_t>(1), std::multiplies<>());
+            m_iter_size = std::accumulate(e.shape().begin(), e.shape().end() - 1, static_cast<size_t>(1), std::multiplies<>());
+        }
+        m_upper_shape = m_lower_shape + m_axis_stride;
+    }
+
+    template <class CT>
+    inline auto xaxis_slice_iterator<CT>::operator++() -> self_type&
+    {
+        ++m_index; ++m_offset;
+        auto index_compare = (m_offset % m_iter_size);
+        if (m_is_target_axis || (m_upper_shape >= index_compare && index_compare >= m_lower_shape))
+        {
+            m_offset += m_axis_stride;
+        }
+        m_sv.set_offset(m_offset);
+        return *this;
+    }
+
+    template <class CT>
+    inline auto xaxis_slice_iterator<CT>::operator++(int) -> self_type
+    {
+        self_type tmp(*this);
+        ++(*this);
+        return tmp;
+    }
+
+    template <class CT>
+    inline auto xaxis_slice_iterator<CT>::operator*() const -> reference
+    {
+        return m_sv;
+    }
+
+    template <class CT>
+    inline auto xaxis_slice_iterator<CT>::operator->() const -> pointer
+    {
+        return xtl::closure_pointer(operator*());
+    }
+
+    template <class CT>
+    inline bool xaxis_slice_iterator<CT>::equal(const self_type& rhs) const
+    {
+        return p_expression == rhs.p_expression && m_index == rhs.m_index;
+    }
+
+    template <class CT>
+    inline bool operator==(const xaxis_slice_iterator<CT>& lhs, const xaxis_slice_iterator<CT>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class CT>
+    inline bool operator!=(const xaxis_slice_iterator<CT>& lhs, const xaxis_slice_iterator<CT>& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    template <class E>
+    inline auto xaxis_slice_begin(E&& e)
+    {
+        using return_type = xaxis_slice_iterator<xtl::closure_type_t<E>>;
+        return return_type(std::forward<E>(e), 0);
+    }
+
+    template <class E>
+    inline auto xaxis_slice_begin(E&& e, typename std::decay_t<E>::size_type axis)
+    {
+        using return_type = xaxis_slice_iterator<xtl::closure_type_t<E>>;
+        return return_type(std::forward<E>(e), axis, 0, e.data_offset());
+    }
+
+    template <class E>
+    inline auto xaxis_slice_end(E&& e)
+    {
+        using return_type = xaxis_slice_iterator<xtl::closure_type_t<E>>;
+        return return_type(std::forward<E>(e), 0, std::accumulate(e.shape().begin() + 1, e.shape().end(), static_cast<size_t>(1), std::multiplies<>()), e.size());
+    }
+
+    template <class E>
+    inline auto xaxis_slice_end(E&& e, typename std::decay_t<E>::size_type axis)
+    {
+        using return_type = xaxis_slice_iterator<xtl::closure_type_t<E>>;
+        auto index_sum = std::accumulate(e.shape().begin(), e.shape().begin() + axis, static_cast<size_t>(1), std::multiplies<>());
+        return return_type(std::forward<E>(e), axis, std::accumulate(e.shape().begin() + axis + 1, e.shape().end(), index_sum, std::multiplies<>()), e.size() + axis);
+    }
+}
+
+#endif

--- a/include/xtensor/xaxis_slice_iterator.hpp
+++ b/include/xtensor/xaxis_slice_iterator.hpp
@@ -15,10 +15,15 @@
 namespace xt
 {
 
-    /************************
-     * xaxis_slice_iterator *
-     ************************/
-
+    /**
+     * @class xaxis_slice_iterator
+     * @brief Class for iteration over one dimensional slices
+     *
+     * The xaxis_slice_iterator iterates over one dimensional slices
+     * oriented along the specified axis
+     *
+     * @param CT the closure type of the \ref xexpression
+     */
     template <class CT>
     class xaxis_slice_iterator
     {
@@ -110,6 +115,15 @@ namespace xt
         return e;
     }
 
+    /**
+     * @name Constructors
+     */
+     //@{
+    /**
+     * Constructs xaxis_slice_iterator
+     *
+     * @param axis the axis to iterate over taking one dimensional slices
+     */
     template <class CT>
     template <class CTA>
     inline xaxis_slice_iterator<CT>::xaxis_slice_iterator(CTA&& e, size_type axis)
@@ -117,6 +131,13 @@ namespace xt
     {
     }
 
+    /**
+     * Constructs xaxis_slice_iterator starting at specified index and initializes
+     *
+     * @param axis the axis to iterate over taking one dimensional slices
+     * @param index the starting index for the iterator
+     * @param offset the starting offset for the iterator
+     */
     template <class CT>
     template <class CTA>
     inline xaxis_slice_iterator<CT>::xaxis_slice_iterator(CTA&& e, size_type axis, size_type index, size_type offset) :
@@ -129,19 +150,27 @@ namespace xt
         if (e.layout() == layout_type::row_major)
         {
             m_is_target_axis = axis == e.dimension() - 1;
-            m_lower_shape = std::accumulate(e.shape().begin() + axis + 1, e.shape().end(), static_cast<size_t>(1), std::multiplies<>());
-            m_iter_size = std::accumulate(e.shape().begin() + 1, e.shape().end(), static_cast<size_t>(1), std::multiplies<>());
+            m_lower_shape = std::accumulate(e.shape().begin() + axis + 1, e.shape().end(), size_t(1), std::multiplies<>());
+            m_iter_size = std::accumulate(e.shape().begin() + 1, e.shape().end(), size_t(1), std::multiplies<>());
 
         }
         else
         {
             m_is_target_axis = axis == 0;
-            m_lower_shape = std::accumulate(e.shape().begin(), e.shape().begin() + axis, static_cast<size_t>(1), std::multiplies<>());
-            m_iter_size = std::accumulate(e.shape().begin(), e.shape().end() - 1, static_cast<size_t>(1), std::multiplies<>());
+            m_lower_shape = std::accumulate(e.shape().begin(), e.shape().begin() + axis, size_t(1), std::multiplies<>());
+            m_iter_size = std::accumulate(e.shape().begin(), e.shape().end() - 1, size_t(1), std::multiplies<>());
         }
         m_upper_shape = m_lower_shape + m_axis_stride;
     }
+    //@}
 
+    /**
+     * @name Increment
+     */
+     //@{
+    /**
+     * Increments the index and offset to the next iterator position
+     */
     template <class CT>
     inline auto xaxis_slice_iterator<CT>::operator++() -> self_type&
     {
@@ -162,7 +191,17 @@ namespace xt
         ++(*this);
         return tmp;
     }
+    //@}
 
+    /**
+     * @name Reference
+     */
+    //@{
+    /**
+     * Returns the strided view at the current iteration position
+     *
+     * @return strided_view
+     */
     template <class CT>
     inline auto xaxis_slice_iterator<CT>::operator*() const -> reference
     {
@@ -174,7 +213,17 @@ namespace xt
     {
         return xtl::closure_pointer(operator*());
     }
+    //@}
 
+    /*
+     * @name Comparisons
+     */
+    //@{
+    /**
+     * Checks equality of the expression
+     *
+     * @return bool equality
+     */
     template <class CT>
     inline bool xaxis_slice_iterator<CT>::equal(const self_type& rhs) const
     {
@@ -187,12 +236,24 @@ namespace xt
         return lhs.equal(rhs);
     }
 
+    /**
+     * Checks inequality of the expressions
+     * @return bool inequality
+     */
     template <class CT>
     inline bool operator!=(const xaxis_slice_iterator<CT>& lhs, const xaxis_slice_iterator<CT>& rhs)
     {
         return !(lhs == rhs);
     }
+    //@}
 
+    /**
+     * @name Iterators
+     */
+    //@{
+    /**
+     * @return an iterator to the first element of the expression for axis 0
+     */
     template <class E>
     inline auto xaxis_slice_begin(E&& e)
     {
@@ -200,6 +261,10 @@ namespace xt
         return return_type(std::forward<E>(e), 0);
     }
 
+    /**
+     * @return an iterator to the first element of the expression for the specified axis
+     * @param axis the axis to iterate over
+     */
     template <class E>
     inline auto xaxis_slice_begin(E&& e, typename std::decay_t<E>::size_type axis)
     {
@@ -207,20 +272,29 @@ namespace xt
         return return_type(std::forward<E>(e), axis, 0, e.data_offset());
     }
 
+    /**
+     * @return Returns an iterator to the element following the last element of
+     * the expression for axis 0
+     */
     template <class E>
     inline auto xaxis_slice_end(E&& e)
     {
         using return_type = xaxis_slice_iterator<xtl::closure_type_t<E>>;
-        return return_type(std::forward<E>(e), 0, std::accumulate(e.shape().begin() + 1, e.shape().end(), static_cast<size_t>(1), std::multiplies<>()), e.size());
+        return return_type(std::forward<E>(e), 0, std::accumulate(e.shape().begin() + 1, e.shape().end(), size_t(1), std::multiplies<>()), e.size());
     }
 
+    /**
+     * @return Returns an iterator to the element following the last element of
+     * the expression for the specified axis
+     */
     template <class E>
     inline auto xaxis_slice_end(E&& e, typename std::decay_t<E>::size_type axis)
     {
         using return_type = xaxis_slice_iterator<xtl::closure_type_t<E>>;
-        auto index_sum = std::accumulate(e.shape().begin(), e.shape().begin() + axis, static_cast<size_t>(1), std::multiplies<>());
+        auto index_sum = std::accumulate(e.shape().begin(), e.shape().begin() + axis, size_t(1), std::multiplies<>());
         return return_type(std::forward<E>(e), axis, std::accumulate(e.shape().begin() + axis + 1, e.shape().end(), index_sum, std::multiplies<>()), e.size() + axis);
     }
+    //@}
 }
 
 #endif

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -285,6 +285,8 @@ namespace xt
         friend class xconst_accessible<self_type>;
         template <class D>
         friend class xaxis_iterator;
+        template <class D>
+        friend class xaxis_slice_iterator;
     };
 
     /**************************

--- a/test/test_xaxis_slice_iterator.cpp
+++ b/test/test_xaxis_slice_iterator.cpp
@@ -1,0 +1,326 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xaxis_slice_iterator.hpp"
+
+
+namespace xt
+{
+    using std::size_t;
+
+    xarray<int> get_slice_test_array()
+    {
+        xarray<int> res = { {{1, 2, 3, 4},
+                            {5, 6, 7, 8},
+                            {9, 10, 11, 12}},
+                           {{13, 14, 15, 16},
+                            {17, 18, 19, 20},
+                            {21, 22, 23, 24}} };
+        return res;
+    }
+
+    TEST(xaxis_slice_iterator, begin)
+    {
+        xarray<int> a = get_slice_test_array();
+        auto iter_begin = xaxis_slice_begin(a, 0);
+        EXPECT_EQ(size_t(1), iter_begin->dimension());
+        EXPECT_EQ(a.shape()[0], iter_begin->shape()[0]);
+        EXPECT_EQ(a(0, 0, 0), (*iter_begin)(0));
+        EXPECT_EQ(a(1, 0, 0), (*iter_begin)(1));
+    }
+
+
+    TEST(xaxis_slice_iterator, end)
+    {
+        xarray<int> a = get_slice_test_array();
+        xarray<int, layout_type::column_major> a_col = get_slice_test_array();
+
+        auto dist = std::distance(xaxis_slice_begin(a, 0), xaxis_slice_end(a, 0));
+        EXPECT_EQ(12, dist);
+
+        dist = std::distance(xaxis_slice_begin(a_col), xaxis_slice_end(a_col));
+        EXPECT_EQ(12, dist);
+
+        dist = std::distance(xaxis_slice_begin(a, 1), xaxis_slice_end(a, 1));
+        EXPECT_EQ(8, dist);
+       
+        dist = std::distance(xaxis_slice_begin(a_col, 1), xaxis_slice_end(a_col, 1));
+        EXPECT_EQ(8, dist);
+       
+        dist = std::distance(xaxis_slice_begin(a, 2), xaxis_slice_end(a, 2));
+        EXPECT_EQ(6, dist);
+
+        dist = std::distance(xaxis_slice_begin(a_col, 2), xaxis_slice_end(a_col, 2));
+        EXPECT_EQ(6, dist);
+    }
+
+    TEST(xaxis_slice_iterator, increment)
+    {
+        xarray<int> a = get_slice_test_array();
+        auto iter = xaxis_slice_begin(a, 0);
+        ++iter;
+
+        EXPECT_EQ(size_t(1), iter->dimension());
+        EXPECT_EQ(a.shape()[0], iter->shape()[0]);
+
+        EXPECT_EQ(a(0, 0, 1), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 1), (*iter)(1));
+    }
+
+    TEST(xaxis_slice_iterator, const_array)
+    {
+        const xarray<int> a = get_slice_test_array();
+        auto iter = xaxis_slice_begin(a, 2);
+        ++iter;
+
+        EXPECT_EQ(size_t(1), iter->dimension());
+        EXPECT_EQ(a.shape()[2], iter->shape()[0]);
+
+        EXPECT_EQ(a(0, 1, 0), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 1), (*iter)(1));
+        EXPECT_EQ(a(0, 1, 2), (*iter)(2));
+        EXPECT_EQ(a(0, 1, 3), (*iter)(3));
+    }
+
+
+    TEST(xaxis_slice_iterator, axis_0)
+    {
+        xarray<int> a = get_slice_test_array();
+        auto iter = xaxis_slice_begin(a, size_t(0));
+
+        EXPECT_EQ(a(0, 0, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 0), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 1), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 1), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 2), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 2), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 3), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 3), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 1, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 0), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 1, 1), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 1), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 1, 2), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 2), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 1, 3), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 3), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 2, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 2, 0), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 2, 1), (*iter)(0));
+        EXPECT_EQ(a(1, 2, 1), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 2, 2), (*iter)(0));
+        EXPECT_EQ(a(1, 2, 2), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 2, 3), (*iter)(0));
+        EXPECT_EQ(a(1, 2, 3), (*iter)(1));
+    }
+
+    TEST(xaxis_slice_iterator, axis_0_col)
+    {
+        xarray<int, layout_type::column_major> a = get_slice_test_array();
+        auto iter = xaxis_slice_begin(a, size_t(0));
+
+        EXPECT_EQ(a(0, 0, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 0), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 1, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 0), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 2, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 2, 0), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 1), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 1), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 1, 1), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 1), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 2, 1), (*iter)(0));
+        EXPECT_EQ(a(1, 2, 1), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 2), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 2), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 1, 2), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 2), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 2, 2), (*iter)(0));
+        EXPECT_EQ(a(1, 2, 2), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 3), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 3), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 1, 3), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 3), (*iter)(1));
+        ++iter;
+        EXPECT_EQ(a(0, 2, 3), (*iter)(0));
+        EXPECT_EQ(a(1, 2, 3), (*iter)(1));
+    }
+
+    TEST(xaxis_slice_iterator, axis_1)
+    {
+        xarray<int> a = get_slice_test_array();
+        auto iter = xaxis_slice_begin(a, size_t(1));
+
+        EXPECT_EQ(a(0, 0, 0), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 0), (*iter)(1));
+        EXPECT_EQ(a(0, 2, 0), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 1), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 1), (*iter)(1));
+        EXPECT_EQ(a(0, 2, 1), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 2), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 2), (*iter)(1));
+        EXPECT_EQ(a(0, 2, 2), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 3), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 3), (*iter)(1));
+        EXPECT_EQ(a(0, 2, 3), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(1, 0, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 0), (*iter)(1));
+        EXPECT_EQ(a(1, 2, 0), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(1, 0, 1), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 1), (*iter)(1));
+        EXPECT_EQ(a(1, 2, 1), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(1, 0, 2), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 2), (*iter)(1));
+        EXPECT_EQ(a(1, 2, 2), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(1, 0, 3), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 3), (*iter)(1));
+        EXPECT_EQ(a(1, 2, 3), (*iter)(2));
+    }
+
+    TEST(xaxis_slice_iterator, axis_1_col)
+    {
+        xarray<int, layout_type::column_major> a = get_slice_test_array();
+        auto iter = xaxis_slice_begin(a, size_t(1));
+
+        EXPECT_EQ(a(0, 0, 0), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 0), (*iter)(1));
+        EXPECT_EQ(a(0, 2, 0), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(1, 0, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 0), (*iter)(1));
+        EXPECT_EQ(a(1, 2, 0), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 1), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 1), (*iter)(1));
+        EXPECT_EQ(a(0, 2, 1), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(1, 0, 1), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 1), (*iter)(1));
+        EXPECT_EQ(a(1, 2, 1), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 2), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 2), (*iter)(1));
+        EXPECT_EQ(a(0, 2, 2), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(1, 0, 2), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 2), (*iter)(1));
+        EXPECT_EQ(a(1, 2, 2), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(0, 0, 3), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 3), (*iter)(1));
+        EXPECT_EQ(a(0, 2, 3), (*iter)(2));
+        ++iter;
+        EXPECT_EQ(a(1, 0, 3), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 3), (*iter)(1));
+        EXPECT_EQ(a(1, 2, 3), (*iter)(2));
+    }
+
+
+    TEST(xaxis_slice_iterator, axis_2)
+    {
+        xarray<int> a = get_slice_test_array();
+        auto iter = xaxis_slice_begin(a, size_t(2));
+
+        EXPECT_EQ(a(0, 0, 0), (*iter)(0));
+        EXPECT_EQ(a(0, 0, 1), (*iter)(1));
+        EXPECT_EQ(a(0, 0, 2), (*iter)(2));
+        EXPECT_EQ(a(0, 0, 3), (*iter)(3));
+        ++iter;
+        EXPECT_EQ(a(0, 1, 0), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 1), (*iter)(1));
+        EXPECT_EQ(a(0, 1, 2), (*iter)(2));
+        EXPECT_EQ(a(0, 1, 3), (*iter)(3));
+        ++iter;
+        EXPECT_EQ(a(0, 2, 0), (*iter)(0));
+        EXPECT_EQ(a(0, 2, 1), (*iter)(1));
+        EXPECT_EQ(a(0, 2, 2), (*iter)(2));
+        EXPECT_EQ(a(0, 2, 3), (*iter)(3));
+        ++iter;
+        EXPECT_EQ(a(1, 0, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 1), (*iter)(1));
+        EXPECT_EQ(a(1, 0, 2), (*iter)(2));
+        EXPECT_EQ(a(1, 0, 3), (*iter)(3));
+        ++iter;
+        EXPECT_EQ(a(1, 1, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 1), (*iter)(1));
+        EXPECT_EQ(a(1, 1, 2), (*iter)(2));
+        EXPECT_EQ(a(1, 1, 3), (*iter)(3));
+        ++iter;
+        EXPECT_EQ(a(1, 2, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 2, 1), (*iter)(1));
+        EXPECT_EQ(a(1, 2, 2), (*iter)(2));
+        EXPECT_EQ(a(1, 2, 3), (*iter)(3));
+    }
+
+    TEST(xaxis_slice_iterator, axis_2_col)
+    {
+        xarray<int, layout_type::column_major> a = get_slice_test_array();
+        auto iter = xaxis_slice_begin(a, size_t(2));
+
+        EXPECT_EQ(a(0, 0, 0), (*iter)(0));
+        EXPECT_EQ(a(0, 0, 1), (*iter)(1));
+        EXPECT_EQ(a(0, 0, 2), (*iter)(2));
+        EXPECT_EQ(a(0, 0, 3), (*iter)(3));
+        ++iter;
+        EXPECT_EQ(a(1, 0, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 0, 1), (*iter)(1));
+        EXPECT_EQ(a(1, 0, 2), (*iter)(2));
+        EXPECT_EQ(a(1, 0, 3), (*iter)(3));
+        ++iter;
+        EXPECT_EQ(a(0, 1, 0), (*iter)(0));
+        EXPECT_EQ(a(0, 1, 1), (*iter)(1));
+        EXPECT_EQ(a(0, 1, 2), (*iter)(2));
+        EXPECT_EQ(a(0, 1, 3), (*iter)(3));
+        ++iter;
+        EXPECT_EQ(a(1, 1, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 1, 1), (*iter)(1));
+        EXPECT_EQ(a(1, 1, 2), (*iter)(2));
+        EXPECT_EQ(a(1, 1, 3), (*iter)(3));
+        ++iter;
+        EXPECT_EQ(a(0, 2, 0), (*iter)(0));
+        EXPECT_EQ(a(0, 2, 1), (*iter)(1));
+        EXPECT_EQ(a(0, 2, 2), (*iter)(2));
+        EXPECT_EQ(a(0, 2, 3), (*iter)(3));
+        ++iter;
+        EXPECT_EQ(a(1, 2, 0), (*iter)(0));
+        EXPECT_EQ(a(1, 2, 1), (*iter)(1));
+        EXPECT_EQ(a(1, 2, 2), (*iter)(2));
+        EXPECT_EQ(a(1, 2, 3), (*iter)(3));
+    }
+}


### PR DESCRIPTION
xaxis_slice_iterator – Iterates over 1D slices oriented along the specified axis, related to feature request – 1429

I am creating this pull request on behalf of Shashank Shekhar.

**Please check if your PR fulfills these requirements**

- The title and the commit message(s) are descriptive
- Small commits made to fix your PR have been squashed to avoid history pollution
- Tests have been added for new features or bug fixes
- API of new functions and classes are documented
- If you PR introduces backward incompatible changes, update the version number
in both docs/source/changelog.rst and include/xtensor/xtensor_config.hpp according
to the following rules:
    - if XTENSOR_VERSION_PATCH is already 0-dev, you have nothing to do
    - otherwise, set XTENSOR_VERSION_PATCH to 0-dev and increase XTENSOR_VERSION_MINOR by 1
