### PR TITLE
Added noexcept in svector

### DIFF
--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -649,7 +649,7 @@ namespace xt
         explicit svector(const svector<T, N2, A, I2>& rhs);
 
         svector& operator=(const svector& rhs);
-        svector& operator=(svector&& rhs);
+        svector& operator=(svector&& rhs) noexcept(std::is_nothrow_move_assignable<value_type>::value);
         svector& operator=(const std::vector<T>& rhs);
         svector& operator=(std::initializer_list<T> il);
 
@@ -657,7 +657,7 @@ namespace xt
         svector& operator=(const svector<T, N2, A, I2>& rhs);
 
         svector(const svector& other);
-        svector(svector&& other);
+        svector(svector&& other) noexcept(std::is_nothrow_move_constructible<value_type>::value);
 
         void assign(size_type n, const value_type& v);
 
@@ -813,7 +813,8 @@ namespace xt
     }
 
     template <class T, std::size_t N, class A, bool Init>
-    inline svector<T, N, A, Init>& svector<T, N, A, Init>::operator=(svector&& rhs)
+    inline svector<T, N, A, Init>& svector<T, N, A, Init>::operator=(svector&& rhs) noexcept(std::is_nothrow_move_assignable<
+                                                                                             value_type>::value)
     {
         assign(rhs.begin(), rhs.end());
         return *this;
@@ -850,7 +851,7 @@ namespace xt
     }
 
     template <class T, std::size_t N, class A, bool Init>
-    inline svector<T, N, A, Init>::svector(svector&& rhs)
+    inline svector<T, N, A, Init>::svector(svector&& rhs) noexcept(std::is_nothrow_move_constructible<value_type>::value)
     {
         this->swap(rhs);
     }

--- a/test/test_xarray.cpp
+++ b/test/test_xarray.cpp
@@ -13,6 +13,7 @@
 #include "xtensor/xmanipulation.hpp"
 #include "xtensor/xio.hpp"
 #include "test_common.hpp"
+#include <type_traits>
 
 namespace xt
 {
@@ -333,5 +334,26 @@ namespace xt
     {
         auto a = test_reshape_compile();
         EXPECT_EQ(a.shape(), std::vector<std::size_t>({1, 25}));
+    }
+
+    TEST(xarray, type_traits)
+    {
+        using array_type = xt::xarray<double>;
+        EXPECT_TRUE(std::is_constructible<array_type>::value);
+
+        EXPECT_TRUE(std::is_default_constructible<array_type>::value);
+
+        EXPECT_TRUE(std::is_copy_constructible<array_type>::value);
+
+        EXPECT_TRUE(std::is_move_constructible<array_type>::value);
+        EXPECT_TRUE(std::is_nothrow_move_constructible<array_type>::value);
+
+        EXPECT_TRUE(std::is_copy_assignable<array_type>::value);
+
+        EXPECT_TRUE(std::is_move_assignable<array_type>::value);
+        EXPECT_TRUE(std::is_nothrow_move_assignable<array_type>::value);
+
+        EXPECT_TRUE(std::is_destructible<array_type>::value);
+        EXPECT_TRUE(std::is_nothrow_destructible<array_type>::value);
     }
 }

--- a/test/test_xtensor.cpp
+++ b/test/test_xtensor.cpp
@@ -11,6 +11,7 @@
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xarray.hpp"
 #include "test_common.hpp"
+#include <type_traits>
 
 #include "xtensor/xio.hpp"
 
@@ -344,5 +345,27 @@ namespace xt
     {
         using tensor_type = xtensor<int, 2>;
         test_iterator_types<tensor_type, int*, const int*>();
+    }
+
+    TEST(xtensor, type_traits)
+    {
+        using tensor_type = xt::xtensor<double, 3>;
+        EXPECT_TRUE(std::is_constructible<tensor_type>::value);
+        EXPECT_TRUE(std::is_constructible<tensor_type>::value);
+
+        EXPECT_TRUE(std::is_default_constructible<tensor_type>::value);
+
+        EXPECT_TRUE(std::is_copy_constructible<tensor_type>::value);
+
+        EXPECT_TRUE(std::is_move_constructible<tensor_type>::value);
+        EXPECT_TRUE(std::is_nothrow_move_constructible<tensor_type>::value);
+
+        EXPECT_TRUE(std::is_copy_assignable<tensor_type>::value);
+
+        EXPECT_TRUE(std::is_move_assignable<tensor_type>::value);
+        EXPECT_TRUE(std::is_nothrow_move_assignable<tensor_type>::value);
+
+        EXPECT_TRUE(std::is_destructible<tensor_type>::value);
+        EXPECT_TRUE(std::is_nothrow_destructible<tensor_type>::value);
     }
 }


### PR DESCRIPTION
Added  noexcept(std::is_nothrow_move_assignable<value_type>::value) to the svector move assign.

Added noexcept(std::is_nothrow_move_constructible<value_type>::value) to the svector move constructor.

Currently no tests have been added.
One could possibly add a 
`static_assert(std::is_nothrow_move_constructible<xt::xarray<double>>::value, "xarray should have a nothrow move constructor")` 
and
`static_assert(std::is_nothrow_move_assignable<xt::xarray<double>>::value, "xarray should have a nothrow move assign")`
as a "test", since this now evaluates to `true`.
But I personally do not like such a `static_assert` as a test, so I have not added it.

Closes #1917 