### PR TITLE
Fix initialization of out shape in xt::tile

### DIFF
--- a/include/xtensor/xpad.hpp
+++ b/include/xtensor/xpad.hpp
@@ -233,6 +233,49 @@ namespace xt
         return pad(e, pw, mode, constant_value);
     }
 
+    namespace detail {
+
+        template <class E, class S>
+        inline auto tile(E&& e, const S& reps)
+        {
+            using size_type = typename std::decay_t<E>::size_type;
+            using value_type = typename std::decay_t<E>::value_type;
+            using return_type = temporary_type_t<value_type,
+                                                 typename std::decay_t<E>::shape_type,
+                                                 std::decay_t<E>::static_layout>;
+
+            XTENSOR_ASSERT(e.shape().size() == reps.size());
+
+            using new_shape_type = typename return_type::shape_type;
+            auto new_shape = xtl::make_sequence<new_shape_type>(e.shape().size());
+
+            xt::xstrided_slice_vector sv;
+
+            for (size_type axis = 0; axis < reps.size(); ++axis)
+            {
+                new_shape[axis] = e.shape(axis) * reps[axis];
+                sv.push_back(xt::range(0, e.shape(axis)));
+            }
+            return_type out(new_shape);
+
+            xt::strided_view(out, sv) = e;
+
+            for (size_type axis = 0; axis < e.shape().size(); ++axis)
+            {
+                for (size_type i = 1; i < reps[axis]; ++i)
+                {
+                    xt::xstrided_slice_vector svs(e.shape().size(), xt::all());
+                    xt::xstrided_slice_vector svt(e.shape().size(), xt::all());
+                    svs[axis] = xt::range(0, e.shape(axis));
+                    svt[axis] = xt::range(i * e.shape(axis), (i + 1) * e.shape(axis));
+                    xt::strided_view(out, svt) = xt::strided_view(out, svs);
+                }
+            }
+
+            return out;
+        }
+    }
+
     /**
      * @brief Tile an array.
      *
@@ -240,40 +283,17 @@ namespace xt
      * @param reps The number of repetitions of A along each axis.
      * @return The tiled array.
      */
+
     template <class E, class S = typename std::decay_t<E>::size_type>
-    inline auto tile(E&& e, const std::vector<S>& reps)
+    inline auto tile(E&& e, std::initializer_list<S> reps)
     {
-        using size_type = typename std::decay_t<E>::size_type;
-        using value_type = typename std::decay_t<E>::value_type;
-        using return_type = temporary_type_t<value_type,
-                                             typename std::decay_t<E>::shape_type,
-                                             std::decay_t<E>::static_layout>;
+      return detail::tile(std::forward<E>(e), std::vector<S>{reps});
+    }
 
-        XTENSOR_ASSERT(e.shape().size() == reps.size());
-
-        auto new_shape = e.shape();
-        xt::xstrided_slice_vector sv;
-        for (size_type axis = 0; axis < e.shape().size(); ++axis)
-        {
-            new_shape[axis] = e.shape(axis) * reps[axis];
-            sv.push_back(xt::range(0, e.shape(axis)));
-        }
-        return_type out(new_shape);
-        xt::strided_view(out, sv) = e;
-
-        for (size_type axis = 0; axis < e.shape().size(); ++axis)
-        {
-            for (size_type i = 1; i < reps[axis]; ++i)
-            {
-                xt::xstrided_slice_vector svs(e.shape().size(), xt::all());
-                xt::xstrided_slice_vector svt(e.shape().size(), xt::all());
-                svs[axis] = xt::range(0, e.shape(axis));
-                svt[axis] = xt::range(i * e.shape(axis), (i + 1) * e.shape(axis));
-                xt::strided_view(out, svt) = xt::strided_view(out, svs);
-            }
-        }
-
-        return out;
+    template <class E, class C, XTL_REQUIRES(xtl::negation<std::is_integral<C>>)>
+    inline auto tile(E&& e, const C& reps)
+    {
+      return detail::tile(std::forward<E>(e), reps);
     }
 
     /**
@@ -283,12 +303,12 @@ namespace xt
      * @param reps The number of repetitions of A along the first axis.
      * @return The tiled array.
      */
-    template <class E, class S = typename std::decay_t<E>::size_type>
+    template <class E, class S = typename std::decay_t<E>::size_type, XTL_REQUIRES(std::is_integral<S>)>
     inline auto tile(E&& e, S reps)
     {
-        std::vector<S> tw(e.shape().size(), static_cast<S>(1));
-        tw[0] = static_cast<S>(reps);
-        return tile(e, tw);
+      std::vector<S> tw(e.shape().size(), static_cast<S>(1));
+      tw[0] = reps;
+      return tile(std::forward<E>(e), tw);
     }
 }
 

--- a/test/test_xpad.cpp
+++ b/test/test_xpad.cpp
@@ -293,4 +293,42 @@ namespace xt
 
         EXPECT_EQ(b, c);
     }
+
+    TEST(xpad, tile_d)
+    {
+        xt::xtensor<size_t, 2> a = xt::arange<size_t>(3 * 2).reshape({3, 2});
+
+        xt::xtensor<size_t, 2> b = {{0, 1, 0, 1, 0, 1, 0, 1},
+                                    {2, 3, 2, 3, 2, 3, 2, 3},
+                                    {4, 5, 4, 5, 4, 5, 4, 5},
+                                    {0, 1, 0, 1, 0, 1, 0, 1},
+                                    {2, 3, 2, 3, 2, 3, 2, 3},
+                                    {4, 5, 4, 5, 4, 5, 4, 5},
+                                    {0, 1, 0, 1, 0, 1, 0, 1},
+                                    {2, 3, 2, 3, 2, 3, 2, 3},
+                                    {4, 5, 4, 5, 4, 5, 4, 5}};
+
+        xt::xtensor<size_t, 2> c = xt::tile(a, std::array<size_t, 2>{{3, 4}});
+
+        EXPECT_EQ(b, c);
+    }
+
+    TEST(xpad, tile_e)
+    {
+        xt::xarray<size_t> a = xt::arange<size_t>(3 * 2).reshape({3, 2});
+
+        xt::xtensor<size_t, 2> b = {{0, 1, 0, 1, 0, 1, 0, 1},
+                                    {2, 3, 2, 3, 2, 3, 2, 3},
+                                    {4, 5, 4, 5, 4, 5, 4, 5},
+                                    {0, 1, 0, 1, 0, 1, 0, 1},
+                                    {2, 3, 2, 3, 2, 3, 2, 3},
+                                    {4, 5, 4, 5, 4, 5, 4, 5},
+                                    {0, 1, 0, 1, 0, 1, 0, 1},
+                                    {2, 3, 2, 3, 2, 3, 2, 3},
+                                    {4, 5, 4, 5, 4, 5, 4, 5}};
+
+        xt::xtensor<size_t, 2> c = xt::tile(a, std::vector<size_t>{{3, 4}});
+
+        EXPECT_EQ(b, c);
+    }
 }


### PR DESCRIPTION
Previous initialization was problematic, as:

1. it is useless (value are overwritten in the shape init loop)
2. it may have the wrong type (signed vs unsigned shape element)