### PR TITLE
Added test which produces errors on valgrind

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -206,6 +206,7 @@ set(XTENSOR_TESTS
     test_extended_xmath_reducers.cpp
     test_extended_xhistogram.cpp
     test_extended_xsort.cpp
+    test_invalid_write_size.cpp
 )
 
 if(nlohmann_json_FOUND)

--- a/test/test_invalid_write_size.cpp
+++ b/test/test_invalid_write_size.cpp
@@ -1,0 +1,70 @@
+
+#include "xtensor/xarray.hpp"
+#include "xtensor/xtensor.hpp"
+#include "gtest/gtest.h"
+
+
+namespace xt {
+
+template<typename OutType, typename CreateType>
+xtensor<OutType, 2> get(const size_t vShape) {
+    xtensor<CreateType, 2> vTensor = ones<CreateType>({ vShape, vShape });
+    return vTensor;
+}
+
+TEST(InvalidWriteOfSizeTest, FloatInt8ValgrindFail) {
+    using CreateType = float;
+    using OutType = uint8_t;
+
+    xtensor<OutType, 2> vExpected = ones<CreateType>({ 1024, 1024 });
+    xtensor<OutType, 2> vResult = get<OutType, CreateType>(vExpected.shape(0));
+    EXPECT_EQ(vResult, vExpected);
+}
+
+TEST(InvalidWriteOfSizeTest, DoubleInt8ValgrindFail) {
+    using CreateType = double;
+    using OutType = uint8_t;
+
+    xtensor<OutType, 2> vExpected = ones<CreateType>({ 1024, 1024 });
+    xtensor<OutType, 2> vResult = get<OutType, CreateType>(vExpected.shape(0));
+    EXPECT_EQ(vResult, vExpected);
+}
+
+TEST(InvalidWriteOfSizeTest, DoubleInt16ValgrindFail) {
+    using CreateType = double;
+    using OutType = uint16_t;
+
+    xtensor<OutType, 2> vExpected = ones<CreateType>({ 1024, 1024 });
+    xtensor<OutType, 2> vResult = get<OutType, CreateType>(vExpected.shape(0));
+    EXPECT_EQ(vResult, vExpected);
+}
+
+// These do not produce any errors with valgrind
+TEST(InvalidWriteOfSizeTest, FloatInt16ValgrindSuccess) {
+    using CreateType = float;
+    using OutType = uint16_t;
+
+    xtensor<OutType, 2> vExpected = ones<CreateType>({ 1024, 1024 });
+    xtensor<OutType, 2> vResult = get<OutType, CreateType>(vExpected.shape(0));
+    EXPECT_EQ(vResult, vExpected);
+}
+
+TEST(InvalidWriteOfSizeTest, DoubleInt32ValgrindSuccess) {
+    using CreateType = double;
+    using OutType = uint32_t;
+
+    xtensor<OutType, 2> vExpected = ones<CreateType>({ 1024, 1024 });
+    xtensor<OutType, 2> vResult = get<OutType, CreateType>(vExpected.shape(0));
+    EXPECT_EQ(vResult, vExpected);
+}
+
+TEST(InvalidWriteOfSizeTest, DoubleFloatValgrindSuccess) {
+    using CreateType = double;
+    using OutType = float;
+
+    xtensor<OutType, 2> vExpected = ones<CreateType>({ 1024, 1024 });
+    xtensor<OutType, 2> vResult = get<OutType, CreateType>(vExpected.shape(0));
+    EXPECT_EQ(vResult, vExpected);
+}
+
+}


### PR DESCRIPTION
After compiling this test with xsimd, valgrind will show `Invalid write of size` errors.
See #1962 for further details.