### PR TITLE
Fixed check_element_index behavior for 0-D expressions

### DIFF
--- a/include/xtensor/xexception.hpp
+++ b/include/xtensor/xexception.hpp
@@ -183,31 +183,17 @@ namespace xt
         It efirst = last - static_cast<std::ptrdiff_t>((std::min)(shape.size(), dst));
         std::size_t axis = 0;
         
-        if(shape.empty())
+        while (efirst != last)
         {
-            if(first != last && *(--last) != value_type(0))
+            if (*efirst >= value_type(shape[axis]) && shape[axis] != 1)
             {
-                XTENSOR_THROW(std::out_of_range, "index out of bound (empty array)");
+                XTENSOR_THROW(std::out_of_range,
+                                "index " + std::to_string(*efirst) +
+                                " is out of bounds for axis " +
+                                std::to_string(axis) + " with size " +
+                                std::to_string(shape[axis]));
             }
-            else
-            {
-                return;
-            }
-        }
-        else
-        {
-            while (efirst != last)
-            {
-                if (*efirst >= value_type(shape[axis]) && shape[axis] != 1)
-                {
-                    XTENSOR_THROW(std::out_of_range,
-                                  "index " + std::to_string(*efirst) +
-                                  " is out of bounds for axis " +
-                                  std::to_string(axis) + " with size " +
-                                  std::to_string(shape[axis]));
-                }
-                ++efirst, ++axis;
-            }
+            ++efirst, ++axis;
         }
     }
 

--- a/test/test_xarray.cpp
+++ b/test/test_xarray.cpp
@@ -243,11 +243,16 @@ namespace xt
     TEST(xarray, zerod)
     {
         xarray_dynamic a;
+        EXPECT_EQ(0u, a.dimension());
         EXPECT_EQ(0, a());
 
         xarray_dynamic b = {1, 2, 3};
         xarray_dynamic c(2 + xt::sum(b));
         EXPECT_EQ(8, c());
+
+        EXPECT_EQ(8, c(1, 2));
+        xindex idx = { 1, 2 };
+        EXPECT_EQ(8, c.element(idx.cbegin(), idx.cend()));
     }
 
     TEST(xarray, xiterator)


### PR DESCRIPTION
Fixes #1964 