### PR TITLE
xrepeat now stores const_xclosure_t<E> instead of E

### DIFF
--- a/include/xtensor/xmanipulation.hpp
+++ b/include/xtensor/xmanipulation.hpp
@@ -888,7 +888,7 @@ namespace xt
         template<class E, class R>
         inline auto make_xrepeat(E&& e, R&& r, typename std::decay_t<E>::size_type axis)
         {
-            return xrepeat<E, R>(std::forward<E>(e), std::forward<R>(r), axis);
+            return xrepeat<const_xclosure_t<E>, R>(std::forward<E>(e), std::forward<R>(r), axis);
         }
     }
 

--- a/test/test_xrepeat.cpp
+++ b/test/test_xrepeat.cpp
@@ -10,13 +10,23 @@
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xrepeat.hpp"
-
-
 #include "xtensor/xview.hpp"
 #include "xtensor/xio.hpp"
 
 namespace xt
 {
+
+    TEST(xrepeat, const_array)
+    {
+        xarray<size_t> const array = {1, 2, 3};
+
+        const auto repeated_array = xt::repeat(array, 1, 0);
+
+        ASSERT_EQ(1, repeated_array(0));
+        ASSERT_EQ(2, repeated_array(1));
+        ASSERT_EQ(3, repeated_array(2));
+    }
+
     TEST(xrepeat, stepper_begin)
     {
         xarray<size_t> array = {


### PR DESCRIPTION
Fixes #1959 