### PR TITLE
Fix segfault when using xt::drop() on an empty list of indices.

### DIFF
--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -1516,7 +1516,7 @@ namespace xt
     template <class T>
     inline auto xdrop_slice<T>::operator()(size_type i) const noexcept -> size_type
     {
-        if (i < m_inc.begin()->first)
+        if (m_inc.empty() || i < m_inc.begin()->first)
         {
             return i;
         }

--- a/include/xtensor/xtensor_config.hpp
+++ b/include/xtensor/xtensor_config.hpp
@@ -12,7 +12,7 @@
 
 #define XTENSOR_VERSION_MAJOR 0
 #define XTENSOR_VERSION_MINOR 21
-#define XTENSOR_VERSION_PATCH 4
+#define XTENSOR_VERSION_PATCH 5-dev
 
 // DETECT 3.6 <= clang < 3.8 for compiler bug workaround.
 #ifdef __clang__

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -1097,6 +1097,12 @@ namespace xt
         EXPECT_FALSE(b);
         b = detail::is_strided_view<decltype(a), xrange<int>, xrange<int>, int>::value;
         EXPECT_TRUE(b);
+
+        std::vector<size_t> empty;
+        auto v5 = xt::view(a, drop(empty), drop(empty), drop(empty));
+        v5(1, 1, 1) = 456;
+        EXPECT_EQ(v5, a);
+        EXPECT_EQ(a(1, 1, 1), 456);
     }
 
     TEST(xview, drop_negative)


### PR DESCRIPTION
My company are trying to build an `xt::view` in a situation where we don't know at compile time which indices we need to `xt::drop`. Our solution has been to pack the indices we need to remove into an `std::vector<size_t>` and pass that as an argument to `xt::drop`, but we've discovered that this crashes when the input vector is empty.