### PR TITLE
Fix return dtype of nanmean and add unittest

### DIFF
--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -2679,17 +2679,17 @@ namespace detail {
     template <class T = void, class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>
     inline auto nanmean(E&& e, std::initializer_list<I> axes, EVS es = EVS())
     {
-        return nanmean(std::forward<E>(e),
-                       xtl::forward_sequence<dynamic_shape<std::size_t>, decltype(axes)>(axes),
-                       es);
+        return nanmean<T>(std::forward<E>(e),
+                          xtl::forward_sequence<dynamic_shape<std::size_t>, decltype(axes)>(axes),
+                          es);
     }
 #else
     template <class T = void, class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
     inline auto nanmean(E&& e, const I (&axes)[N], EVS es = EVS())
     {
-        return nanmean(std::forward<E>(e),
-                       xtl::forward_sequence<std::array<std::size_t, N>, decltype(axes)>(axes),
-                       es);
+        return nanmean<T>(std::forward<E>(e),
+                          xtl::forward_sequence<std::array<std::size_t, N>, decltype(axes)>(axes),
+                          es);
     }
 #endif
 

--- a/test/test_xnan_functions.cpp
+++ b/test/test_xnan_functions.cpp
@@ -187,4 +187,49 @@ namespace xt
         EXPECT_EQ(nanvar(nantest::aN, {0}, evaluation_strategy::immediate), eaN0);
         EXPECT_TRUE(allclose(nanvar(nantest::aN, {1}, evaluation_strategy::immediate), eaN1));
     }
+
+    using shape_type = dynamic_shape<size_t>;
+
+    /*******************
+     * type conversion *
+     *******************/
+
+#define CHECK_RESULT_TYPE(EXPRESSION, EXPECTED_TYPE)                                 \
+    {                                                                                \
+        using result_type = typename std::decay_t<decltype(EXPRESSION)>::value_type; \
+        EXPECT_TRUE((std::is_same<result_type, EXPECTED_TYPE>::value));              \
+    }
+
+    TEST(xnanfunctions, result_type) {
+        shape_type shape = {4, 3, 2};
+        xarray<int> aint(shape);
+        xarray<float> afloat(shape);
+        xarray<double> adouble(shape);
+
+        /*********
+         * int *
+         *********/
+        CHECK_RESULT_TYPE(nansum(aint, {1, 2}), int);
+        CHECK_RESULT_TYPE(nanmean(aint, {1, 2}), double);
+        CHECK_RESULT_TYPE(nanstd(aint, {1, 2}), double);
+        CHECK_RESULT_TYPE(nanvar(aint, {1, 2}), double);
+        CHECK_RESULT_TYPE(nanmean<int>(aint, {1, 2}), int);
+
+        /*********
+         * float *
+         *********/
+        CHECK_RESULT_TYPE(nansum(afloat, {1, 2}), float);
+        CHECK_RESULT_TYPE(nanmean(afloat, {1, 2}), double);
+        CHECK_RESULT_TYPE(nanstd(afloat, {1, 2}), double);
+        CHECK_RESULT_TYPE(nanvar(afloat, {1, 2}), double);
+        CHECK_RESULT_TYPE(nanmean<float>(afloat, {1, 2}), float);
+
+        /**********
+         * double *
+         **********/
+        CHECK_RESULT_TYPE(nansum(adouble, {1, 2}), double);
+        CHECK_RESULT_TYPE(nanmean(adouble, {1, 2}), double);
+        CHECK_RESULT_TYPE(nanstd(adouble, {1, 2}), double);
+        CHECK_RESULT_TYPE(nanvar(adouble, {1, 2}), double);
+    }
 }


### PR DESCRIPTION
This is to clean my leftover in PR #1749. I am sorry for the omission. Unittest are included now.

Two thoughts after this PR:

1. `nanvar` and `nanstd` do not provide the template argument to specify the return value type. while in `numpy`, an `nan` operation on an array of `np.float32` always returns an array with the same dtype;

2. I found the following promotion in the file `test_xmath_result_type.cpp`:

```cpp
    CHECK_RESULT_TYPE(sum(aint), long long);
    CHECK_RESULT_TYPE(sum(afloat), double);
```
while there is no such promotion in the test of this PR

```cpp
    CHECK_RESULT_TYPE(nansum(aint, {1, 2}), int);
    CHECK_RESULT_TYPE(nansum(afloat, {1, 2}), float);
```

I checked `numpy` and there is also no such promotion in `np.sum`.
