### PR TITLE
Add result type template argument for stddev, variance, nanstd and na…

### DIFF
--- a/test/test_xmath_result_type.cpp
+++ b/test/test_xmath_result_type.cpp
@@ -66,20 +66,31 @@ namespace xt
         CHECK_RESULT_TYPE(FUNC<signed int>(INPUT), signed int);                      \
         CHECK_RESULT_TYPE(FUNC<int>(INPUT), int);                                    \
         CHECK_RESULT_TYPE(FUNC<unsigned long long>(INPUT), unsigned long long);      \
-        CHECK_RESULT_TYPE(FUNC<signed long long>(INPUT), signed long long);
+        CHECK_RESULT_TYPE(FUNC<signed long long>(INPUT), signed long long);          \
+        CHECK_RESULT_TYPE(FUNC<long long>(INPUT), long long);                        \
+        CHECK_RESULT_TYPE(FUNC<float>(INPUT), float);                                \
+        CHECK_RESULT_TYPE(FUNC<double>(INPUT), double);
 
     TEST(xmath, result_type)
     {
         shape_type shape = {3, 2};
         xarray<unsigned char> auchar(shape);
         xarray<short> ashort(shape);
+        xarray<unsigned short> aushort(shape);
         xarray<int> aint(shape);
         xarray<unsigned int> auint(shape);
+        xarray<long long> along(shape);
         xarray<unsigned long long> aulong(shape);
         xarray<float> afloat(shape);
         xarray<double> adouble(shape);
         xarray<std::complex<float>> afcomplex(shape);
         xarray<std::complex<double>> adcomplex(shape);
+
+#define CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(INPUT)                                   \
+        CHECK_TEMPLATED_RESULT_TYPE(mean, INPUT)                                     \
+        CHECK_TEMPLATED_RESULT_TYPE(variance, INPUT)
+// FIXME: the first 6 checks in "#define CHECK_TEMPLATED_RESULT_TYPE(FUNC, INPUT)" fail
+//        CHECK_TEMPLATED_RESULT_TYPE(stddev, INPUT)
 
         /*****************
          * unsigned char *
@@ -92,7 +103,7 @@ namespace xt
         CHECK_RESULT_TYPE(sum(auchar), unsigned long long);
         CHECK_RESULT_TYPE(mean(auchar), double);
         CHECK_RESULT_TYPE(minmax(auchar), ARRAY_TYPE(unsigned char));
-        CHECK_TEMPLATED_RESULT_TYPE(mean, auchar);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auchar);
 
         /*********
          * short *
@@ -105,7 +116,20 @@ namespace xt
         CHECK_RESULT_TYPE(sum(ashort), long long);
         CHECK_RESULT_TYPE(mean(ashort), double);
         CHECK_RESULT_TYPE(minmax(ashort), ARRAY_TYPE(short));
-        CHECK_TEMPLATED_RESULT_TYPE(mean, ashort);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort);
+
+        /******************
+         * unsigned short *
+         ******************/
+        CHECK_RESULT_TYPE(aushort + aushort, int);
+        CHECK_RESULT_TYPE(2u * aushort, unsigned int);
+        CHECK_RESULT_TYPE(2.0 * aushort, double);
+        CHECK_RESULT_TYPE(sqrt(aushort), double);
+        CHECK_RESULT_TYPE(abs(aushort), unsigned short);
+        CHECK_RESULT_TYPE(sum(aushort), unsigned long long);
+        CHECK_RESULT_TYPE(mean(aushort), double);
+        CHECK_RESULT_TYPE(minmax(aushort), ARRAY_TYPE(unsigned short));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort);
 
         /*******
          * int *
@@ -118,7 +142,7 @@ namespace xt
         CHECK_RESULT_TYPE(sum(aint), long long);
         CHECK_RESULT_TYPE(mean(aint), double);
         CHECK_RESULT_TYPE(minmax(aint), ARRAY_TYPE(int));
-        CHECK_TEMPLATED_RESULT_TYPE(mean, aint);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aint);
 
         /****************
          * unsigned int *
@@ -131,7 +155,20 @@ namespace xt
         CHECK_RESULT_TYPE(sum(auint), unsigned long long);
         CHECK_RESULT_TYPE(mean(auint), double);
         CHECK_RESULT_TYPE(minmax(auint), ARRAY_TYPE(unsigned int));
-        CHECK_TEMPLATED_RESULT_TYPE(mean, auint);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auint);
+
+        /**********************
+         * long long *
+         **********************/
+        CHECK_RESULT_TYPE(along + along, signed long long);
+        CHECK_RESULT_TYPE(2 * along, signed long long);
+        CHECK_RESULT_TYPE(2.0 * along, double);
+        CHECK_RESULT_TYPE(sqrt(along), double);
+        CHECK_RESULT_TYPE(abs(along), signed long long);
+        CHECK_RESULT_TYPE(sum(along), signed long long);
+        CHECK_RESULT_TYPE(mean(along), double);
+        CHECK_RESULT_TYPE(minmax(along), ARRAY_TYPE(signed long long));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(along);
 
         /**********************
          * unsigned long long *
@@ -144,7 +181,7 @@ namespace xt
         CHECK_RESULT_TYPE(sum(aulong), unsigned long long);
         CHECK_RESULT_TYPE(mean(aulong), double);
         CHECK_RESULT_TYPE(minmax(aulong), ARRAY_TYPE(unsigned long long));
-        CHECK_TEMPLATED_RESULT_TYPE(mean, aulong);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aulong);
 
         /*********
          * float *
@@ -157,7 +194,7 @@ namespace xt
         CHECK_RESULT_TYPE(sum(afloat), double);
         CHECK_RESULT_TYPE(mean(afloat), double);
         CHECK_RESULT_TYPE(minmax(afloat), ARRAY_TYPE(float));
-        CHECK_TEMPLATED_RESULT_TYPE(mean, afloat);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(afloat);
 
         /**********
          * double *
@@ -169,7 +206,7 @@ namespace xt
         CHECK_RESULT_TYPE(sum(adouble), double);
         CHECK_RESULT_TYPE(mean(adouble), double);
         CHECK_RESULT_TYPE(minmax(adouble), ARRAY_TYPE(double));
-        CHECK_TEMPLATED_RESULT_TYPE(mean, adouble);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(adouble);
 
         /***********************
          * std::complex<float> *

--- a/test/test_xnan_functions.cpp
+++ b/test/test_xnan_functions.cpp
@@ -202,34 +202,73 @@ namespace xt
 
     TEST(xnanfunctions, result_type) {
         shape_type shape = {4, 3, 2};
+        xarray<short> ashort(shape);
+        xarray<unsigned short> aushort(shape);
         xarray<int> aint(shape);
+        xarray<unsigned int> auint(shape);
+        xarray<long long> along(shape);
+        xarray<unsigned long long> aulong(shape);
         xarray<float> afloat(shape);
         xarray<double> adouble(shape);
+
+#define CHECK_RESULT_TYPE_FOR_ALL(INPUT, RESULT_TYPE)                               \
+        CHECK_RESULT_TYPE(nansum(INPUT, {1, 2}), RESULT_TYPE);                      \
+        CHECK_RESULT_TYPE(nanmean(INPUT, {1, 2}), double);                          \
+        CHECK_RESULT_TYPE(nanvar(INPUT, {1, 2}), double);                           \
+        CHECK_RESULT_TYPE(nanstd(INPUT, {1, 2}), double);
+
+#define CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(INPUT, RESULT_TYPE)                     \
+        CHECK_RESULT_TYPE(nansum<RESULT_TYPE>(INPUT, {1, 2}), RESULT_TYPE)          \
+        CHECK_RESULT_TYPE(nanmean<RESULT_TYPE>(INPUT, {1, 2}), RESULT_TYPE)         \
+        CHECK_RESULT_TYPE(nanvar<RESULT_TYPE>(INPUT, {1, 2}), RESULT_TYPE)          \
+        CHECK_RESULT_TYPE(nanstd<RESULT_TYPE>(INPUT, {1, 2}), RESULT_TYPE)
+
+        /*********
+         * short *
+         *********/
+        CHECK_RESULT_TYPE_FOR_ALL(ashort, short);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort, int);
+
+        /******************
+         * unsigned short *
+         ******************/
+        CHECK_RESULT_TYPE_FOR_ALL(aushort, unsigned short);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aushort, unsigned int);
 
         /*********
          * int *
          *********/
-        CHECK_RESULT_TYPE(nansum(aint, {1, 2}), int);
-        CHECK_RESULT_TYPE(nanmean(aint, {1, 2}), double);
-        CHECK_RESULT_TYPE(nanstd(aint, {1, 2}), double);
-        CHECK_RESULT_TYPE(nanvar(aint, {1, 2}), double);
-        CHECK_RESULT_TYPE(nanmean<int>(aint, {1, 2}), int);
+        CHECK_RESULT_TYPE_FOR_ALL(aint, int);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aint, int);
+
+        /****************
+         * unsigned int *
+         ****************/
+        CHECK_RESULT_TYPE_FOR_ALL(auint, unsigned int);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auint, unsigned int);
+
+        /**********************
+         * long long *
+         **********************/
+        CHECK_RESULT_TYPE_FOR_ALL(along, signed long long);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(along, signed long long);
+
+        /**********************
+         * unsigned long long *
+         **********************/
+        CHECK_RESULT_TYPE_FOR_ALL(aulong, unsigned long long);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aulong, unsigned long long);
 
         /*********
          * float *
          *********/
-        CHECK_RESULT_TYPE(nansum(afloat, {1, 2}), float);
-        CHECK_RESULT_TYPE(nanmean(afloat, {1, 2}), double);
-        CHECK_RESULT_TYPE(nanstd(afloat, {1, 2}), double);
-        CHECK_RESULT_TYPE(nanvar(afloat, {1, 2}), double);
-        CHECK_RESULT_TYPE(nanmean<float>(afloat, {1, 2}), float);
+        CHECK_RESULT_TYPE_FOR_ALL(afloat, float);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(afloat, float);
 
         /**********
          * double *
          **********/
-        CHECK_RESULT_TYPE(nansum(adouble, {1, 2}), double);
-        CHECK_RESULT_TYPE(nanmean(adouble, {1, 2}), double);
-        CHECK_RESULT_TYPE(nanstd(adouble, {1, 2}), double);
-        CHECK_RESULT_TYPE(nanvar(adouble, {1, 2}), double);
+        CHECK_RESULT_TYPE_FOR_ALL(adouble, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(adouble, double);
     }
 }


### PR DESCRIPTION
As discussed in #1996

I am still struggling with how should I add the unittest with the template argument.

In the meanwhile, I found a bug in `nanmean` as well as `nanstd` and `nanvar` which make use of `nanmean` with template argument. The `numpy.nanmean` code below speaks the issue

```py
    arr, mask = _replace_nan(a, 0)
    if mask is None:
        return np.mean(arr, axis=axis, dtype=dtype, out=out, keepdims=keepdims)

    if dtype is not None:
        dtype = np.dtype(dtype)
    if dtype is not None and not issubclass(dtype.type, np.inexact):
        raise TypeError("If a is inexact, then dtype must be inexact")
    if out is not None and not issubclass(out.dtype.type, np.inexact):
        raise TypeError("If a is inexact, then out must be inexact")
   ...
```
The bug occurs when one tries to do something like `xt::nanmean<int>(xt::array<double>{1, 2, nan});`. In numpy, it raises `TypeError`, while in xtensor it is undefined behavior. However, the numpy implementation is not idea since it always makes a copy in `_replace_nan`.
