### PR TITLE
Fix variance overload

### DIFF
--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -2089,7 +2089,7 @@ namespace detail {
         return detail::mean_noaxis<void>(square(abs(sc - mean(sc, es))), ddof, es);
     }
 
-    template <class E, class D=int, class EVS = DEFAULT_STRATEGY_REDUCERS,
+    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS,
               XTL_REQUIRES(is_reducer_options<EVS>)>
     inline auto variance(E&& e, EVS es = EVS())
     {
@@ -2143,7 +2143,7 @@ namespace detail {
     }
 
     template <class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,
-              XTL_REQUIRES(xtl::negation<is_reducer_options<X>>, xtl::negation<std::is_integral<std::decay_t<X>>>, xtl::negation<std::is_integral<EVS>>)>
+              XTL_REQUIRES(xtl::negation<is_reducer_options<X>>, xtl::negation<std::is_integral<std::decay_t<X>>>, is_reducer_options<EVS>)>
     inline auto variance(E&& e, X&& axes, EVS es = EVS())
     {
       return variance(std::forward<E>(e), std::forward<X>(axes), 0u, es);
@@ -2182,12 +2182,22 @@ namespace detail {
                       es);
     }
 
-    template <class E, class A, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    template <class E, class A, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              XTL_REQUIRES(is_reducer_options<EVS>)>
     inline auto variance(E&& e, const A (&axes)[N], EVS es = EVS())
     {
         return variance(std::forward<E>(e),
                         xtl::forward_sequence<std::array<std::size_t, N>, decltype(axes)>(axes),
                         es);
+    }
+
+    template <class E, class A, std::size_t N, class D, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    inline auto variance(E&& e, const A (&axes)[N], D const& ddof, EVS es = EVS())
+    {
+      return variance(std::forward<E>(e),
+                      xtl::forward_sequence<std::array<std::size_t, N>, decltype(axes)>(axes),
+                      ddof,
+                      es);
     }
 #else
     template <class E, class A, class EVS = DEFAULT_STRATEGY_REDUCERS>
@@ -2198,11 +2208,21 @@ namespace detail {
                       es);
     }
 
-    template <class E, class A, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    template <class E, class A, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              XTL_REQUIRES(is_reducer_options<EVS>)>
     inline auto variance(E&& e, std::initializer_list<A> axes, EVS es = EVS())
     {
         return variance(std::forward<E>(e),
                         xtl::forward_sequence<dynamic_shape<std::size_t>, decltype(axes)>(axes),
+                        es);
+    }
+
+    template <class E, class A, class D, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    inline auto variance(E&& e, std::initializer_list<A> axes, D const& ddof, EVS es = EVS())
+    {
+        return variance(std::forward<E>(e),
+                        xtl::forward_sequence<dynamic_shape<std::size_t>, decltype(axes)>(axes),
+                        ddof,
                         es);
     }
 #endif

--- a/test/test_extended_xmath_reducers.cpp
+++ b/test/test_extended_xmath_reducers.cpp
@@ -1268,17 +1268,23 @@ namespace xt
         auto st_all = xt::stddev(py_a);
         auto vr_all = xt::variance(py_a);
         auto vr_all_ddof = xt::variance(py_a, {0, 1, 2, 3}, 1);
+        std::vector<size_t> axes_all = {0, 1, 2, 3};
+        auto vr_all_ddof_with_axes_arr = xt::variance(py_a, axes_all, 1);
 
         auto st = xt::stddev(py_a, {0, 2});
         auto vr = xt::variance(py_a, {0, 2});
         auto vr_ddof = xt::variance(py_a, {0, 2}, 1);
+        std::vector<size_t> axes02 = {0, 2};
+        auto vr_ddof_with_axes_arr = xt::variance(py_a, axes02, 1);
 
         EXPECT_TRUE(xt::allclose(st_all, py_st_all));
         EXPECT_TRUE(xt::allclose(vr_all, py_vr_all));
         EXPECT_TRUE(xt::allclose(vr_all_ddof, py_vr_all_ddof));
+        EXPECT_TRUE(xt::allclose(vr_all_ddof_with_axes_arr, py_vr_all_ddof));
         EXPECT_TRUE(xt::allclose(st, py_st));
         EXPECT_TRUE(xt::allclose(vr, py_vr));
         EXPECT_TRUE(xt::allclose(vr_ddof, py_vr_ddof));
+        EXPECT_TRUE(xt::allclose(vr_ddof_with_axes_arr, py_vr_ddof));
     }
 
 }


### PR DESCRIPTION
Fix #1935

I add an overload since the total number of overloads should be 6 (doubled from 3 after adding an extra argument `ddof`)

The warning message changes from:

```
/home/jun/Projects/xtensor/include/xtensor/xmath.hpp: In instantiation of ‘auto xt::detail::mean(E&&, X&&, const D&, EVS) [with T = void; E = xt::xfunction<xt::detail::lambda_adapt<xt::square_fct>, xt::xfunction<xt::math::abs_fun, xt::xfunction<xt::detail::minus, const xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>&, xt::xstrided_view<xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, (xt::layout_type)1, xt::detail::flat_adaptor_getter<xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>, (xt::layout_type)1> > > > >; X = std::array<long unsigned int, 4ul>; D = int; EVS = std::tuple<xt::evaluation_strategy::lazy_type>; typename std::enable_if<xtl_requires<xtl::negation<xt::is_reducer_options<X> >, std::is_integral<X> >, int>::type <anonymous> = 0]’:
/home/jun/Projects/xtensor/include/xtensor/xmath.hpp:2142:34:   required from ‘auto xt::variance(E&&, X&&, const D&, EVS) [with E = xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>&; X = std::array<long unsigned int, 4ul>; D = int; EVS = std::tuple<xt::evaluation_strategy::lazy_type>; typename std::enable_if<xtl_requires<xtl::negation<xt::is_reducer_options<EVS> >, std::is_integral<X> >, int>::type <anonymous> = 0]’
/home/jun/Projects/xtensor/include/xtensor/xmath.hpp:2188:24:   required from ‘auto xt::variance(E&&, const A (&)[N], EVS) [with E = xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>&; A = int; long unsigned int N = 4ul; EVS = int]’
/home/jun/Projects/xtensor/test/test_extended_xmath_reducers.cpp:1270:62:   required from here
```

To 

```
/home/jun/Projects/xtensor/include/xtensor/xmath.hpp: In instantiation of ‘auto xt::detail::mean(E&&, X&&, const D&, EVS) [with T = void; E = xt::xfunction<xt::detail::lambda_adapt<xt::square_fct>, xt::xfunction<xt::math::abs_fun, xt::xfunction<xt::detail::minus, const xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>&, xt::xstrided_view<xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, (xt::layout_type)1, xt::detail::flat_adaptor_getter<xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>, (xt::layout_type)1> > > > >; X = std::array<long unsigned int, 4ul>; D = int; EVS = std::tuple<xt::evaluation_strategy::lazy_type>; typename std::enable_if<xtl_requires<xtl::negation<xt::is_reducer_options<X> >, std::is_integral<X> >, int>::type <anonymous> = 0]’:
/home/jun/Projects/xtensor/include/xtensor/xmath.hpp:2142:34:   required from ‘auto xt::variance(E&&, X&&, const D&, EVS) [with E = xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>&; X = std::array<long unsigned int, 4ul>; D = int; EVS = std::tuple<xt::evaluation_strategy::lazy_type>; typename std::enable_if<xtl_requires<xtl::negation<xt::is_reducer_options<EVS> >, std::is_integral<X> >, int>::type <anonymous> = 0]’
/home/jun/Projects/xtensor/include/xtensor/xmath.hpp:2197:22:   required from ‘auto xt::variance(E&&, const A (&)[N], const D&, EVS) [with E = xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4ul, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>&; A = int; long unsigned int N = 4ul; D = int; EVS = std::tuple<xt::evaluation_strategy::lazy_type>]’
/home/jun/Projects/xtensor/test/test_extended_xmath_reducers.cpp:1270:62:   required from here
```
Please see the change of the selected overload in the second to last line.
