### PR TITLE
Sanitizer error fix for Ubuntu 18.04 gcc 7.5

### DIFF
--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -50,7 +50,7 @@ namespace xt
             bool is_trivial;
             bool is_initialized;
 
-            xfunction_cache_impl() : shape(xtl::make_sequence<S>(0, std::size_t(0))), is_initialized(false) {}
+            xfunction_cache_impl() : shape(xtl::make_sequence<S>(0, std::size_t(0))), is_initialized(false), is_trivial(false) {}
         };
 
         template<std::size_t... N, class is_shape_trivial>


### PR DESCRIPTION
For ubuntu 18.04 gcc 7.5, including flag -fsanitize=undefined throws errors in xfunction.hpp line 47.

Sample project to demonstrate at https://github.com/aclifton/xtensor-asan-tests
