### PR TITLE
Fix initialize order

### DIFF
--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -52,8 +52,8 @@ namespace xt
 
             xfunction_cache_impl() :
                 shape(xtl::make_sequence<S>(0, std::size_t(0))),
-                is_initialized(false),
-                is_trivial(false) {}
+                is_trivial(false),
+                is_initialized(false) {}
         };
 
         template<std::size_t... N, class is_shape_trivial>


### PR DESCRIPTION
#1640 Checklist

- [V] The title and commit message(s) are descriptive.
- [V] Small commits made to fix your PR have been squashed to avoid history pollution.
- [V] Tests have been added for new features or bug fixes.
- [V] API of new functions and classes are documented.

# Description

Commit e4f2bc5b596acf28aa25aa01752f6aa74a3222f1 fixed the initialize order, but somehow in 9c8aa63cb950555d0c3136c49a470b7adf81dc06 the order was reverted when reformatting the code. This commit fix it again.