### PR TITLE
Adding missing "a" to "in a shared expression".

### DIFF
--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -175,7 +175,7 @@ namespace xt
      * @tparam T The value type of the elements.
      * @tparam FSH A xshape template shape.
      * @tparam L The layout_type of the tensor (default: XTENSOR_DEFAULT_LAYOUT).
-     * @tparam Sharable Whether the tensor can be used in shared expression.
+     * @tparam Sharable Whether the tensor can be used in a shared expression.
      */
     template <class T,
               class FSH,


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

This a follow up based on https://github.com/xtensor-stack/xtensor/pull/2054/files#r433049338