### PR TITLE
Add xchunked_array

### DIFF
--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -1,0 +1,91 @@
+#include <vector>
+#include <array>
+#include "xarray.hpp"
+
+template <class Chunk_type>
+class xchunked_array
+{
+    public:
+
+        using const_reference = typename Chunk_type::const_reference;
+
+        template <class... Args>
+        inline const_reference operator()(Args... args) const
+        {
+            return access_impl(args...);
+        }
+
+        xchunked_array(std::vector<size_t> shape, std::vector<size_t> chunks):
+            m_shape(shape),
+            m_chunk_shape(chunks)
+        {
+            std::vector<size_t> shape_chunk;
+            size_t di = 0;
+            std::cout << "Creating chunked array with shape";
+            for (auto s: shape)
+            {
+                std::cout << " " << s;
+                size_t chunk_nb = s / chunks[di];
+                if (s % chunks[di] > 0)
+                    chunk_nb += 1;  // edge chunk
+                shape_chunk.push_back(chunk_nb);
+                di++;
+            }
+            std::cout << ", chunk shape";
+            for (auto s: chunks)
+                std::cout << " " << s;
+            std::cout << std::endl;
+            m_chunks.resize(shape_chunk);
+        }
+
+    private:
+
+        template <class Idx, class Arg>
+        size_t get_index_of_chunk_in_dimension(Idx idx, Arg arg) const
+        {
+            size_t index_of_chunk = arg / m_chunk_shape[idx];
+            return index_of_chunk;
+        }
+
+        template <class Idx, class Arg>
+        size_t get_index_in_chunk_in_dimension(Idx idx, Arg arg) const
+        {
+            std::cout << " " << arg;
+            size_t index_of_chunk = get_index_of_chunk_in_dimension(idx, arg);
+            size_t index_in_chunk = arg - index_of_chunk * m_chunk_shape[idx];
+            return index_in_chunk;
+        }
+
+        template <size_t... idxs, class... Args>
+        std::tuple<std::array<size_t, sizeof...(Args)>, std::array<size_t, sizeof...(Args)>>
+        get_chunk_indexes(std::index_sequence<idxs...>, Args... args) const
+        {
+            std::array<size_t, sizeof...(Args)> indexes_of_chunk = {{get_index_of_chunk_in_dimension(idxs, args)...}};
+            std::array<size_t, sizeof...(Args)> indexes_in_chunk = {{get_index_in_chunk_in_dimension(idxs, args)...}};
+            return std::make_tuple(indexes_of_chunk, indexes_in_chunk);
+        }
+
+        template <class... Args>
+        inline const_reference access_impl(Args... args) const
+        {
+            std::cout << "Accessing chunked array at";
+            auto chunk_indexes = get_chunk_indexes(std::make_index_sequence<sizeof...(Args)>(), args...);
+            std::cout << std::endl;
+            auto indexes_of_chunk(std::get<0>(chunk_indexes));
+            auto indexes_in_chunk(std::get<1>(chunk_indexes));
+            Chunk_type chunk = m_chunks.element(indexes_of_chunk.cbegin(), indexes_of_chunk.cend());
+            const_reference val = chunk.element(indexes_in_chunk.cbegin(), indexes_in_chunk.cend());
+            int di = 0;
+            for (auto index_of_chunk: indexes_of_chunk)
+            {
+                auto index_in_chunk = indexes_in_chunk[di];
+                std::cout << "Dimension " << di << ": chunk " << index_of_chunk << " at " << index_in_chunk << std::endl;
+                di++;
+            }
+            return val;
+        }
+
+        xt::xarray<Chunk_type> m_chunks;
+        std::vector<size_t> m_shape;
+        std::vector<size_t> m_chunk_shape;
+};

--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -75,18 +75,17 @@ namespace xt
             return chunk_indexes;
         }
 
-        template <class T, size_t N, size_t... Is>
-        std::tuple<std::array<size_t, N>, std::array<size_t, N>> unpack_impl(std::array<T, N> &arr, std::index_sequence<Is...>) const
-        {
-            std::array<size_t, N> arr0 = {{std::get<0>(arr[Is])...}};
-            std::array<size_t, N> arr1 = {{std::get<1>(arr[Is])...}};
-            return std::make_tuple(arr0, arr1);
-        }
-
         template <class T, std::size_t N>
         std::tuple<std::array<size_t, N>, std::array<size_t, N>> unpack(std::array<T, N> &arr) const
         {
-            return unpack_impl(arr, std::make_index_sequence<N>());
+            std::array<size_t, N> arr0;
+            std::array<size_t, N> arr1;
+            for (size_t i = 0; i < N; ++i)
+            {
+                arr0[i] = std::get<0>(arr[i]);
+                arr1[i] = std::get<1>(arr[i]);
+            }
+            return std::make_tuple(arr0, arr1);
         }
 
         xt::xarray<chunk_type> m_chunks;

--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -14,9 +14,7 @@ namespace xt
         template <class... Idxs>
         inline const_reference operator()(Idxs... idxs) const
         {
-            std::cout << "Accessing chunked array at";
             auto chunk_indexes_packed = get_chunk_indexes(std::make_index_sequence<sizeof...(Idxs)>(), idxs...);
-            std::cout << std::endl;
             auto chunk_indexes = unpack(chunk_indexes_packed);
             auto indexes_of_chunk(std::get<0>(chunk_indexes));
             auto indexes_in_chunk(std::get<1>(chunk_indexes));
@@ -26,7 +24,6 @@ namespace xt
             for (auto index_of_chunk: indexes_of_chunk)
             {
                 auto index_in_chunk = indexes_in_chunk[di];
-                std::cout << "Dimension " << di << ": chunk " << index_of_chunk << " at " << index_in_chunk << std::endl;
                 di++;
             }
             return val;
@@ -39,20 +36,15 @@ namespace xt
         {
             std::vector<size_t> shape_chunk(shape.size());
             size_t di = 0;
-            std::cout << "Creating chunked array with shape";
             for (auto s: shape)
             {
-                std::cout << " " << s;
                 size_t chunk_nb = s / chunks[di];
                 if (s % chunks[di] > 0)
                     chunk_nb += 1;  // edge chunk
                 shape_chunk[di] = chunk_nb;
                 di++;
             }
-            std::cout << ", chunk shape";
             for (auto s: chunks)
-                std::cout << " " << s;
-            std::cout << std::endl;
             m_chunks.resize(shape_chunk);
         }
 
@@ -61,7 +53,6 @@ namespace xt
         template <class Dim, class Idx>
         std::tuple<size_t, size_t> get_chunk_indexes_in_dimension(Dim dim, Idx idx) const
         {
-            std::cout << " " << dim;
             size_t index_of_chunk = idx / m_chunk_shape[dim];
             size_t index_in_chunk = idx - index_of_chunk * m_chunk_shape[dim];
             return std::make_tuple(index_of_chunk, index_in_chunk);

--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -2,78 +2,24 @@
 #include <array>
 #include "xarray.hpp"
 
-template <class Chunk_type>
-class xchunked_array
+namespace xt
 {
+    template <class chunk_type>
+    class xchunked_array
+    {
     public:
 
-        using const_reference = typename Chunk_type::const_reference;
+        using const_reference = typename chunk_type::const_reference;
 
-        template <class... Args>
-        inline const_reference operator()(Args... args) const
-        {
-            return access_impl(args...);
-        }
-
-        xchunked_array(std::vector<size_t> shape, std::vector<size_t> chunks):
-            m_shape(shape),
-            m_chunk_shape(chunks)
-        {
-            std::vector<size_t> shape_chunk;
-            size_t di = 0;
-            std::cout << "Creating chunked array with shape";
-            for (auto s: shape)
-            {
-                std::cout << " " << s;
-                size_t chunk_nb = s / chunks[di];
-                if (s % chunks[di] > 0)
-                    chunk_nb += 1;  // edge chunk
-                shape_chunk.push_back(chunk_nb);
-                di++;
-            }
-            std::cout << ", chunk shape";
-            for (auto s: chunks)
-                std::cout << " " << s;
-            std::cout << std::endl;
-            m_chunks.resize(shape_chunk);
-        }
-
-    private:
-
-        template <class Idx, class Arg>
-        size_t get_index_of_chunk_in_dimension(Idx idx, Arg arg) const
-        {
-            size_t index_of_chunk = arg / m_chunk_shape[idx];
-            return index_of_chunk;
-        }
-
-        template <class Idx, class Arg>
-        size_t get_index_in_chunk_in_dimension(Idx idx, Arg arg) const
-        {
-            std::cout << " " << arg;
-            size_t index_of_chunk = get_index_of_chunk_in_dimension(idx, arg);
-            size_t index_in_chunk = arg - index_of_chunk * m_chunk_shape[idx];
-            return index_in_chunk;
-        }
-
-        template <size_t... idxs, class... Args>
-        std::tuple<std::array<size_t, sizeof...(Args)>, std::array<size_t, sizeof...(Args)>>
-        get_chunk_indexes(std::index_sequence<idxs...>, Args... args) const
-        {
-            std::array<size_t, sizeof...(Args)> indexes_of_chunk = {{get_index_of_chunk_in_dimension(idxs, args)...}};
-            std::array<size_t, sizeof...(Args)> indexes_in_chunk = {{get_index_in_chunk_in_dimension(idxs, args)...}};
-            return std::make_tuple(indexes_of_chunk, indexes_in_chunk);
-        }
-
-        template <class... Args>
-        inline const_reference access_impl(Args... args) const
+        template <class... Idxs>
+        inline const_reference operator()(Idxs... idxs) const
         {
             std::cout << "Accessing chunked array at";
-            auto chunk_indexes = get_chunk_indexes(std::make_index_sequence<sizeof...(Args)>(), args...);
+            auto chunk_indexes = get_chunk_indexes(std::make_index_sequence<sizeof...(Idxs)>(), idxs...);
             std::cout << std::endl;
             auto indexes_of_chunk(std::get<0>(chunk_indexes));
             auto indexes_in_chunk(std::get<1>(chunk_indexes));
-            Chunk_type chunk = m_chunks.element(indexes_of_chunk.cbegin(), indexes_of_chunk.cend());
+            chunk_type chunk = m_chunks.element(indexes_of_chunk.cbegin(), indexes_of_chunk.cend());
             const_reference val = chunk.element(indexes_in_chunk.cbegin(), indexes_in_chunk.cend());
             int di = 0;
             for (auto index_of_chunk: indexes_of_chunk)
@@ -85,7 +31,60 @@ class xchunked_array
             return val;
         }
 
-        xt::xarray<Chunk_type> m_chunks;
+
+        xchunked_array(std::vector<size_t> shape, std::vector<size_t> chunks):
+            m_shape(shape),
+            m_chunk_shape(chunks)
+        {
+            std::vector<size_t> shape_chunk(shape.size());
+            size_t di = 0;
+            std::cout << "Creating chunked array with shape";
+            for (auto s: shape)
+            {
+                std::cout << " " << s;
+                size_t chunk_nb = s / chunks[di];
+                if (s % chunks[di] > 0)
+                    chunk_nb += 1;  // edge chunk
+                shape_chunk[di] = chunk_nb;
+                di++;
+            }
+            std::cout << ", chunk shape";
+            for (auto s: chunks)
+                std::cout << " " << s;
+            std::cout << std::endl;
+            m_chunks.resize(shape_chunk);
+        }
+
+    private:
+
+        template <class Dim, class Idx>
+        size_t get_index_of_chunk_in_dimension(Dim dim, Idx idx) const
+        {
+            size_t index_of_chunk = idx / m_chunk_shape[dim];
+            return index_of_chunk;
+        }
+
+        template <class Dim, class Idx>
+        size_t get_index_in_chunk_in_dimension(Dim dim, Idx idx) const
+        {
+            std::cout << " " << dim;
+            size_t index_of_chunk = get_index_of_chunk_in_dimension(dim, idx);
+            size_t index_in_chunk = idx - index_of_chunk * m_chunk_shape[dim];
+            return index_in_chunk;
+        }
+
+        template <size_t... dims, class... Idxs>
+        std::tuple<std::array<size_t, sizeof...(Idxs)>, std::array<size_t, sizeof...(Idxs)>>
+        get_chunk_indexes(std::index_sequence<dims...>, Idxs... idxs) const
+        {
+            std::array<size_t, sizeof...(Idxs)> indexes_of_chunk = {{get_index_of_chunk_in_dimension(dims, idxs)...}};
+            std::array<size_t, sizeof...(Idxs)> indexes_in_chunk = {{get_index_in_chunk_in_dimension(dims, idxs)...}};
+            return std::make_tuple(indexes_of_chunk, indexes_in_chunk);
+        }
+
+        xt::xarray<chunk_type> m_chunks;
         std::vector<size_t> m_shape;
         std::vector<size_t> m_chunk_shape;
-};
+    };
+
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -220,6 +220,7 @@ set(XTENSOR_TESTS
     test_extended_xmath_reducers.cpp
     test_extended_xhistogram.cpp
     test_extended_xsort.cpp
+    test_xchunked_array.cpp
 )
 
 if(nlohmann_json_FOUND)

--- a/test/test_xchunked_array.cpp
+++ b/test/test_xchunked_array.cpp
@@ -1,0 +1,25 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xchunked_array.hpp"
+
+namespace xt
+{
+    using chunked_array = xt::xchunked_array<xt::xarray<double>>;
+
+    TEST(xchunked_array, indexed_access)
+    {
+        chunked_array a(
+            {10, 10, 10},
+            {2, 3, 4}
+        );
+        a(3, 9, 8);
+    }
+}


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->

This is preliminary work towards a chunked array, similar to what [Zarr](https://zarr.readthedocs.io) can offer in Python, which can allow for bigger-than-memory arrays (stored on disk, in the cloud...) and parallel array processing.

```cpp
#include "xtensor/xchunked_array.hpp"

int main () {
    using chunked_array = xchunked_array<xt::xarray<double>>;
    chunked_array arr(
        {10, 10, 10},  // shape
        {2, 3, 4});  // chunk shape
    arr(3, 9, 8);
}
```

```
Creating chunked array with shape 10 10 10, chunk shape 2 3 4
Accessing chunked array at 3 9 8
Dimension 0: chunk 1 at 1
Dimension 1: chunk 3 at 0
Dimension 2: chunk 2 at 0
```