### PR TITLE
Inherit from xcontainer_semantic

### DIFF
--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -5,14 +5,16 @@
 namespace xt
 {
     template <class chunk_type>
-    class xchunked_array: public xt::xaccessible<xchunked_array<chunk_type>>,
-                          public xt::xiterable<xchunked_array<chunk_type>>
+    class xchunked_array: public xaccessible<xchunked_array<chunk_type>>,
+                          public xiterable<xchunked_array<chunk_type>>,
+                          public xcontainer_semantic<xchunked_array<chunk_type>>
     {
     public:
 
         using const_reference = typename chunk_type::const_reference;
         using reference = typename chunk_type::reference;
         using self_type = xchunked_array<chunk_type>;
+        using semantic_base = xcontainer_semantic<self_type>;
         using iterable_base = xconst_iterable<self_type>;
         using const_stepper = typename iterable_base::const_stepper;
         using stepper = typename iterable_base::stepper;
@@ -76,6 +78,24 @@ namespace xt
                 c.resize(chunk_shape);
         }
 
+        xchunked_array(const xchunked_array&) = default;
+        xchunked_array& operator=(const xchunked_array&) = default;
+
+        xchunked_array(xchunked_array&&) = default;
+        xchunked_array& operator=(xchunked_array&&) = default;
+
+        template <class E>
+        xchunked_array(const xexpression<E>& e)
+        {
+            semantic_base::assign(e);
+        }
+
+        template <class E>
+        self_type& operator=(const xexpression<E>& e)
+        {
+            return semantic_base::operator=(e);
+        }
+
         reference operator[](const xindex& index)
         {
             reference el = element(index.cbegin(), index.cend());
@@ -106,7 +126,7 @@ namespace xt
 
     private:
 
-        xt::xarray<chunk_type> m_chunks;
+        xarray<chunk_type> m_chunks;
         shape_type m_shape;
         shape_type m_chunk_shape;
 
@@ -164,6 +184,24 @@ namespace xt
                 dim++;
             }
             return std::make_pair(indexes_of_chunk, indexes_in_chunk);
+        }
+
+        size_type dimension() const
+        {
+            return shape().size();
+        }
+
+        template <class S>
+        bool broadcast_shape(const S& s) const
+        {
+            // Available in "xtensor/xtrides.hpp"
+            return broadcast_shape(shape(), s);
+        }
+
+        template <class S>
+        bool is_trivial_broadcast(const S& str) const noexcept
+        {
+            return false;
         }
     };
 

--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -1,9 +1,36 @@
+#ifndef XTENSOR_CHUNKED_ARRAY_HPP
+#define XTENSOR_CHUNKED_ARRAY_HPP
+
 #include <vector>
 #include <array>
+
 #include "xarray.hpp"
+#include "xnoalias.hpp"
+#include "xstrided_view.hpp"
 
 namespace xt
 {
+    template <class chunk_type>
+    class xchunked_array;
+
+    template <class chunk_type>
+    struct xcontainer_inner_types<xchunked_array<chunk_type>>
+    {
+        using const_reference = typename chunk_type::const_reference;
+        using reference = typename chunk_type::reference;
+        using size_type = std::size_t;
+        using storage_type = chunk_type;
+        using temporary_type = xchunked_array<chunk_type>;
+    };
+
+    template <class chunk_type>
+    struct xiterable_inner_types<xchunked_array<chunk_type>>
+    {
+        using inner_shape_type = typename chunk_type::shape_type;
+        using const_stepper = xindexed_stepper<xchunked_array<chunk_type>, true>;
+        using stepper = xindexed_stepper<xchunked_array<chunk_type>, false>;
+    };
+
     template <class chunk_type>
     class xchunked_array: public xaccessible<xchunked_array<chunk_type>>,
                           public xiterable<xchunked_array<chunk_type>>,
@@ -26,6 +53,7 @@ namespace xt
         using const_pointer = const value_type*;
         using difference_type = std::ptrdiff_t;
         using shape_type = typename chunk_type::shape_type;
+        using temporary_type = typename inner_types::temporary_type;
 
         template <class O>
         const_stepper stepper_begin(const O& shape) const noexcept;
@@ -87,7 +115,32 @@ namespace xt
         template <class E>
         xchunked_array(const xexpression<E>& e)
         {
-            semantic_base::assign(e);
+            const auto& sh = e.derived_cast().shape();
+            resize_container(m_shape, sh.size());
+            std::copy(sh.begin(), sh.end(), m_shape.begin());
+            m_chunk_shape = m_shape;
+            // Naive implementation to refine later
+            m_chunk_shape[0] = std::min(size_type(10), m_shape[0]);
+            size_type nb_chunks = m_shape[0] / m_chunk_shape[0];
+            bool additional_chunk = m_shape[0] % m_chunk_shape[0] > 0;
+            if (additional_chunk)
+            {
+                m_chunks.resize({nb_chunks + 1u});
+            }
+            else
+            {
+                m_chunks.resize({nb_chunks});
+            }
+            for (size_type i = 0; i < nb_chunks; ++i)
+            {
+                noalias(m_chunks(i)) = strided_view(e.derived_cast(),
+                    {range(i * m_chunk_shape[0], (i + 1u) * m_chunk_shape[0]), ellipsis()});
+            }
+            if (additional_chunk)
+            {
+                noalias(m_chunks(nb_chunks)) = strided_view(e.derived_cast(),
+                    {range(nb_chunks * m_chunk_shape[0], m_shape[0]), ellipsis()});
+            }
         }
 
         template <class E>
@@ -205,23 +258,7 @@ namespace xt
         }
     };
 
-    template <class chunk_type>
-    struct xcontainer_inner_types<xchunked_array<chunk_type>>
-    {
-        using temporary_type = xarray<chunk_type>;
-        using const_reference = typename chunk_type::const_reference;
-        using reference = typename chunk_type::reference;
-        using size_type = std::size_t;
-        using storage_type = chunk_type;
-    };
 
-    template <class chunk_type>
-    struct xiterable_inner_types<xchunked_array<chunk_type>>
-    {
-        using inner_shape_type = typename chunk_type::shape_type;
-        using const_stepper = xindexed_stepper<xchunked_array<chunk_type>, true>;
-        using stepper = xindexed_stepper<xchunked_array<chunk_type>, false>;
-    };
 
     template <class chunk_type>
     template <class O>
@@ -255,3 +292,6 @@ namespace xt
         return stepper(this, offset, true);
     }
 }
+
+#endif
+

--- a/test/test_xchunked_array.cpp
+++ b/test/test_xchunked_array.cpp
@@ -8,6 +8,8 @@
 ****************************************************************************/
 
 #include "gtest/gtest.h"
+
+#include "xtensor/xbroadcast.hpp"
 #include "xtensor/xchunked_array.hpp"
 
 namespace xt
@@ -38,5 +40,28 @@ namespace xt
             it = v;
         for (auto it: a)
             ASSERT_EQ(it, v);
+    }
+
+    TEST(xchunked_array, assign_expression)
+    {
+        std::vector<size_t> shape = {2, 2, 2};
+        std::vector<size_t> chunk_shape = {2, 3, 4};
+        chunked_array a(shape, chunk_shape);
+
+        a = xt::broadcast(3., a.shape());
+        for (const auto& v: a)
+        {
+            EXPECT_EQ(v, 3.);
+        }
+
+        std::vector<size_t> shape2 = {32, 10, 10};
+        chunked_array a2(shape2, chunk_shape);
+
+        a2 = xt::broadcast(3., a2.shape());
+        for (const auto& v: a2)
+        {
+            EXPECT_EQ(v, 3.);
+        }
+
     }
 }


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
Unfortunately this doesn't allow to do e.g. `arr = 3.;`:
```
main.cpp: In function 'int main()':
main.cpp:20:10: error: no match for 'operator=' (operand types are 'chunked_array {aka xt::xchunked_array<xt::xarray_container<xt::uvector<double, std::alloca
tor<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag> >}' and 'double')
     arr = 3.;
          ^~
In file included from main.cpp:1:0:
../include/xtensor/xchunked_array.hpp:82:25: note: candidate: xt::xchunked_array<chunk_type>& xt::xchunked_array<chunk_type>::operator=(const xt::xchunked_arr
ay<chunk_type>&) [with chunk_type = xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4, s
td::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>]
         xchunked_array& operator=(const xchunked_array&) = default;
                         ^~~~~~~~
../include/xtensor/xchunked_array.hpp:82:25: note:   no known conversion for argument 1 from 'double' to 'const xt::xchunked_array<xt::xarray_container<xt::uv
ector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4, std::allocator<long unsigned int>, true>, xt::xtensor_expression
_tag> >&'
../include/xtensor/xchunked_array.hpp:85:25: note: candidate: xt::xchunked_array<chunk_type>& xt::xchunked_array<chunk_type>::operator=(xt::xchunked_array<chu
nk_type>&&) [with chunk_type = xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4, std::a
llocator<long unsigned int>, true>, xt::xtensor_expression_tag>]
         xchunked_array& operator=(xchunked_array&&) = default;
                         ^~~~~~~~
../include/xtensor/xchunked_array.hpp:85:25: note:   no known conversion for argument 1 from 'double' to 'xt::xchunked_array<xt::xarray_container<xt::uvector<
double, std::allocator<double> >, (xt::layout_type)1, xt::svector<long unsigned int, 4, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag> 
>&&'
../include/xtensor/xchunked_array.hpp:94:20: note: candidate: template<class E> xt::xchunked_array<chunk_type>::self_type& xt::xchunked_array<chunk_type>::ope
rator=(const xt::xexpression<E>&) [with E = E; chunk_type = xt::xarray_container<xt::uvector<double, std::allocator<double> >, (xt::layout_type)1, xt::svector
<long unsigned int, 4, std::allocator<long unsigned int>, true>, xt::xtensor_expression_tag>]
         self_type& operator=(const xexpression<E>& e)
                    ^~~~~~~~
../include/xtensor/xchunked_array.hpp:94:20: note:   template argument deduction/substitution failed:
main.cpp:20:10: note:   mismatched types 'const xt::xexpression<D>' and 'double'
     arr = 3.;
          ^~
```