### PR TITLE
Improve histogram performance with equal bin sizes

### DIFF
--- a/include/xtensor/xhistogram.hpp
+++ b/include/xtensor/xhistogram.hpp
@@ -76,7 +76,7 @@ namespace xt
                     // left and right are not bounds of data
                     if ( v >= left & v < right )
                     {
-                        auto i_bin = static_cast<size_t>(static_cast<double>(n_bins) * (static_cast<double>(data(i)) - left) * norm);
+                        auto i_bin = static_cast<size_t>(static_cast<double>(n_bins) * (v - left) * norm);
                         count(i_bin) += weights(i);
                     }
                     else if ( v == right )

--- a/include/xtensor/xhistogram.hpp
+++ b/include/xtensor/xhistogram.hpp
@@ -44,6 +44,79 @@ namespace xt
         return xt::searchsorted(std::forward<E2>(bin_edges), std::forward<E1>(data), right);
     }
 
+    namespace detail
+    {
+        template <class R = double, class E1, class E2, class E3>
+        inline auto histogram_imp(E1&& data, E2&& bin_edges, E3&& weights, bool density, bool equal_bins)
+        {
+            using size_type = common_size_type_t<std::decay_t<E1>, std::decay_t<E2>, std::decay_t<E3>>;
+            using value_type = typename std::decay_t<E3>::value_type;
+
+            XTENSOR_ASSERT(data.dimension() == 1);
+            XTENSOR_ASSERT(weights.dimension() == 1);
+            XTENSOR_ASSERT(bin_edges.dimension() == 1);
+            XTENSOR_ASSERT(weights.size() == data.size());
+            XTENSOR_ASSERT(bin_edges.size() >= 2);
+            XTENSOR_ASSERT(std::is_sorted(bin_edges.cbegin(), bin_edges.cend()));
+            XTENSOR_ASSERT(xt::amin(data)[0] >= bin_edges[0]);
+            XTENSOR_ASSERT(xt::amax(data)[0] <= bin_edges[bin_edges.size() - 1]);
+
+            size_t n_bins = bin_edges.size() - 1;
+            xt::xtensor<value_type, 1> count = xt::zeros<value_type>({ n_bins });
+
+            if (equal_bins)
+            {
+                std::array<typename std::decay_t<E2>::value_type, 2> bounds = xt::minmax(bin_edges)();
+                auto left = static_cast<double>(bounds[0]);
+                auto right = static_cast<double>(bounds[1]);
+                double norm = 1. / (right - left);
+                for (size_t i = 0; i < data.size(); ++i)
+                {
+                    auto v = static_cast<double>(data(i));
+                    // left and right are not bounds of data
+                    if ( v >= left & v < right )
+                    {
+                        auto i_bin = static_cast<size_t>(static_cast<double>(n_bins) * (static_cast<double>(data(i)) - left) * norm);
+                        count(i_bin) += weights(i);
+                    }
+                    else if ( v == right )
+                    {
+                        count(n_bins - 1) += weights(i);
+                    }
+                }
+            }
+            else
+            {
+                auto sorter = xt::argsort(data);
+
+                size_type ibin = 0;
+
+                for (auto& idx : sorter)
+                {
+                    while (data[idx] >= bin_edges[ibin + 1] && ibin < bin_edges.size() - 2)
+                    {
+                        ++ibin;
+                    }
+                    count[ibin] += weights[idx];
+                }
+            }
+
+            xt::xtensor<R, 1> prob = xt::cast<R>(count);
+
+            if (density)
+            {
+                R n = static_cast<R>(data.size());
+                for (size_type i = 0; i < bin_edges.size() - 1; ++i)
+                {
+                    prob[i] /= (static_cast<R>(bin_edges[i + 1] - bin_edges[i]) * n);
+                }
+            }
+
+            return prob;
+        }
+
+    } //detail
+
     /**
      * @ingroup histogram
      * @brief Compute the histogram of a set of data.
@@ -57,45 +130,11 @@ namespace xt
     template <class R = double, class E1, class E2, class E3>
     inline auto histogram(E1&& data, E2&& bin_edges, E3&& weights, bool density = false)
     {
-        using size_type = common_size_type_t<std::decay_t<E1>, std::decay_t<E2>, std::decay_t<E3>>;
-        using value_type = typename std::decay_t<E3>::value_type;
-
-        XTENSOR_ASSERT(data.dimension() == 1);
-        XTENSOR_ASSERT(weights.dimension() == 1);
-        XTENSOR_ASSERT(bin_edges.dimension() == 1);
-        XTENSOR_ASSERT(weights.size() == data.size());
-        XTENSOR_ASSERT(bin_edges.size() >= 2);
-        XTENSOR_ASSERT(std::is_sorted(bin_edges.cbegin(), bin_edges.cend()));
-        XTENSOR_ASSERT(xt::amin(data)[0] >= bin_edges[0]);
-        XTENSOR_ASSERT(xt::amax(data)[0] <= bin_edges[bin_edges.size() - 1]);
-
-        xt::xtensor<value_type, 1> count = xt::zeros<value_type>({ bin_edges.size() - 1 });
-
-        auto sorter = xt::argsort(data);
-
-        size_type ibin = 0;
-
-        for (auto& idx : sorter)
-        {
-            while (data[idx] >= bin_edges[ibin + 1] && ibin < bin_edges.size() - 2)
-            {
-                ++ibin;
-            }
-            count[ibin] += weights[idx];
-        }
-
-        xt::xtensor<R, 1> prob = xt::cast<R>(count);
-
-        if (density)
-        {
-            R n = static_cast<R>(data.size());
-            for (size_type i = 0; i < bin_edges.size() - 1; ++i)
-            {
-                prob[i] /= (static_cast<R>(bin_edges[i + 1] - bin_edges[i]) * n);
-            }
-        }
-
-        return prob;
+        return detail::histogram_imp<R>(std::forward<E1>(data),
+                                        std::forward<E2>(bin_edges),
+                                        std::forward<E3>(weights),
+                                        density,
+                                        false);
     }
 
     /**
@@ -114,10 +153,11 @@ namespace xt
 
         auto n = data.size();
 
-        return histogram(std::forward<E1>(data),
-                         std::forward<E2>(bin_edges),
-                         xt::ones<value_type>({ n }),
-                         density);
+        return detail::histogram_imp(std::forward<E1>(data),
+                                     std::forward<E2>(bin_edges),
+                                     xt::ones<value_type>({ n }),
+                                     density,
+                                     false);
     }
 
     /**
@@ -138,10 +178,11 @@ namespace xt
 
         auto bin_edges = histogram_bin_edges(data, xt::ones<value_type>({ n }), bins);
 
-        return histogram(std::forward<E1>(data),
-                         std::forward<E1>(bin_edges),
-                         xt::ones<value_type>({ n }),
-                         density);
+        return detail::histogram_imp(std::forward<E1>(data),
+                                     std::forward<E1>(bin_edges),
+                                     xt::ones<value_type>({ n }),
+                                     density,
+                                     true);
     }
 
     /**
@@ -159,10 +200,11 @@ namespace xt
     {
         auto bin_edges = histogram_bin_edges(data, weights, bins);
 
-        return histogram(std::forward<E1>(data),
-                         std::forward<E1>(bin_edges),
-                         std::forward<E2>(weights),
-                         density);
+        return detail::histogram_imp(std::forward<E1>(data),
+                                     std::forward<E1>(bin_edges),
+                                     std::forward<E2>(weights),
+                                     density,
+                                     true);
     }
 
     /**

--- a/test/test_xhistogram.cpp
+++ b/test/test_xhistogram.cpp
@@ -14,8 +14,6 @@
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xhistogram.hpp"
 #include "xtensor/xrandom.hpp"
-#include "xtensor/xio.hpp"
-
 
 namespace xt
 {
@@ -29,16 +27,6 @@ namespace xt
             EXPECT_EQ(count.size(), std::size_t(2) );
             EXPECT_EQ(count(0), 2.);
             EXPECT_EQ(count(1), 2.);
-        }
-
-        {
-            xt::xtensor<double, 1> edges {0, 1.5, 3};
-            xt::xtensor<double, 1> weights {1, 1, 1, 1};
-            auto count = xt::histogram<int>(data, edges, weights, true);
-            // This is indeed a bug. If the count is the density, an integral return
-            // type should not be allowed.
-            EXPECT_EQ(count(0), 0.);
-            EXPECT_EQ(count(1), 0.);
         }
 
         {

--- a/test/test_xhistogram.cpp
+++ b/test/test_xhistogram.cpp
@@ -14,6 +14,8 @@
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xhistogram.hpp"
 #include "xtensor/xrandom.hpp"
+#include "xtensor/xio.hpp"
+
 
 namespace xt
 {
@@ -27,6 +29,16 @@ namespace xt
             EXPECT_EQ(count.size(), std::size_t(2) );
             EXPECT_EQ(count(0), 2.);
             EXPECT_EQ(count(1), 2.);
+        }
+
+        {
+            xt::xtensor<double, 1> edges {0, 1.5, 3};
+            xt::xtensor<double, 1> weights {1, 1, 1, 1};
+            auto count = xt::histogram<int>(data, edges, weights, true);
+            // This is indeed a bug. If the count is the density, an integral return
+            // type should not be allowed.
+            EXPECT_EQ(count(0), 0.);
+            EXPECT_EQ(count(1), 0.);
         }
 
         {


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

Fix #1546

Performance of numpy:

```
In [1]: import numpy as np

In [2]: x = np.arange(1e6)

In [3]: %timeit np.histogram(x, 100)
17.3 ms ± 1.44 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Performance of this fix:

```
#include "xtensor/xtensor.hpp"
#include "xtensor/xhistogram.hpp"

#include "chrono"

int main()
{
        xt::xtensor<double, 1> x = xt::arange(1000000);
        auto start = std::chrono::high_resolution_clock::now();
        xt::histogram(x, size_t(100));
        auto end = std::chrono::high_resolution_clock::now();
        std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << std::endl;
       // output varies between 7 - 11 ms
       // before this fix, output is > 40 ms
}
```
