### PR TITLE
Copy constructor gets expression's chunk_shape if it is chunked

### DIFF
--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -17,11 +17,7 @@ namespace xt
         {
             return e.derived_cast().shape();
         }
-        static auto is_chunked(const xexpression<E>& e)
-        {
-            (void)(e);
-            return false;
-        }
+        using is_chunked = std::false_type;
     };
 
     template <class E>
@@ -31,17 +27,14 @@ namespace xt
         {
             return e.derived_cast().chunk_shape();
         }
-        static auto is_chunked(const xexpression<E>& e)
-        {
-            (void)(e);
-            return true;
-        }
+        using is_chunked = std::true_type;
     };
 
     template<class E>
-    auto is_chunked(const xexpression<E>& e) -> bool
+    constexpr auto is_chunked(const xexpression<E>& e) -> bool
     {
-        return chunk_helper<E>::is_chunked(e);
+        using return_type = typename chunk_helper<E>::is_chunked;
+        return return_type::value;
     }
 
     template <class chunk_type>

--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -17,8 +17,9 @@ namespace xt
         {
             return e.derived_cast().shape();
         }
-        static bool is_chunked(const xexpression<E>& e)
+        static auto is_chunked(const xexpression<E>& e)
         {
+            (void)(e);
             return false;
         }
     };
@@ -30,8 +31,9 @@ namespace xt
         {
             return e.derived_cast().chunk_shape();
         }
-        static bool is_chunked(const xexpression<E>& e)
+        static auto is_chunked(const xexpression<E>& e)
         {
+            (void)(e);
             return true;
         }
     };

--- a/test/test_xchunked_array.cpp
+++ b/test/test_xchunked_array.cpp
@@ -75,13 +75,33 @@ namespace xt
           {{1., 2., 3.},
            {4., 5., 6.},
            {7., 8., 9.}};
+
+        EXPECT_EQ(xt::is_chunked(a3), false);
+
         std::vector<size_t> chunk_shape4 = {2, 2};
         auto a4 = chunked_array(a3, chunk_shape4);
+
+        EXPECT_EQ(xt::is_chunked(a4), true);
+
         double i = 1.;
         for (const auto& v: a4)
         {
             EXPECT_EQ(v, i);
             i += 1.;
+        }
+
+        auto a5 = chunked_array(a4);
+        EXPECT_EQ(xt::is_chunked(a5), true);
+        for (const auto& v: a5.chunk_shape())
+        {
+            EXPECT_EQ(v, 2);
+        }
+
+        auto a6 = chunked_array(a3);
+        EXPECT_EQ(xt::is_chunked(a6), true);
+        for (const auto& v: a6.chunk_shape())
+        {
+            EXPECT_EQ(v, 3);
         }
     }
 }

--- a/test/test_xchunked_array.cpp
+++ b/test/test_xchunked_array.cpp
@@ -44,6 +44,9 @@ namespace xt
 
     TEST(xchunked_array, assign_expression)
     {
+#ifdef _MSC_FULL_VER
+        std::cout << "MSC_FULL_VER = " << _MSC_FULL_VER << std::endl;
+#endif
         std::vector<size_t> shape1 = {2, 2, 2};
         std::vector<size_t> chunk_shape1 = {2, 3, 4};
         chunked_array a1(shape1, chunk_shape1);


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->

If an expression is assigned to a chunked array without specifying a chunk shape, the chunk shape is taken from the expression if the expression is chunked, otherwise the chunk shape is the expression's shape, which basically means no chunk (or one chunk). 
TODO: propagate chunk shape in expressions.