### PR TITLE
Replace template parameter chunk_type with chunk_storage

### DIFF
--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -47,37 +47,40 @@ namespace xt
         return return_type::value;
     }
 
-    template <class chunk_type>
+    template <class chunk_storage>
     class xchunked_array;
 
-    template <class chunk_type>
-    struct xcontainer_inner_types<xchunked_array<chunk_type>>
+    template <class chunk_storage>
+    struct xcontainer_inner_types<xchunked_array<chunk_storage>>
     {
+        using chunk_type = typename chunk_storage::value_type;
         using const_reference = typename chunk_type::const_reference;
         using reference = typename chunk_type::reference;
         using size_type = std::size_t;
         using storage_type = chunk_type;
-        using temporary_type = xchunked_array<chunk_type>;
+        using temporary_type = xchunked_array<chunk_storage>;
     };
 
-    template <class chunk_type>
-    struct xiterable_inner_types<xchunked_array<chunk_type>>
+    template <class chunk_storage>
+    struct xiterable_inner_types<xchunked_array<chunk_storage>>
     {
+        using chunk_type = typename chunk_storage::value_type;
         using inner_shape_type = typename chunk_type::shape_type;
-        using const_stepper = xindexed_stepper<xchunked_array<chunk_type>, true>;
-        using stepper = xindexed_stepper<xchunked_array<chunk_type>, false>;
+        using const_stepper = xindexed_stepper<xchunked_array<chunk_storage>, true>;
+        using stepper = xindexed_stepper<xchunked_array<chunk_storage>, false>;
     };
 
-    template <class chunk_type>
-    class xchunked_array: public xaccessible<xchunked_array<chunk_type>>,
-                          public xiterable<xchunked_array<chunk_type>>,
-                          public xcontainer_semantic<xchunked_array<chunk_type>>
+    template <class chunk_storage>
+    class xchunked_array: public xaccessible<xchunked_array<chunk_storage>>,
+                          public xiterable<xchunked_array<chunk_storage>>,
+                          public xcontainer_semantic<xchunked_array<chunk_storage>>
     {
     public:
 
+        using chunk_type = typename chunk_storage::value_type;
         using const_reference = typename chunk_type::const_reference;
         using reference = typename chunk_type::reference;
-        using self_type = xchunked_array<chunk_type>;
+        using self_type = xchunked_array<chunk_storage>;
         using semantic_base = xcontainer_semantic<self_type>;
         using iterable_base = xconst_iterable<self_type>;
         using const_stepper = typename iterable_base::const_stepper;
@@ -200,7 +203,7 @@ namespace xt
         xchunked_array(const xexpression<E>& e)
         {
             const auto& chunk_shape = detail::chunk_helper<E>::chunk_shape(e);
-            *this = xchunked_array<chunk_type>(e, chunk_shape);
+            *this = xchunked_array<chunk_storage>(e, chunk_shape);
         }
 
         template <class E>
@@ -255,7 +258,7 @@ namespace xt
 
     private:
 
-        xarray<chunk_type> m_chunks;
+        chunk_storage m_chunks;
         shape_type m_shape;
         shape_type m_chunk_shape;
 
@@ -345,33 +348,33 @@ namespace xt
         }
     };
 
-    template <class chunk_type>
+    template <class chunk_storage>
     template <class O>
-    inline auto xchunked_array<chunk_type>::stepper_begin(const O& shape) const noexcept -> const_stepper
+    inline auto xchunked_array<chunk_storage>::stepper_begin(const O& shape) const noexcept -> const_stepper
     {
         size_type offset = shape.size() - this->dimension();
         return const_stepper(this, offset);
     }
 
-    template <class chunk_type>
+    template <class chunk_storage>
     template <class O>
-    inline auto xchunked_array<chunk_type>::stepper_end(const O& shape, layout_type) const noexcept -> const_stepper
+    inline auto xchunked_array<chunk_storage>::stepper_end(const O& shape, layout_type) const noexcept -> const_stepper
     {
         size_type offset = shape.size() - this->dimension();
         return const_stepper(this, offset, true);
     }
 
-    template <class chunk_type>
+    template <class chunk_storage>
     template <class O>
-    inline auto xchunked_array<chunk_type>::stepper_begin(const O& shape) noexcept -> stepper
+    inline auto xchunked_array<chunk_storage>::stepper_begin(const O& shape) noexcept -> stepper
     {
         size_type offset = shape.size() - this->dimension();
         return stepper(this, offset);
     }
 
-    template <class chunk_type>
+    template <class chunk_storage>
     template <class O>
-    inline auto xchunked_array<chunk_type>::stepper_end(const O& shape, layout_type) noexcept -> stepper
+    inline auto xchunked_array<chunk_storage>::stepper_end(const O& shape, layout_type) noexcept -> stepper
     {
         size_type offset = shape.size() - this->dimension();
         return stepper(this, offset, true);

--- a/test/test_xchunked_array.cpp
+++ b/test/test_xchunked_array.cpp
@@ -14,7 +14,7 @@
 
 namespace xt
 {
-    using chunked_array = xt::xchunked_array<xt::xarray<double>>;
+    using chunked_array = xchunked_array<xarray<xarray<double>>>;
 
     TEST(xchunked_array, indexed_access)
     {
@@ -53,7 +53,7 @@ namespace xt
         double val;
 
         val = 3.;
-        a1 = xt::broadcast(val, a1.shape());
+        a1 = broadcast(val, a1.shape());
         for (const auto& v: a1)
         {
             EXPECT_EQ(v, val);
@@ -62,7 +62,7 @@ namespace xt
         std::vector<size_t> shape2 = {32, 10, 10};
         chunked_array a2(shape2, chunk_shape1);
 
-        a2 = xt::broadcast(val, a2.shape());
+        a2 = broadcast(val, a2.shape());
         for (const auto& v: a2)
         {
             EXPECT_EQ(v, val);
@@ -74,17 +74,17 @@ namespace xt
             EXPECT_EQ(v, 2. * val);
         }
 
-        xt::xarray<double> a3
+        xarray<double> a3
           {{1., 2., 3.},
            {4., 5., 6.},
            {7., 8., 9.}};
 
-        EXPECT_EQ(xt::is_chunked(a3), false);
+        EXPECT_EQ(is_chunked(a3), false);
 
         std::vector<size_t> chunk_shape4 = {2, 2};
         auto a4 = chunked_array(a3, chunk_shape4);
 
-        EXPECT_EQ(xt::is_chunked(a4), true);
+        EXPECT_EQ(is_chunked(a4), true);
 
         double i = 1.;
         for (const auto& v: a4)
@@ -94,14 +94,14 @@ namespace xt
         }
 
         auto a5 = chunked_array(a4);
-        EXPECT_EQ(xt::is_chunked(a5), true);
+        EXPECT_EQ(is_chunked(a5), true);
         for (const auto& v: a5.chunk_shape())
         {
             EXPECT_EQ(v, 2);
         }
 
         auto a6 = chunked_array(a3);
-        EXPECT_EQ(xt::is_chunked(a6), true);
+        EXPECT_EQ(is_chunked(a6), true);
         for (const auto& v: a6.chunk_shape())
         {
             EXPECT_EQ(v, 3);


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
Instantiation is now e.g. `xt::xchunked_array<xt::xarray<xt::xarray<double>>>` instead of `xt::xchunked_array<xt::xarray<double>>`.