### PR TITLE
Fixing various compiler warnings

### DIFF
--- a/include/xtensor/xaxis_slice_iterator.hpp
+++ b/include/xtensor/xaxis_slice_iterator.hpp
@@ -285,7 +285,7 @@ namespace xt
      *
      * @param e the expession to iterate over
      * @param axis the axis to iterate over
-     * @return an instance of xaxis_slice_iterator 
+     * @return an instance of xaxis_slice_iterator
      */
     template <class E>
     inline auto axis_slice_begin(E&& e, typename std::decay_t<E>::size_type axis)
@@ -317,7 +317,7 @@ namespace xt
      *
      * @param e the expession to iterate over
      * @param axis the axis to iterate over
-     * @return an instance of xaxis_slice_iterator 
+     * @return an instance of xaxis_slice_iterator
      */
     template <class E>
     inline auto axis_slice_end(E&& e, typename std::decay_t<E>::size_type axis)

--- a/include/xtensor/xfile_array.hpp
+++ b/include/xtensor/xfile_array.hpp
@@ -298,7 +298,7 @@ namespace xt
         {
             using is_stored = std::false_type;
 
-            static const char* path(const xexpression<E>& e)
+            static const char* path(const xexpression<E>&)
             {
                 return "";
             }
@@ -320,7 +320,7 @@ namespace xt
     }
 
     template<class E>
-    constexpr bool is_stored(const xexpression<E>& e)
+    constexpr bool is_stored(const xexpression<E>&)
     {
         using return_type = typename detail::file_helper<E>::is_stored;
         return return_type::value;
@@ -429,7 +429,7 @@ namespace xt
 
     template <class E, class IOH>
     template <class... Idxs>
-    inline auto xfile_array_container<E, IOH>::operator()(Idxs... idxs) -> reference 
+    inline auto xfile_array_container<E, IOH>::operator()(Idxs... idxs) -> reference
     {
         return reference(m_storage(idxs...), m_dirty);
     }
@@ -462,7 +462,7 @@ namespace xt
     }
 
     template <class E, class IOH>
-    inline auto xfile_array_container<E, IOH>::storage() const noexcept -> const storage_type& 
+    inline auto xfile_array_container<E, IOH>::storage() const noexcept -> const storage_type&
     {
         return m_storage;
     }
@@ -514,7 +514,7 @@ namespace xt
     }
 
     template <class E, class IOH>
-    inline auto xfile_array_container<E, IOH>::data_element(size_type i) -> reference 
+    inline auto xfile_array_container<E, IOH>::data_element(size_type i) -> reference
     {
         return reference(m_storage.data_element(i), m_dirty);
     }

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -1882,6 +1882,9 @@ namespace detail {
      * \em axes.
      * @param e an \ref xexpression
      * @param axes the axes along which the product is computed (optional)
+     * @param ddof delta degrees of freedom (optional).
+     *             The divisor used in calculations is N - ddof, where N represents the number of
+                   elements. By default ddof is zero.
      * @param es evaluation strategy of the reducer
      * @return an \ref xreducer
      */
@@ -1909,26 +1912,32 @@ namespace detail {
         {
             // sum cannot always be a double. It could be a complex number which cannot operate on
             // std::plus<double>.
-            const auto size = e.size();
+            using size_type = typename std::decay_t<E>::size_type;
+            const size_type size = e.size();
+            XTENSOR_ASSERT(static_cast<size_type>(ddof) <= size);
             auto s = sum<T>(std::forward<E>(e), std::forward<X>(axes), es);
-            return mean_division<T>(std::move(s), size - ddof);
+            return mean_division<T>(std::move(s), size - static_cast<size_type>(ddof));
         }
 
 #ifdef X_OLD_CLANG
         template <class T, class E, class I, class D, class EVS>
         inline auto mean(E&& e, std::initializer_list<I> axes, const D& ddof, EVS es)
         {
-            const auto size = e.size();
+            using size_type = typename std::decay_t<E>::size_type;
+            const size_type size = e.size();
+            XTENSOR_ASSERT(static_cast<size_type>(ddof) <= size);
             auto s = sum<T>(std::forward<E>(e), axes, es);
-            return detail::mean_division<T>(std::move(s), size - ddof);
+            return detail::mean_division<T>(std::move(s), size - static_cast<size_type>(ddof));
         }
 #else
         template <class T, class E, class I, std::size_t N, class D, class EVS>
         inline auto mean(E&& e, const I (&axes)[N], const D& ddof, EVS es)
         {
-            const auto size = e.size();
+            using size_type = typename std::decay_t<E>::size_type;
+            const size_type size = e.size();
+            XTENSOR_ASSERT(static_cast<size_type>(ddof) <= size);
             auto s = sum<T>(std::forward<E>(e), axes, es);
-            return detail::mean_division<T>(std::move(s), size - ddof);
+            return detail::mean_division<T>(std::move(s), size - static_cast<size_type>(ddof));
         }
 #endif
 
@@ -2116,7 +2125,9 @@ namespace detail {
      *
      * @param e an \ref xexpression
      * @param axes the axes along which the variance is computed (optional)
-     * @param ddof delta degrees of freedom (optional)
+     * @param ddof delta degrees of freedom (optional).
+     *             The divisor used in calculations is N - ddof, where N represents the number of
+                   elements. By default ddof is zero.
      * @param es evaluation strategy to use (lazy (default), or immediate)
      * @return an \ref xexpression
      *
@@ -2947,13 +2958,13 @@ namespace detail {
     template<class E1, class E2, class E3, typename T>
     inline auto interp(const E1 &x, const E2 &xp, const E3 &fp, T left, T right)
     {
-        using size_type = common_size_type_t<E1,E2,E3>;
+        using size_type = common_size_type_t<E1, E2, E3>;
         using value_type = typename E3::value_type;
 
         // basic checks
-        XTENSOR_ASSERT( xp.dimension() == 1 );
-        XTENSOR_ASSERT( std::is_sorted(x.cbegin(), x.cend()) );
-        XTENSOR_ASSERT( std::is_sorted(xp.cbegin(), xp.cend()) );
+        XTENSOR_ASSERT(xp.dimension() == 1);
+        XTENSOR_ASSERT(std::is_sorted(x.cbegin(), x.cend()));
+        XTENSOR_ASSERT(std::is_sorted(xp.cbegin(), xp.cend()));
 
         // allocate output
         auto f = xtensor<value_type, 1>::from_shape(x.shape());
@@ -3055,7 +3066,7 @@ namespace detail {
                 return covar;
             }
 
-            XTENSOR_ASSERT( x.dimension() == 2 );
+            XTENSOR_ASSERT(x.dimension() == 2);
 
             auto covar = eval(zeros<value_type>({ s[0], s[0] }));
             auto m = eval(mean(x, {1}));

--- a/include/xtensor/xset_operation.hpp
+++ b/include/xtensor/xset_operation.hpp
@@ -178,14 +178,14 @@ namespace xt
         {
             for (size_t i = 0; i < v.size(); ++i)
             {
-                out(i) = std::lower_bound(a.cbegin(), a.cend(), v(i)) - a.cbegin();
+                out(i) = static_cast<std::size_t>(std::lower_bound(a.cbegin(), a.cend(), v(i)) - a.cbegin());
             }
         }
         else
         {
             for (size_t i = 0; i < v.size(); ++i)
             {
-                out(i) = std::upper_bound(a.cbegin(), a.cend(), v(i)) - a.cbegin();
+                out(i) = static_cast<std::size_t>(std::upper_bound(a.cbegin(), a.cend(), v(i)) - a.cbegin());
             }
         }
 


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->

There are two more compiler warnings for which my expertise is falling short. 

```
include/xtensor/xslice.hpp:1498:51: warning: implicit conversion changes signedness: 'std::ptrdiff_t'
      (aka 'long') to 'unsigned long' [-Wsign-conversion]
            m_indices[i] = m_raw_indices[i] < 0 ? static_cast<std::ptrdiff_t>(shape) + m_raw_indices[i] : m_raw_indices[i];
                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
/xtensor/xslice.hpp:919:23: note: in instantiation of member function
      'xt::xdrop_slice<unsigned long>::normalize' requested here
                slice.normalize(e.shape()[index]);
                      ^
```
There seems to be a reason to cast already, but to the wrong type?


```
/xtensor/xaxis_slice_iterator.hpp:147:41: warning: implicit conversion changes signedness: 'const
      xt::svector<long, 4, std::__1::allocator<long>, true>::value_type' (aka 'const long') to 'unsigned long' [-Wsign-conversion]
        m_offset(offset), m_axis_stride(e.strides()[axis] * (e.shape()[axis] - 1)),
                                        ^~~~~~~~~~~~~~~~~ ~
/xtensor/xaxis_slice_iterator.hpp:294:16: note: in instantiation of function template
      specialization 'xt::xaxis_slice_iterator<xt::xarray_container<xt::uvector<int, std::__1::allocator<int> >, xt::layout_type::row_major,
      xt::svector<unsigned long, 4, std::__1::allocator<unsigned long>, true>, xt::xtensor_expression_tag>
      &>::xaxis_slice_iterator<xt::xarray_container<xt::uvector<int, std::__1::allocator<int> >, xt::layout_type::row_major,
      xt::svector<unsigned long, 4, std::__1::allocator<unsigned long>, true>, xt::xtensor_expression_tag> &>' requested here
        return return_type(std::forward<E>(e), axis, 0, e.data_offset());
               ^
/xtensor/xaxis_slice_iterator.hpp:147:41: warning: implicit conversion changes signedness: 'const
      xt::svector<long, 4, std::__1::allocator<long>, true>::value_type' (aka 'const long') to 'unsigned long' [-Wsign-conversion]
        m_offset(offset), m_axis_stride(e.strides()[axis] * (e.shape()[axis] - 1)),
                                        ^~~~~~~~~~~~~~~~~ ~
/xtensor/xaxis_slice_iterator.hpp:308:16: note: in instantiation of function template
      specialization 'xt::xaxis_slice_iterator<xt::xarray_container<xt::uvector<int, std::__1::allocator<int> >,
      xt::layout_type::column_major, xt::svector<unsigned long, 4, std::__1::allocator<unsigned long>, true>, xt::xtensor_expression_tag>
      &>::xaxis_slice_iterator<xt::xarray_container<xt::uvector<int, std::__1::allocator<int> >, xt::layout_type::column_major,
      xt::svector<unsigned long, 4, std::__1::allocator<unsigned long>, true>, xt::xtensor_expression_tag> &>' requested here
        return return_type(std::forward<E>(e),
               ^
/xtensor/xaxis_slice_iterator.hpp:147:41: warning: implicit conversion changes signedness: 'const
      xt::svector<long, 4, std::__1::allocator<long>, true>::value_type' (aka 'const long') to 'unsigned long' [-Wsign-conversion]
        m_offset(offset), m_axis_stride(e.strides()[axis] * (e.shape()[axis] - 1)),
                                        ^~~~~~~~~~~~~~~~~ ~
/xtensor/xaxis_slice_iterator.hpp:294:16: note: in instantiation of function template
      specialization 'xt::xaxis_slice_iterator<const xt::xarray_container<xt::uvector<int, std::__1::allocator<int> >,
      xt::layout_type::row_major, xt::svector<unsigned long, 4, std::__1::allocator<unsigned long>, true>, xt::xtensor_expression_tag>
      &>::xaxis_slice_iterator<const xt::xarray_container<xt::uvector<int, std::__1::allocator<int> >, xt::layout_type::row_major,
      xt::svector<unsigned long, 4, std::__1::allocator<unsigned long>, true>, xt::xtensor_expression_tag> &>' requested here
        return return_type(std::forward<E>(e), axis, 0, e.data_offset());
               ^
```
Why is the result from `strides` not `size_t`?
