### PR TITLE
Adding get_rank and has_fixed_rank

### DIFF
--- a/docs/source/sfinae.rst
+++ b/docs/source/sfinae.rst
@@ -30,7 +30,7 @@ Consider the following example:
         ... // act on object of fixed rank == 2
     }
 
-    TEST(sfinae, rank_basic)
+    int main()
     {
         xt::xarray<size_t> a = {{9, 9}, {9, 9}};
         xt::xtensor<size_t, 1> b = {9, 9};
@@ -39,6 +39,8 @@ Consider the following example:
         foo(a); // flexible rank -> first overload
         foo(b); // fixed rank == 2 -> first overload
         foo(c); // fixed rank == 2 -> second overload
+
+        return 0;
     }
 
 .. note::
@@ -50,7 +52,7 @@ Consider the following example:
     .. code-block:: cpp
 
         // flexible rank
-        template <class E, std::enable_if_t<xt::has_rank_t<E, SIZE_MAX>::value, int> = 0>
+        template <class E, std::enable_if_t<!xt::has_fixed_rank_t<E>::value, int> = 0>
         inline E foo(E&& a);
 
         // fixed rank == 1
@@ -75,3 +77,36 @@ Consider the following example:
 
         // fixed rank == 2
         inline void foo(xt::xtensor<double,2>& a);
+
+Rank as member
+--------------
+
+If you want to use the rank as a member of your own class you can use ``xt::get_rank<E>``.
+Consider the following example:
+
+.. code-block:: cpp
+
+    template <class T>
+    struct Foo
+    {
+        static const size_t rank = xt::get_rank<T>::value;
+
+        static size_t value()
+        {
+            return rank;
+        }
+    };
+
+    int main()
+    {
+        xt::xtensor<double, 1> A = xt::zeros<double>({2});
+        xt::xtensor<double, 2> B = xt::zeros<double>({2, 2});
+        xt::xarray<double> C = xt::zeros<double>({2, 2});
+
+        std::cout << Foo<decltype(A)>::value() << std::endl;
+        std::cout << Foo<decltype(B)>::value() << std::endl;
+        std::cout << Foo<decltype(C)>::value() << std::endl;
+
+        return 0;
+    }
+

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -859,17 +859,47 @@ namespace xt
     using inner_reference_t = typename inner_reference<ST>::type;
 
     /************
+     * get_rank *
+     ************/
+
+    template <class E, typename = void>
+    struct get_rank
+    {
+        constexpr static std::size_t value = SIZE_MAX;
+    };
+
+    template <class E>
+    struct get_rank<E, decltype((void)E::rank, void())>
+    {
+        constexpr static std::size_t value= E::rank;
+    };
+
+    /******************
+     * has_fixed_rank *
+     ******************/
+
+    template <class E>
+    struct has_fixed_rank
+    {
+        using type = std::integral_constant<bool, get_rank<std::decay_t<E>>::value != SIZE_MAX>;
+    };
+
+    template <class E>
+    using has_fixed_rank_t = typename has_fixed_rank<std::decay_t<E>>::type;
+
+    /************
      * has_rank *
      ************/
 
     template <class E, size_t N>
     struct has_rank
     {
-        using type = std::integral_constant<bool, std::decay_t<E>::rank == N>;
+        using type = std::integral_constant<bool, get_rank<std::decay_t<E>>::value == N>;
     };
 
     template <class E, size_t N>
     using has_rank_t = typename has_rank<std::decay_t<E>, N>::type;
+
 }
 
 #endif

--- a/test/test_sfinae.cpp
+++ b/test/test_sfinae.cpp
@@ -19,19 +19,15 @@
 namespace xt
 {
     template <class E, std::enable_if_t<!xt::has_rank_t<E, 2>::value, int> = 0>
-    inline E sfinae_rank_basic_func(E&& a)
+    inline size_t sfinae_rank_basic_func(E&&)
     {
-        E b = a;
-        b.fill(0);
-        return b;
+        return 0;
     }
 
     template <class E, std::enable_if_t<xt::has_rank_t<E, 2>::value, int> = 0>
-    inline E sfinae_rank_basic_func(E&& a)
+    inline size_t sfinae_rank_basic_func(E&&)
     {
-        E b = a;
-        b.fill(2);
-        return b;
+        return 2;
     }
 
     TEST(sfinae, rank_basic)
@@ -42,35 +38,33 @@ namespace xt
         // xt::xtensor_fixed<size_t, xt::xshape<2, 2>> d = {{9, 9}, {9, 9}};
         auto v = xt::view(c, 0, xt::all());
 
-        EXPECT_TRUE(xt::all(xt::equal(sfinae_rank_basic_func(a), 0ul)));
-        EXPECT_TRUE(xt::all(xt::equal(sfinae_rank_basic_func(b), 0ul)));
-        EXPECT_TRUE(xt::all(xt::equal(sfinae_rank_basic_func(c), 2ul)));
-        // EXPECT_TRUE(xt::all(xt::equal(sfinae_rank_basic_func(d), 2ul)));
-        EXPECT_TRUE(xt::all(xt::equal(sfinae_rank_basic_func(v), 0ul)));
+        EXPECT_TRUE(sfinae_rank_basic_func(a) == 0ul);
+        EXPECT_TRUE(sfinae_rank_basic_func(b) == 0ul);
+        EXPECT_TRUE(sfinae_rank_basic_func(c) == 2ul);
+        // EXPECT_TRUE(sfinae_rank_basic_func(d) == 2ul);
+        EXPECT_TRUE(sfinae_rank_basic_func(v) == 0ul);
+        EXPECT_TRUE(sfinae_rank_basic_func(2ul * a) == 0ul);
+        EXPECT_TRUE(sfinae_rank_basic_func(2ul * b) == 0ul);
+        EXPECT_TRUE(sfinae_rank_basic_func(2ul * c) == 0ul);
+
     }
 
     template <class E, std::enable_if_t<xt::has_rank_t<E, SIZE_MAX>::value, int> = 0>
-    inline E sfinae_rank_func(E&& a)
+    inline size_t sfinae_rank_func(E&&)
     {
-        E b = a;
-        b.fill(0);
-        return b;
+        return 0;
     }
 
     template <class E, std::enable_if_t<xt::has_rank_t<E, 1>::value, int> = 0>
-    inline E sfinae_rank_func(E&& a)
+    inline size_t sfinae_rank_func(E&&)
     {
-        E b = a;
-        b.fill(1);
-        return b;
+        return 1;
     }
 
     template <class E, std::enable_if_t<xt::has_rank_t<E, 2>::value, int> = 0>
-    inline E sfinae_rank_func(E&& a)
+    inline size_t sfinae_rank_func(E&&)
     {
-        E b = a;
-        b.fill(2);
-        return b;
+        return 2;
     }
 
     TEST(sfinae, rank)
@@ -81,10 +75,68 @@ namespace xt
         // xt::xtensor_fixed<size_t, xt::xshape<2, 2>> d = {{9, 9}, {9, 9}};
         auto v = xt::view(c, 0, xt::all());
 
-        EXPECT_TRUE(xt::all(xt::equal(sfinae_rank_func(a), 0ul)));
-        EXPECT_TRUE(xt::all(xt::equal(sfinae_rank_func(b), 1ul)));
-        EXPECT_TRUE(xt::all(xt::equal(sfinae_rank_func(c), 2ul)));
-        // EXPECT_TRUE(xt::all(xt::equal(sfinae_rank_func(d), 2ul)));
-        EXPECT_TRUE(xt::all(xt::equal(sfinae_rank_func(v), 0ul)));
+        EXPECT_TRUE(sfinae_rank_func(a) == 0ul);
+        EXPECT_TRUE(sfinae_rank_func(b) == 1ul);
+        EXPECT_TRUE(sfinae_rank_func(c) == 2ul);
+        // EXPECT_TRUE(sfinae_rank_func(d) == 2ul);
+        EXPECT_TRUE(sfinae_rank_func(v) == 0ul);
+        EXPECT_TRUE(sfinae_rank_func(2ul * a) == 0ul);
+        EXPECT_TRUE(sfinae_rank_func(2ul * b) == 0ul);
+        EXPECT_TRUE(sfinae_rank_func(2ul * c) == 0ul);
+    }
+
+    template <class E, std::enable_if_t<!xt::has_fixed_rank_t<E>::value, int> = 0>
+    inline bool sfinae_fixed_func(E&&)
+    {
+        return false;
+    }
+
+    template <class E, std::enable_if_t<xt::has_fixed_rank_t<E>::value, int> = 0>
+    inline bool sfinae_fixed_func(E&&)
+    {
+        return true;
+    }
+
+    TEST(sfinae, fixed_rank)
+    {
+        xt::xarray<size_t> a = {{9, 9, 9}, {9, 9, 9}};
+        xt::xtensor<size_t, 1> b = {9, 9};
+        xt::xtensor<size_t, 2> c = {{9, 9}, {9, 9}};
+        // xt::xtensor_fixed<size_t, xt::xshape<2, 2>> d = {{9, 9}, {9, 9}};
+        auto v = xt::view(c, 0, xt::all());
+
+        EXPECT_TRUE(sfinae_fixed_func(a) == false);
+        EXPECT_TRUE(sfinae_fixed_func(b) == true);
+        EXPECT_TRUE(sfinae_fixed_func(c) == true);
+        // EXPECT_TRUE(sfinae_fixed_func(d) == 2ul);
+        EXPECT_TRUE(sfinae_fixed_func(v) == false);
+        EXPECT_TRUE(sfinae_fixed_func(2ul * a) == false);
+        EXPECT_TRUE(sfinae_fixed_func(2ul * b) == false);
+        EXPECT_TRUE(sfinae_fixed_func(2ul * c) == false);
+    }
+
+    template <class T>
+    struct sfinae_get_rank
+    {
+        static const size_t rank = xt::get_rank<T>::value;
+
+        static size_t value()
+        {
+            return rank;
+        }
+    };
+
+    TEST(sfinae, get_rank)
+    {
+        xt::xtensor<double, 1> A = xt::zeros<double>({2});
+        xt::xtensor<double, 2> B = xt::zeros<double>({2, 2});
+        xt::xarray<double> C = xt::zeros<double>({2, 2});
+
+        EXPECT_TRUE(sfinae_get_rank<decltype(A)>::value() == 1ul);
+        EXPECT_TRUE(sfinae_get_rank<decltype(B)>::value() == 2ul);
+        EXPECT_TRUE(sfinae_get_rank<decltype(C)>::value() == SIZE_MAX);
+        EXPECT_TRUE(sfinae_get_rank<decltype(2.0 * A)>::value() == SIZE_MAX);
+        EXPECT_TRUE(sfinae_get_rank<decltype(2.0 * B)>::value() == SIZE_MAX);
+        EXPECT_TRUE(sfinae_get_rank<decltype(2.0 * C)>::value() == SIZE_MAX);
     }
 }


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Fixes #2155

@JohanMabille Is it hard to have a variadic template such that one could use `xt::has_rank<T, 1, 2>` ?
