### PR TITLE
Added missing header

### DIFF
--- a/include/xtensor/xtensor_config.hpp
+++ b/include/xtensor/xtensor_config.hpp
@@ -31,6 +31,7 @@
 
 // Exception support.
 #if defined(XTENSOR_DISABLE_EXCEPTIONS)
+#include <iostream>
 #define XTENSOR_THROW(_, msg)            \
     {                                    \
       std::cerr << msg << std::endl;     \


### PR DESCRIPTION
# Description

Fixed for the issue #2168 by adding `#include <iostream>` in xtensor_config.hpp
