### PR TITLE
Fix xchunked_array assignment

### DIFF
--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -4,7 +4,6 @@
 #include <vector>
 #include <array>
 
-#include "xarray.hpp"
 #include "xnoalias.hpp"
 #include "xstrided_view.hpp"
 
@@ -68,6 +67,7 @@ namespace xt
         using temporary_type = typename inner_types::temporary_type;
         using bool_load_type = xt::bool_load_type<value_type>;
         static constexpr layout_type static_layout = layout_type::dynamic;
+        static constexpr bool contiguous_layout = false;
 
         template <class S>
         xchunked_array(S&& shape, S&& chunk_shape);
@@ -87,6 +87,9 @@ namespace xt
 
         template <class E>
         xchunked_array& operator=(const xexpression<E>& e);
+
+        template <class E>
+        void assign(const xexpression<E>& e);
 
         const shape_type& shape() const noexcept;
         layout_type layout() const noexcept;
@@ -108,6 +111,9 @@ namespace xt
         bool broadcast_shape(S& s, bool reuse_cache = false) const;
 
         template <class S>
+        bool has_linear_assign(const S& strides) const noexcept;
+
+        template <class S>
         stepper stepper_begin(const S& shape) noexcept;
         template <class S>
         stepper stepper_end(const S& shape, layout_type) noexcept;
@@ -124,15 +130,15 @@ namespace xt
     private:
 
         template <class... Idxs>
-        using indexes_type = std::pair<std::array<size_t, sizeof...(Idxs)>, std::array<size_t, sizeof...(Idxs)>>;
+        using indexes_type = std::pair<std::array<std::size_t, sizeof...(Idxs)>, std::array<std::size_t, sizeof...(Idxs)>>;
 
         template <class... Idxs>
-        using chunk_indexes_type = std::array<std::pair<size_t, size_t>, sizeof...(Idxs)>;
+        using chunk_indexes_type = std::array<std::pair<std::size_t, std::size_t>, sizeof...(Idxs)>;
 
         template <std::size_t N>
-        using static_indexes_type = std::pair<std::array<size_t, N>, std::array<size_t, N>>;
+        using static_indexes_type = std::pair<std::array<std::size_t, N>, std::array<std::size_t, N>>;
 
-        using dynamic_indexes_type = std::pair<std::vector<size_t>, std::vector<size_t>>;
+        using dynamic_indexes_type = std::pair<std::vector<std::size_t>, std::vector<std::size_t>>;
 
         template <class S1, class S2>
         void resize(S1&& shape, S2&& chunk_shape);
@@ -141,9 +147,9 @@ namespace xt
         indexes_type<Idxs...> get_indexes(Idxs... idxs) const;
 
         template <class Idx>
-        std::pair<size_t, size_t> get_chunk_indexes_in_dimension(size_t dim, Idx idx) const;
+        std::pair<std::size_t, std::size_t> get_chunk_indexes_in_dimension(std::size_t dim, Idx idx) const;
 
-        template <size_t... dims, class... Idxs>
+        template <std::size_t... dims, class... Idxs>
         chunk_indexes_type<Idxs...> get_chunk_indexes(std::index_sequence<dims...>, Idxs... idxs) const;
 
         template <class T, std::size_t N>
@@ -224,10 +230,16 @@ namespace xt
     inline xchunked_array<CS, EX>::xchunked_array(const xexpression<E>& e, S&& chunk_shape)
     {
         resize(e.derived_cast().shape(), std::forward<S>(chunk_shape));
+        assign(e);
+    }
+
+    template <class CS, class EX>
+    template <class E>
+    inline void xchunked_array<CS, EX>::assign(const xexpression<E>& e)
+    {
         xstrided_slice_vector sv(m_chunk_shape.size());  // element slice corresponding to chunk
         std::transform(m_chunk_shape.begin(), m_chunk_shape.end(), sv.begin(),
                        [](auto size) { return range(0, size); });
-
         shape_type ic(this->dimension());  // index of chunk, initialized to 0...
         size_type ci = 0;
         for (auto& chunk: m_chunks)
@@ -251,7 +263,6 @@ namespace xt
                         {
                             di--;
                         }
-
                     }
                     else
                     {
@@ -269,7 +280,8 @@ namespace xt
     template <class E>
     inline auto xchunked_array<CS, EX>::operator=(const xexpression<E>& e) -> self_type&
     {
-        return semantic_base::operator=(e);
+        assign(e);
+        return *this;
     }
 
     template <class CS, class EX>
@@ -279,7 +291,7 @@ namespace xt
     }
 
     template <class CS, class EX>
-    inline auto xchunked_array<CS, EX>::layout() const noexcept -> layout_type 
+    inline auto xchunked_array<CS, EX>::layout() const noexcept -> layout_type
     {
         return static_layout;
     }
@@ -331,6 +343,13 @@ namespace xt
     inline bool xchunked_array<CS, EX>::broadcast_shape(S& s, bool) const
     {
         return xt::broadcast_shape(shape(), s);
+    }
+
+    template <class CS, class EX>
+    template <class S>
+    inline bool xchunked_array<CS, EX>::has_linear_assign(const S& strides) const noexcept
+    {
+        return false;
     }
 
     template <class CS, class EX>
@@ -388,7 +407,7 @@ namespace xt
     inline void xchunked_array<CS, EX>::resize(S1&& shape, S2&& chunk_shape)
     {
         // compute chunk number in each dimension (shape_of_chunks)
-        std::vector<size_t> shape_of_chunks(shape.size());
+        std::vector<std::size_t> shape_of_chunks(shape.size());
         std::transform
         (
             shape.cbegin(), shape.cend(),
@@ -396,14 +415,14 @@ namespace xt
             shape_of_chunks.begin(),
             [](auto s, auto cs)
             {
-                size_t cn = s / cs;
+                std::size_t cn = s / cs;
                 if (s % cs > 0)
-                    cn += size_t(1); // edge_chunk
+                    cn += std::size_t(1); // edge_chunk
                 return cn;
             }
         );
 
-        // resize the xarray of chunks
+        // resize the chunk container
         m_chunks.resize(shape_of_chunks);
         // resize each chunk
         for (auto& c: m_chunks)
@@ -425,15 +444,15 @@ namespace xt
 
     template <class CS, class EX>
     template <class Idx>
-    inline std::pair<size_t, size_t> xchunked_array<CS, EX>::get_chunk_indexes_in_dimension(size_t dim, Idx idx) const
+    inline std::pair<std::size_t, std::size_t> xchunked_array<CS, EX>::get_chunk_indexes_in_dimension(std::size_t dim, Idx idx) const
     {
-        size_t index_of_chunk = static_cast<size_t>(idx) / m_chunk_shape[dim];
-        size_t index_in_chunk = static_cast<size_t>(idx) - index_of_chunk * m_chunk_shape[dim];
+        std::size_t index_of_chunk = static_cast<size_t>(idx) / m_chunk_shape[dim];
+        std::size_t index_in_chunk = static_cast<size_t>(idx) - index_of_chunk * m_chunk_shape[dim];
         return std::make_pair(index_of_chunk, index_in_chunk);
     }
 
     template <class CS, class EX>
-    template <size_t... dims, class... Idxs>
+    template <std::size_t... dims, class... Idxs>
     inline auto xchunked_array<CS, EX>::get_chunk_indexes(std::index_sequence<dims...>, Idxs... idxs) const
         -> chunk_indexes_type<Idxs...>
     {
@@ -445,9 +464,9 @@ namespace xt
     template <class T, std::size_t N>
     inline auto xchunked_array<CS, EX>::unpack(const std::array<T, N> &arr) const -> static_indexes_type<N>
     {
-        std::array<size_t, N> arr0;
-        std::array<size_t, N> arr1;
-        for (size_t i = 0; i < N; ++i)
+        std::array<std::size_t, N> arr0;
+        std::array<std::size_t, N> arr1;
+        for (std::size_t i = 0; i < N; ++i)
         {
             arr0[i] = std::get<0>(arr[i]);
             arr1[i] = std::get<1>(arr[i]);
@@ -459,10 +478,10 @@ namespace xt
     template <class It>
     inline auto xchunked_array<CS, EX>::get_indexes_dynamic(It first, It last) const -> dynamic_indexes_type
     {
-        auto size = static_cast<size_t>(std::distance(first, last));
-        std::vector<size_t> indexes_of_chunk(size);
-        std::vector<size_t> indexes_in_chunk(size);
-        for (size_t dim = 0; dim < size; ++dim)
+        auto size = static_cast<std::size_t>(std::distance(first, last));
+        std::vector<std::size_t> indexes_of_chunk(size);
+        std::vector<std::size_t> indexes_in_chunk(size);
+        for (std::size_t dim = 0; dim < size; ++dim)
         {
             auto chunk_index = get_chunk_indexes_in_dimension(dim, *first++);
             indexes_of_chunk[dim] = chunk_index.first;

--- a/include/xtensor/xfile_array.hpp
+++ b/include/xtensor/xfile_array.hpp
@@ -12,18 +12,18 @@ namespace xt
 {
 
     template <class T>
-    class xfile_reference
+    class xfile_value_reference
     {
     public:
 
-        using self_type = xfile_reference<T>;
+        using self_type = xfile_value_reference<T>;
         using const_reference = const T&;
 
-        xfile_reference(T& value, bool& dirty);
-        ~xfile_reference() = default;
+        xfile_value_reference(T& value, bool& dirty);
+        ~xfile_value_reference() = default;
 
-        xfile_reference(const xfile_reference&) = default;
-        xfile_reference(xfile_reference&&) = default;
+        xfile_value_reference(const xfile_value_reference&) = default;
+        xfile_value_reference(xfile_value_reference&&) = default;
 
         self_type& operator=(const self_type&);
         self_type& operator=(self_type&&);
@@ -50,7 +50,19 @@ namespace xt
         T& m_value;
         bool& m_dirty;
     };
+}
 
+namespace std
+{
+    template <class T>
+    struct is_signed<xt::xfile_value_reference<T>>
+        : is_signed<T>
+    {
+    };
+}
+
+namespace xt
+{
     template <class E, class IOH>
     class xfile_array_container;
 
@@ -59,7 +71,7 @@ namespace xt
     {
         using storage_type = E;
         using value_type = typename storage_type::value_type;
-        using reference = xfile_reference<value_type>;
+        using reference = xfile_value_reference<value_type>;
         using const_reference = typename storage_type::const_reference;
         using size_type = typename storage_type::size_type;
         using temporary_type = xfile_array_container<E, IOH>;
@@ -99,6 +111,7 @@ namespace xt
         using temporary_type = typename inner_types::temporary_type;
         using bool_load_type = xt::bool_load_type<value_type>;
         static constexpr layout_type static_layout = layout_type::dynamic;
+        static constexpr bool contiguous_layout = true;
 
         xfile_array_container() = default;
         ~xfile_array_container();
@@ -182,7 +195,7 @@ namespace xt
 
         const std::string& path() const noexcept;
         void ignore_empty_path(bool ignore);
-        void set_path(std::string& path);
+        void set_path(const std::string& path);
 
         template <class C>
         void configure_format(C& config);
@@ -207,19 +220,19 @@ namespace xt
               class SA = std::allocator<typename std::vector<T, A>::size_type>>
     using xfile_array = xfile_array_container<xarray<T, L, A, SA>, IOH>;
 
-    /**********************************
-     * xfile_reference implementation *
-     **********************************/
+    /****************************************
+     * xfile_value_reference implementation *
+     ****************************************/
 
     template <class T>
-    inline xfile_reference<T>::xfile_reference(T& value, bool& dirty)
+    inline xfile_value_reference<T>::xfile_value_reference(T& value, bool& dirty)
         : m_value(value), m_dirty(dirty)
     {
     }
 
     template <class T>
     template <class V>
-    inline auto xfile_reference<T>::operator=(const V& v) -> self_type&
+    inline auto xfile_value_reference<T>::operator=(const V& v) -> self_type&
     {
         if (v != m_value)
         {
@@ -231,7 +244,7 @@ namespace xt
 
     template <class T>
     template <class V>
-    inline auto xfile_reference<T>::operator+=(const V& v) -> self_type&
+    inline auto xfile_value_reference<T>::operator+=(const V& v) -> self_type&
     {
         if (v != T(0))
         {
@@ -243,7 +256,7 @@ namespace xt
 
     template <class T>
     template <class V>
-    inline auto xfile_reference<T>::operator-=(const V& v) -> self_type&
+    inline auto xfile_value_reference<T>::operator-=(const V& v) -> self_type&
     {
         if (v != T(0))
         {
@@ -255,7 +268,7 @@ namespace xt
 
     template <class T>
     template <class V>
-    inline auto xfile_reference<T>::operator*=(const V& v) -> self_type&
+    inline auto xfile_value_reference<T>::operator*=(const V& v) -> self_type&
     {
         if (v != T(1))
         {
@@ -267,7 +280,7 @@ namespace xt
 
     template <class T>
     template <class V>
-    inline auto xfile_reference<T>::operator/=(const V& v) -> self_type&
+    inline auto xfile_value_reference<T>::operator/=(const V& v) -> self_type&
     {
         if (v != T(1))
         {
@@ -278,7 +291,7 @@ namespace xt
     }
 
     template <class T>
-    inline xfile_reference<T>::operator const_reference() const
+    inline xfile_value_reference<T>::operator const_reference() const
     {
         return m_value;
     }
@@ -567,7 +580,7 @@ namespace xt
     }
 
     template <class E, class IOH>
-    inline void xfile_array_container<E, IOH>::set_path(std::string& path)
+    inline void xfile_array_container<E, IOH>::set_path(const std::string& path)
     {
         if (path != m_path)
         {


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

This allows to do an assignment such as:
```cpp
// a, b and c are xchunked_array<xchunk_store_manager<...>>
c = a + b;
```
chunk by chunk, and not using `semantic_base::operator=(e)`, which would create a temporary chunked array.