### PR TITLE
First implementation of zchunked_wrapper

### DIFF
--- a/include/xtensor/xchunk_store_manager.hpp
+++ b/include/xtensor/xchunk_store_manager.hpp
@@ -143,7 +143,7 @@ namespace xt
      * xindex_path implementation *
      ******************************/
 
-    void xindex_path::set_directory(const std::string& directory)
+    inline void xindex_path::set_directory(const std::string& directory)
     {
         m_directory = directory;
         if (m_directory.back() != '/')

--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -400,7 +400,7 @@ namespace xt
 
     template <class CS, class EX>
     template <class S>
-    inline bool xchunked_array<CS, EX>::has_linear_assign(const S& strides) const noexcept
+    inline bool xchunked_array<CS, EX>::has_linear_assign(const S&) const noexcept
     {
         return false;
     }

--- a/include/xtensor/zarray.hpp
+++ b/include/xtensor/zarray.hpp
@@ -70,6 +70,8 @@ namespace xt
         template <class T>
         const xarray<T>& get_array() const;
 
+        const zchunked_array& as_chunked_array() const;
+
     private:
 
         template <class E>
@@ -169,6 +171,11 @@ namespace xt
     inline const xarray<T>& zarray::get_array() const
     {
         return dynamic_cast<const ztyped_array<T>*>(p_impl.get())->get_array();
+    }
+
+    inline const zchunked_array& zarray::as_chunked_array() const
+    {
+        return dynamic_cast<const zchunked_array&>(*(p_impl.get()));
     }
 }
 

--- a/include/xtensor/zarray_impl.hpp
+++ b/include/xtensor/zarray_impl.hpp
@@ -11,6 +11,7 @@
 #define XTENSOR_ZARRAY_IMPL_HPP
 
 #include "xarray.hpp"
+#include "xchunked_array.hpp"
 
 namespace xt
 {
@@ -154,6 +155,56 @@ namespace xt
         CTE m_array;
     };
 
+    /********************
+     * zchunked_wrapper *
+     ********************/
+
+    class zchunked_array
+    {
+    public:
+
+        using shape_type = std::vector<std::size_t>;
+
+        virtual ~zchunked_array() = default;
+        virtual const shape_type& chunk_shape() const = 0;
+    };
+
+    template <class CTE>
+    class zchunked_wrapper : public ztyped_array<typename std::decay_t<CTE>::value_type>,
+                             public zchunked_array
+    {
+    public:
+
+        using self_type = zchunked_wrapper;
+        using value_type = typename std::decay_t<CTE>::value_type;
+        using base_type = ztyped_array<value_type>;
+        using shape_type = typename zchunked_array::shape_type;
+
+        template <class E>
+        zchunked_wrapper(E&& e);
+
+        virtual ~zchunked_wrapper() = default;
+
+        xarray<value_type>& get_array() override;
+        const xarray<value_type>& get_array() const override;
+
+        self_type* clone() const override;
+
+        const shape_type& chunk_shape() const override;
+
+    private:
+
+        zchunked_wrapper(const zchunked_wrapper&) = default;
+
+        void compute_cache() const;
+
+        CTE m_chunked_array;
+        shape_type m_chunk_shape;
+        mutable xarray<value_type> m_cache;
+        mutable bool m_cache_initialized;
+
+    };
+
     /***********************
      * zexpression_wrapper *
      ***********************/
@@ -228,6 +279,60 @@ namespace xt
         return new self_type(*this);
     }
 
+    /********************
+     * zchunked_wrapper *
+     ********************/
+
+    template <class CTE>
+    template <class E>
+    inline zchunked_wrapper<CTE>::zchunked_wrapper(E&& e)
+        : base_type()
+        , m_chunked_array(std::forward<E>(e))
+        , m_chunk_shape(m_chunked_array.chunk_shape().size())
+        , m_cache()
+        , m_cache_initialized(false)
+    {
+        std::copy(m_chunked_array.chunk_shape().begin(),
+                  m_chunked_array.chunk_shape().end(),
+                  m_chunk_shape.begin());
+    }
+
+    template <class CTE>
+    inline auto zchunked_wrapper<CTE>::get_array() -> xarray<value_type>&
+    {
+        compute_cache();
+        return m_cache;
+    }
+
+    template <class CTE>
+    inline auto zchunked_wrapper<CTE>::get_array() const -> const xarray<value_type>&
+    {
+        compute_cache();
+        return m_cache;
+    }
+
+    template <class CTE>
+    inline auto zchunked_wrapper<CTE>::clone() const -> self_type*
+    {
+        return new self_type(*this);
+    }
+
+    template <class CTE>
+    inline auto zchunked_wrapper<CTE>::chunk_shape() const -> const shape_type&
+    {
+        return m_chunk_shape;
+    }
+
+    template <class CTE>
+    inline void zchunked_wrapper<CTE>::compute_cache() const
+    {
+        if (!m_cache_initialized)
+        {
+            m_cache = m_chunked_array;
+            m_cache_initialized = true;
+        }
+    }
+
     /******************
      * zarray builder *
      ******************/
@@ -245,12 +350,26 @@ namespace xt
         };
 
         template <class E>
+        struct is_chunked_array : std::false_type
+        {
+        };
+
+        template <class CS, class E>
+        struct is_chunked_array<xchunked_array<CS, E>> : std::true_type
+        {
+        };
+
+        template <class E>
         struct zwrapper_builder
         {
             using closure_type = xtl::closure_type_t<E>;
             using wrapper_type = std::conditional_t<is_xarray<std::decay_t<E>>::value,
                                                     zarray_wrapper<closure_type>,
-                                                    zexpression_wrapper<closure_type>>;
+                                                    std::conditional_t<is_chunked_array<std::decay_t<E>>::value,
+                                                                       zchunked_wrapper<closure_type>,
+                                                                       zexpression_wrapper<closure_type>
+                                                                      >
+                                                    >;
 
             template <class OE>
             static wrapper_type* run(OE&& e)

--- a/test/test_zarray.cpp
+++ b/test/test_zarray.cpp
@@ -123,6 +123,18 @@ namespace xt
         const auto& res = zres.get_array<double>();
         EXPECT_TRUE(all(isclose(res, expected)));
     }
+
+    TEST(zarray, chunked_array)
+    {
+        using shape_type = std::vector<size_t>;
+        shape_type shape = {10, 10, 10};
+        shape_type chunk_shape = {2, 3, 4};
+        xchunked_array<xarray<xarray<double>>> a(shape, chunk_shape);
+
+        zarray za(a);
+        shape_type res = za.as_chunked_array().chunk_shape();
+        EXPECT_EQ(res, chunk_shape);
+    }
 }
 #endif
 


### PR DESCRIPTION
@davidbrochart with this PR, you can write things like:

```cpp
xchunked_array<xarray<xarray<double>>> a(shape, chunk_shape);

zarray za(a);
shape_type res = za.as_chunked_array().chunk_shape();
```


This is not perfect yet since we cannot assign to a chunked_array with this wrapper (it will assign to the cache xarray of the wrapper instead of the wrapped chunked array) but we'll fix that later.

