### PR TITLE
Fix generated cmake config to include missing required lib

### DIFF
--- a/xtensorConfig.cmake.in
+++ b/xtensorConfig.cmake.in
@@ -43,6 +43,7 @@ if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER_EQUAL 3.11)
             target_compile_options(xtensor::optimize INTERFACE /EHsc /MP /bigobj)
         # gcc, clang, ...
         else()
+            include(CheckCXXCompilerFlag)
             CHECK_CXX_COMPILER_FLAG(-march=native arch_native_supported)
             if(arch_native_supported)
               target_compile_options(xtensor::optimize INTERFACE -march=native)


### PR DESCRIPTION
# Checklist

- [ ] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

Commit cf840966b27d18200cd423cf8ecb923cb0179e83 introduced the use of cmake macro `CHECK_CXX_COMPILER_FLAG `. This leads to an error when using this config from another cmake project:

```
CMake Error at /opt/xtensor/lib/cmake/xtensor/xtensorConfig.cmake:70 (CHECK_CXX_COMPILER_FLAG):
  Unknown CMake command "CHECK_CXX_COMPILER_FLAG".
Call Stack (most recent call first):
  CMakeLists.txt:47 (find_package)

```

This PR fixes this issue by including the cmake lib needed to be able to call this macro?