### PR TITLE
xcontainer.hpp: Renamed a shadowing type name inside a function

### DIFF
--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -334,7 +334,7 @@ namespace xt
 
         static constexpr bool is_bool_conversion() { return is_bool<e2_value_type>::value && !is_bool<e1_value_type>::value; }
         static constexpr bool contiguous_layout() { return E1::contiguous_layout && E2::contiguous_layout; }
-        static constexpr bool convertible_types() { return std::is_convertible<e2_value_type, e1_value_type>::value 
+        static constexpr bool convertible_types() { return std::is_convertible<e2_value_type, e1_value_type>::value
                                                         && !is_bool_conversion(); }
 
         static constexpr bool use_xsimd() { return xt_simd::simd_traits<int8_t>::size > 1; }
@@ -345,7 +345,7 @@ namespace xt
         static constexpr bool simd_interface() { return has_simd_interface<E2, requested_value_type>(); }
 
     public:
-        
+
         // constexpr methods instead of constexpr data members avoid the need of definitions at namespace
         // scope of these data members (since they are odr-used).
 
@@ -565,13 +565,13 @@ namespace xt
     template <class E1, class E2, layout_type L>
     inline void stepper_assigner<E1, E2, L>::run()
     {
-        using size_type = typename E1::size_type;
+        using tmp_size_type = typename E1::size_type;
         using argument_type = std::decay_t<decltype(*m_rhs)>;
         using result_type = std::decay_t<decltype(*m_lhs)>;
         constexpr bool needs_cast = has_assign_conversion<argument_type, result_type>::value;
 
-        size_type s = m_e1.size();
-        for (size_type i = 0; i < s; ++i)
+        tmp_size_type s = m_e1.size();
+        for (tmp_size_type i = 0; i < s; ++i)
         {
             *m_lhs = conditional_cast<needs_cast, result_type>(*m_rhs);
             stepper_tools<L>::increment_stepper(*this, m_index, m_e1.shape());
@@ -906,7 +906,7 @@ namespace xt
         std::size_t inner_loop_size, outer_loop_size, cut;
         std::tie(inner_loop_size, outer_loop_size, cut) = strided_assign_detail::get_loop_sizes(e1, e2, is_row_major);
 
-        if ((is_row_major && cut == e1.dimension()) || (!is_row_major && cut == 0)) 
+        if ((is_row_major && cut == e1.dimension()) || (!is_row_major && cut == 0))
         {
             return fallback_assigner(e1, e2).run();
         }

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -1026,14 +1026,14 @@ namespace xt
     template <class S>
     inline void xstrided_container<D>::reshape_impl(S&& _shape, std::true_type /* is signed */, layout_type layout)
     {
-        using value_type = typename std::decay_t<S>::value_type;
+        using tmp_value_type = typename std::decay_t<S>::value_type;
         auto new_size = compute_size(_shape);
         if (this->size() % new_size)
         {
             XTENSOR_THROW(std::runtime_error, "Negative axis size cannot be inferred. Shape mismatch.");
         }
         std::decay_t<S> shape = _shape;
-        value_type accumulator = 1;
+        tmp_value_type accumulator = 1;
         std::size_t neg_idx = 0;
         std::size_t i = 0;
         for(auto it = shape.begin(); it != shape.end(); ++it, i++)
@@ -1048,7 +1048,7 @@ namespace xt
         }
         if(accumulator < 0)
         {
-            shape[neg_idx] = static_cast<value_type>(this->size()) / std::abs(accumulator);
+            shape[neg_idx] = static_cast<tmp_value_type>(this->size()) / std::abs(accumulator);
         }
         else if(this->size() != new_size)
         {
@@ -1060,7 +1060,7 @@ namespace xt
         resize_container(m_backstrides, m_shape.size());
         compute_strides<D::static_layout>(m_shape, m_layout, m_strides, m_backstrides);
     }
-    
+
     template <class D>
     inline auto xstrided_container<D>::mutable_layout() noexcept -> layout_type&
     {

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -467,14 +467,14 @@ namespace xt
     template <std::size_t dim, class I, class... Args>
     inline void xgenerator<F, R, S>::adapt_index(I& arg, Args&... args) const
     {
-        using value_type = typename decltype(m_shape)::value_type;
+        using tmp_value_type = typename decltype(m_shape)::value_type;
         if (sizeof...(Args) + 1 > m_shape.size())
         {
             adapt_index<dim>(args...);
         }
         else
         {
-            if (static_cast<value_type>(arg) >= m_shape[dim] && m_shape[dim] == 1)
+            if (static_cast<tmp_value_type>(arg) >= m_shape[dim] && m_shape[dim] == 1)
             {
                 arg = 0;
             }


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

This is again a tiny change, to rename a local typedef that shadows a class typedef. Thanks for considering it!