### PR TITLE
xnpy.hpp: fix multiple definition of 'host_endian_char' variable when included in different linked objects

### DIFF
--- a/include/xtensor/xnpy.hpp
+++ b/include/xtensor/xnpy.hpp
@@ -60,7 +60,7 @@ namespace xt
         const char big_endian_char = '>';
         const char no_endian_char = '|';
 
-        char host_endian_char = (is_big_endian() ? big_endian_char : little_endian_char);
+        static char host_endian_char = (is_big_endian() ? big_endian_char : little_endian_char);
 
         template <class O>
         inline void write_magic(O& ostream,


### PR DESCRIPTION
# Checklist

- [ ] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

Commit 808ceb4a803909a309a00d72fbfd633d81843ea8 introduced an issue when `xnpy.hpp` is included in two different objects that are then linked together. The `host_endian_char` becomes exported in both objects, resulting in a `multiple definition` error when linking these objects together.

This patch fixes this issue by making it a static variable so that it's not exported.
