### PR TITLE
Improve xeval

### DIFF
--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -147,7 +147,7 @@ namespace xt
     template <class E>
     inline auto empty_like(const xexpression<E>& e)
     {
-        using xtype = temporary_type_t<typename E::value_type, typename E::shape_type, E::static_layout>;
+        using xtype = temporary_type_t<E>;
         auto res = xtype::from_shape(e.derived_cast().shape());
         return res;
     }
@@ -162,7 +162,7 @@ namespace xt
     template <class E>
     inline auto full_like(const xexpression<E>& e, typename E::value_type fill_value)
     {
-        using xtype = temporary_type_t<typename E::value_type, typename E::shape_type, E::static_layout>;
+        using xtype = temporary_type_t<E>;
         auto res = xtype::from_shape(e.derived_cast().shape());
         res.fill(fill_value);
         return res;

--- a/include/xtensor/xeval.hpp
+++ b/include/xtensor/xeval.hpp
@@ -10,6 +10,7 @@
 #ifndef XTENSOR_EVAL_HPP
 #define XTENSOR_EVAL_HPP
 
+#include "xexpression_traits.hpp"
 #include "xtensor_forward.hpp"
 #include "xshape.hpp"
 
@@ -40,28 +41,12 @@ namespace xt
     }
 
     /// @cond DOXYGEN_INCLUDE_SFINAE
-    template <class T, class I = std::decay_t<T>>
+    template <class T>
     inline auto eval(T&& t)
-        -> std::enable_if_t<!detail::is_container<I>::value && detail::is_array<typename I::shape_type>::value && !detail::is_fixed<typename I::shape_type>::value, xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>>
+        -> std::enable_if_t<!detail::is_container<std::decay_t<T>>::value, temporary_type_t<T>>
     {
-        return xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>(std::forward<T>(t));
+        return std::forward<T>(t);
     }
-
-    template <class T, class I = std::decay_t<T>>
-    inline auto eval(T&& t)
-        -> std::enable_if_t<!detail::is_container<I>::value && !detail::is_array<typename I::shape_type>::value && !detail::is_fixed<typename I::shape_type>::value, xt::xarray<typename I::value_type>>
-    {
-        return xarray<typename I::value_type>(std::forward<T>(t));
-    }
-
-    template <class T, class I = std::decay_t<T>>
-    inline auto eval(T&& t)
-        -> std::enable_if_t<!detail::is_container<I>::value && detail::is_fixed<typename I::shape_type>::value && !detail::is_array<typename I::shape_type>::value,
-                            xt::xtensor_fixed<typename I::value_type, typename I::shape_type>>
-    {
-        return xtensor_fixed<typename I::value_type, typename I::shape_type>(std::forward<T>(t));
-    }
-    /// @endcond
 }
 
 #endif

--- a/include/xtensor/xexpression_traits.hpp
+++ b/include/xtensor/xexpression_traits.hpp
@@ -51,7 +51,7 @@ namespace xt
 
     template <class... C>
     using common_value_type_t = typename common_value_type<C...>::type;
-    
+
     /********************
      * common_size_type *
      ********************/
@@ -89,7 +89,7 @@ namespace xt
 
     template <class... Args>
     using common_difference_type_t = typename common_difference_type<Args...>::type;
-    
+
     /******************
      * temporary_type *
      ******************/
@@ -104,7 +104,7 @@ namespace xt
         };
 
 #if defined(__GNUC__) && (__GNUC__ > 6)
-#if __cplusplus == 201703L 
+#if __cplusplus == 201703L
         template <template <class, std::size_t, class, bool> class S, class X, std::size_t N, class A, bool Init>
         struct xtype_for_shape<S<X, N, A, Init>>
         {
@@ -128,15 +128,34 @@ namespace xt
             using type = xtensor_fixed<T, xshape<X...>, L>;
         };
     }
-    
-    template <class T, class S, layout_type L>
-    struct temporary_type
+
+    template <class Tag, class T>
+    struct temporary_type_from_tag;
+
+    template <class T>
+    struct temporary_type_from_tag<xtensor_expression_tag, T>
     {
-        using type = typename detail::xtype_for_shape<S>::template type<T, L>;
+        using I = std::decay_t<T>;
+        using shape_type = typename I::shape_type;
+        using value_type = typename I::value_type;
+        static constexpr layout_type static_layout = XTENSOR_DEFAULT_LAYOUT;
+        using type = typename detail::xtype_for_shape<shape_type>::template type<value_type, static_layout>;
     };
 
-    template <class T, class S, layout_type L>
-    using temporary_type_t = typename temporary_type<T, S, L>::type;
+    template <class T, class = void>
+    struct temporary_type
+    {
+        using type = typename temporary_type_from_tag<xexpression_tag_t<T>, T>::type;
+    };
+
+    template <class T>
+    struct temporary_type<T, void_t<typename std::decay_t<T>::temporary_type>>
+    {
+        using type = typename std::decay_t<T>::temporary_type;
+    };
+
+    template <class T>
+    using temporary_type_t = typename temporary_type<T>::type;
 
     /**********************
      * common_tensor_type *
@@ -148,9 +167,9 @@ namespace xt
         struct common_tensor_type_impl
         {
             static constexpr layout_type static_layout = compute_layout(std::decay_t<C>::static_layout...);
-            using type = temporary_type_t<common_value_type_t<C...>,
-                                          promote_shape_t<typename C::shape_type...>,
-                                          static_layout>;
+            using value_type = common_value_type_t<C...>;
+            using shape_type = promote_shape_t<typename C::shape_type...>;
+            using type = typename xtype_for_shape<shape_type>::template type<value_type, static_layout>;
         };
     }
 

--- a/include/xtensor/xpad.hpp
+++ b/include/xtensor/xpad.hpp
@@ -80,10 +80,7 @@ namespace xt
         XTENSOR_ASSERT(detail::check_pad_width(pad_width, e.shape()));
 
         using size_type = typename std::decay_t<E>::size_type;
-        using value_type = typename std::decay_t<E>::value_type;
-        using return_type = temporary_type_t<value_type,
-                                             typename std::decay_t<E>::shape_type,
-                                             std::decay_t<E>::static_layout>;
+        using return_type = temporary_type_t<E>;
 
         // place the original array in the center
 
@@ -239,10 +236,8 @@ namespace xt
         inline auto tile(E&& e, const S& reps)
         {
             using size_type = typename std::decay_t<E>::size_type;
-            using value_type = typename std::decay_t<E>::value_type;
-            using return_type = temporary_type_t<value_type,
-                                                 typename std::decay_t<E>::shape_type,
-                                                 std::decay_t<E>::static_layout>;
+
+            using return_type = temporary_type_t<E>;
 
             XTENSOR_ASSERT(e.shape().size() == reps.size());
 
@@ -262,7 +257,7 @@ namespace xt
 
             xt::xstrided_slice_vector svs(e.shape().size(), xt::all());
             xt::xstrided_slice_vector svt(e.shape().size(), xt::all());
-            
+
             for (size_type axis = 0; axis < e.shape().size(); ++axis)
             {
                 for (size_type i = 1; i < static_cast<size_type>(reps[axis]); ++i)

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -81,7 +81,7 @@ namespace xt
         using undecay_shape = S;
         using storage_getter = FST;
         using inner_storage_type = typename storage_getter::type;
-        using temporary_type = temporary_type_t<typename xexpression_type::value_type, S, L>;
+        using temporary_type = typename detail::xtype_for_shape<S>::template type<typename xexpression_type::value_type, L>;
         using storage_type = std::remove_reference_t<inner_storage_type>;
         static constexpr layout_type layout = L;
     };


### PR DESCRIPTION
This PR adds the construction of a `temporary_type` from a tag expression. This allows to use `xeval` for other expressions such as those used in `xtensor-sparse`.