### PR TITLE
Implement xt::random::choice with weights vector

### DIFF
--- a/docs/source/api/xrandom.rst
+++ b/docs/source/api/xrandom.rst
@@ -80,7 +80,9 @@ Defined in ``xtensor/xrandom.hpp``
    :project: xtensor
 
 .. _random-choice-function-reference:
-.. doxygenfunction:: xt::random::choice
+.. doxygenfunction:: xt::random::choice(const xexpression<T>&, std::size_t, bool, E&)
+   :project: xtensor
+.. doxygenfunction:: xt::random::choice(const xexpression<T>&, std::size_t, const xexpression<W>&, bool, E&)
    :project: xtensor
 
 .. _random-shuffle-function-reference:

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -28,6 +28,7 @@
 #include "xtensor.hpp"
 #include "xtensor_config.hpp"
 #include "xview.hpp"
+#include "xmath.hpp"
 
 namespace xt
 {
@@ -846,7 +847,19 @@ namespace xt
 
             if (replace)
             {
-                XTENSOR_THROW(std::runtime_error, "Not implemented");
+                // Sample u uniformly in the range [0, sum(weights)[
+                // The index idx of the sampled element in e is the largest idx such that weight_cumul[idx] < u (given by std::upper_bound - 1).
+                const xtensor<weight_type, 1> weight_cumul = cumsum(dweights);  // 0 included as first elem
+                const auto weight_cumul_begin = weight_cumul.storage().begin();
+                std::uniform_real_distribution<weight_type> weight_dist{0, weight_cumul[weight_cumul.size() - 1]};
+                for(auto& x : result)
+                {
+                    const auto u = weight_dist(engine);
+                    const auto idx_iter = std::upper_bound(weight_cumul_begin, weight_cumul.storage().end(), u) - 1;
+                    const auto idx = static_cast<size_type>(idx_iter - weight_cumul_begin);
+                    x = de.storage()[idx];
+                }
+
             }
             else
             {

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -767,14 +767,8 @@ namespace xt
         xtensor<typename T::value_type, 1> choice(const xexpression<T>& e, std::size_t n, bool replace, E& engine)
         {
             const auto& de = e.derived_cast();
-            if (de.dimension() != 1)
-            {
-                XTENSOR_THROW(std::runtime_error, "Sample expression must be 1 dimensional");
-            }
-            if (de.size() < n && !replace)
-            {
-                XTENSOR_THROW(std::runtime_error, "If replace is false, then the sample expression's size must be > n");
-            }
+            XTENSOR_ASSERT((de.dimension() == 1));
+            XTENSOR_ASSERT((replace || n <= de.size()));
             using result_type = xtensor<typename T::value_type, 1>;
             using size_type = typename result_type::size_type;
             result_type result;
@@ -837,18 +831,10 @@ namespace xt
         {
             const auto& de = e.derived_cast();
             const auto& dweights = weights.derived_cast();
-            if (de.dimension() != 1)
-            {
-                XTENSOR_THROW(std::runtime_error, "Sample and weight expression must be 1 dimensional");
-            }
-            if (de.size() < n && !replace)
-            {
-                XTENSOR_THROW(std::runtime_error, "If replace is false, then the sample expression's size must be > n");
-            }
-            if (de.size() != dweights.size() || de.dimension() != dweights.dimension())
-            {
-                XTENSOR_THROW(std::runtime_error, "Sample and weight expression must have the same size");
-            }
+            XTENSOR_ASSERT((de.dimension() == 1));
+            XTENSOR_ASSERT((replace || n <= de.size()));
+            XTENSOR_ASSERT((de.size() == dweights.size()));
+            XTENSOR_ASSERT((de.dimension() == dweights.dimension()));
             XTENSOR_ASSERT(xt::all(dweights >= 0));
             static_assert(std::is_floating_point<typename W::value_type>::value,
                           "Weight expression must be of floating point type");

--- a/test/test_xrandom.cpp
+++ b/test/test_xrandom.cpp
@@ -173,28 +173,21 @@ namespace xt
     TEST(xrandom, weighted_choice)
     {
         xarray<int> a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        xarray<double> w = {1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
-        xt::random::seed(42);
-        auto ac1 = xt::random::choice(a, 6, w, false);
-        auto ac2 = xt::random::choice(a, 6, w, false);
-        xt::random::seed(42);
-        auto ac3 = xt::random::choice(a, 6, w, false);
+        xarray<double> w = {1, 0, 2, 0, 1, 0, 1, 0, 2, 0, 1, 0};
 
-        static_assert(std::is_same<decltype(a)::value_type, decltype(ac1)::value_type>::value, "Elements must be same type");
-        ASSERT_EQ(ac1, ac3);
-        ASSERT_NE(ac1, ac2);
-        ASSERT_TRUE(all(isin(ac1, a)));
-        ASSERT_TRUE(all(equal(ac1 % 2, 1)));
-
-        xt::random::seed(42);
-        auto acr1 = xt::random::choice(a, 6, w, false);
-        auto acr2 = xt::random::choice(a, 6, w, false);
-        xt::random::seed(42);
-        auto acr3 = xt::random::choice(a, 6, w, false);
-        ASSERT_EQ(acr1, acr3);
-        ASSERT_NE(acr1, acr2);
-        ASSERT_TRUE(all(isin(acr1, a)));
-        ASSERT_TRUE(all(equal(acr1 % 2, 1)));
+        for(bool replace : {true, false}) {
+            xt::random::seed(42);
+            auto ac1 = xt::random::choice(a, 6, w, replace);
+            auto ac2 = xt::random::choice(a, 6, w, replace);
+            xt::random::seed(42);
+            auto ac3 = xt::random::choice(a, 6, w, replace);
+            static_assert(std::is_same<decltype(a)::value_type, decltype(ac1)::value_type>::value,
+                          "Elements must be same type");
+            ASSERT_EQ(ac1, ac3);
+            ASSERT_NE(ac1, ac2);
+            ASSERT_TRUE(all(isin(ac1, a)));
+            ASSERT_TRUE(all(equal(ac1 % 2, 1)));
+        }
 
         xarray<double> b = {-1, 1};
         xarray<double> v = {1, 1};

--- a/test/test_xrandom.cpp
+++ b/test/test_xrandom.cpp
@@ -7,6 +7,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include <type_traits>
+
 #include "gtest/gtest.h"
 #include "test_common_macros.hpp"
 #if (defined(__GNUC__) && !defined(__clang__))
@@ -19,6 +21,7 @@
 #endif
 #include "xtensor/xarray.hpp"
 #include "xtensor/xview.hpp"
+#include "xtensor/xset_operation.hpp"
 
 namespace xt
 {
@@ -165,6 +168,33 @@ namespace xt
         XT_ASSERT_NO_THROW(xt::random::choice(b, 5, true));
         xarray<double> multidim_input = { {1,2,3}, {3,4,5} };
         XT_ASSERT_THROW(xt::random::choice(multidim_input, 5, true), std::runtime_error);
+    }
+
+    TEST(xrandom, weighted_choice)
+    {
+        xarray<int> a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+        xarray<double> w = {1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+        xt::random::seed(42);
+        auto ac1 = xt::random::choice(a, 6, w, false);
+        auto ac2 = xt::random::choice(a, 6, w, false);
+        xt::random::seed(42);
+        auto ac3 = xt::random::choice(a, 6, w, false);
+
+        static_assert(std::is_same<decltype(a)::value_type, decltype(ac1)::value_type>::value, "Elements must be same type");
+        ASSERT_EQ(ac1, ac3);
+        ASSERT_NE(ac1, ac2);
+        ASSERT_TRUE(all(isin(ac1, a)));
+        ASSERT_TRUE(all(equal(ac1 % 2, 1)));
+
+        xarray<double> b = {-1, 1};
+        xarray<double> v = {1, 1};
+        xt::random::seed(42);
+        XT_ASSERT_THROW(xt::random::choice(b, 5, v, false), std::runtime_error);
+        XT_ASSERT_NO_THROW(xt::random::choice(b, 5, v, true));
+        xarray<double> multidim_input = { {1,2,3}, {3,4,5} };
+        XT_ASSERT_THROW(xt::random::choice(multidim_input, 5, v, true), std::runtime_error);
+        xarray<double> bad_count_weights = {1, 1, 4};
+        XT_ASSERT_THROW(xt::random::choice(b, 5, bad_count_weights, true), std::runtime_error);
     }
 
     TEST(xrandom, shuffle)

--- a/test/test_xrandom.cpp
+++ b/test/test_xrandom.cpp
@@ -161,13 +161,6 @@ namespace xt
         auto acr3 = xt::random::choice(a, 5, true);
         ASSERT_EQ(acr1, acr3);
         ASSERT_NE(acr1, acr2);
-
-        xarray<double> b = {-1, 1};
-        xt::random::seed(42);
-        XT_ASSERT_THROW(xt::random::choice(b, 5, false), std::runtime_error);
-        XT_ASSERT_NO_THROW(xt::random::choice(b, 5, true));
-        xarray<double> multidim_input = { {1,2,3}, {3,4,5} };
-        XT_ASSERT_THROW(xt::random::choice(multidim_input, 5, true), std::runtime_error);
     }
 
     TEST(xrandom, weighted_choice)
@@ -188,16 +181,6 @@ namespace xt
             ASSERT_TRUE(all(isin(ac1, a)));
             ASSERT_TRUE(all(equal(ac1 % 2, 1)));
         }
-
-        xarray<double> b = {-1, 1};
-        xarray<double> v = {1, 1};
-        xt::random::seed(42);
-        XT_ASSERT_THROW(xt::random::choice(b, 5, v, false), std::runtime_error);
-        XT_ASSERT_NO_THROW(xt::random::choice(b, 5, v, true));
-        xarray<double> multidim_input = { {1,2,3}, {3,4,5} };
-        XT_ASSERT_THROW(xt::random::choice(multidim_input, 5, v, true), std::runtime_error);
-        xarray<double> bad_count_weights = {1, 1, 4};
-        XT_ASSERT_THROW(xt::random::choice(b, 5, bad_count_weights, true), std::runtime_error);
     }
 
     TEST(xrandom, shuffle)

--- a/test/test_xrandom.cpp
+++ b/test/test_xrandom.cpp
@@ -186,6 +186,16 @@ namespace xt
         ASSERT_TRUE(all(isin(ac1, a)));
         ASSERT_TRUE(all(equal(ac1 % 2, 1)));
 
+        xt::random::seed(42);
+        auto acr1 = xt::random::choice(a, 6, w, false);
+        auto acr2 = xt::random::choice(a, 6, w, false);
+        xt::random::seed(42);
+        auto acr3 = xt::random::choice(a, 6, w, false);
+        ASSERT_EQ(acr1, acr3);
+        ASSERT_NE(acr1, acr2);
+        ASSERT_TRUE(all(isin(acr1, a)));
+        ASSERT_TRUE(all(equal(acr1 % 2, 1)));
+
         xarray<double> b = {-1, 1};
         xarray<double> v = {1, 1};
         xt::random::seed(42);


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

Close #2213. This add an overload to `xt::random::choice` that takes as an extra argument an (unormalized) probability vector.

- I have added inline documentation but did not manage to see if it rendered properly since it appears to be broken #2242.
- There are currently no check that the weight vector is positive, although it is required, since I figured it would be unnecessarily costly. Is there a macro that could be relevant to use here `XTENSOR_ASSERT` maybe?