### PR TITLE
Drop support of 3.* Clang versions

### DIFF
--- a/docs/source/compilers.rst
+++ b/docs/source/compilers.rst
@@ -70,6 +70,8 @@ Workarounds for this compiler bug arise in various files of the code base.
 Everywhere, the handling of `Clang < 3.8` is wrapped with checks for the
 ``X_OLD_CLANG`` macro.
 
+The support of `Clang < 4.0` is dropped in xtensor 0.22.
+
 GCC < 5.1 and ``std::is_trivially_default_constructible``
 ---------------------------------------------------------
 

--- a/include/xtensor/xadapt.hpp
+++ b/include/xtensor/xadapt.hpp
@@ -396,21 +396,12 @@ namespace xt
         return return_type(buffer_type(pointer, detail::fixed_compute_size<fixed_shape<X...>>::value));
     }
 
-#ifndef X_OLD_CLANG
     template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class C, class T,  std::size_t N>
     inline auto adapt(C&& ptr, const T(&shape)[N])
     {
         using shape_type = std::array<std::size_t, N>;
         return adapt(std::forward<C>(ptr), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
-#else
-    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class C>
-    inline auto adapt(C&& ptr, std::initializer_list<std::size_t> shape)
-    {
-        using shape_type = xt::dynamic_shape<std::size_t>;
-        return adapt(std::forward<C>(ptr), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
-    }
-#endif
 
     /*****************************
      * smart_ptr adapter builder *
@@ -514,7 +505,6 @@ namespace xt
         );
     }
 
-#ifndef X_OLD_CLANG
     /**
      * Adapt a smart pointer to a typed memory block (unique_ptr or shared_ptr)
      *
@@ -608,7 +598,6 @@ namespace xt
             l
         );
     }
-#endif
 }
 
 #endif

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -38,13 +38,8 @@ namespace xt
     template <class E, class S>
     auto broadcast(E&& e, const S& s);
 
-#ifdef X_OLD_CLANG
-    template <class E, class I>
-    auto broadcast(E&& e, std::initializer_list<I> s);
-#else
     template <class E, class I, std::size_t L>
     auto broadcast(E&& e, const I (&s)[L]);
-#endif
 
     /*************************
      * xbroadcast extensions *
@@ -243,15 +238,6 @@ namespace xt
         return broadcast_type(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(s)>(s));
     }
 
-#ifdef X_OLD_CLANG
-    template <class E, class I>
-    inline auto broadcast(E&& e, std::initializer_list<I> s)
-    {
-        using broadcast_type = xbroadcast<const_xclosure_t<E>, std::vector<std::size_t>>;
-        using shape_type = typename broadcast_type::shape_type;
-        return broadcast_type(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(s)>(s));
-    }
-#else
     template <class E, class I, std::size_t L>
     inline auto broadcast(E&& e, const I (&s)[L])
     {
@@ -259,7 +245,6 @@ namespace xt
         using shape_type = typename broadcast_type::shape_type;
         return broadcast_type(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(s)>(s));
     }
-#endif
 
     /*****************************
      * xbroadcast implementation *

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -21,9 +21,6 @@
 #include <functional>
 #include <utility>
 #include <vector>
-#ifdef X_OLD_CLANG
-    #include <initializer_list>
-#endif
 
 #include <xtl/xclosure.hpp>
 #include <xtl/xsequence.hpp>
@@ -51,19 +48,11 @@ namespace xt
         return broadcast(T(1), std::forward<S>(shape));
     }
 
-#ifdef X_OLD_CLANG
-    template <class T, class I>
-    inline auto ones(std::initializer_list<I> shape) noexcept
-    {
-        return broadcast(T(1), shape);
-    }
-#else
     template <class T, class I, std::size_t L>
     inline auto ones(const I (&shape)[L]) noexcept
     {
         return broadcast(T(1), shape);
     }
-#endif
 
     /*********
      * zeros *
@@ -79,19 +68,11 @@ namespace xt
         return broadcast(T(0), std::forward<S>(shape));
     }
 
-#ifdef X_OLD_CLANG
-    template <class T, class I>
-    inline auto zeros(std::initializer_list<I> shape) noexcept
-    {
-        return broadcast(T(0), shape);
-    }
-#else
     template <class T, class I, std::size_t L>
     inline auto zeros(const I (&shape)[L]) noexcept
     {
         return broadcast(T(0), shape);
     }
-#endif
 
     /**
      * Create a xcontainer (xarray, xtensor or xtensor_fixed) with uninitialized values of
@@ -117,20 +98,12 @@ namespace xt
         return xtensor<T, N, L>(xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
 
-#ifndef X_OLD_CLANG
     template <class T, layout_type L = XTENSOR_DEFAULT_LAYOUT, class I, std::size_t N>
     inline xtensor<T, N, L> empty(const I(&shape)[N])
     {
         using shape_type = typename xtensor<T, N>::shape_type;
         return xtensor<T, N, L>(xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
-#else
-    template <class T, layout_type L = XTENSOR_DEFAULT_LAYOUT, class I>
-    inline xarray<T, L> empty(const std::initializer_list<I>& init)
-    {
-        return xarray<T, L>::from_shape(init);
-    }
-#endif
 
     template <class T, layout_type L = XTENSOR_DEFAULT_LAYOUT, std::size_t... N>
     inline xtensor_fixed<T, fixed_shape<N...>, L> empty(const fixed_shape<N...>& /*shape*/)
@@ -900,7 +873,7 @@ namespace xt
         template <std::size_t... I, class... E>
         inline auto meshgrid_impl(std::index_sequence<I...>, E&&... e) noexcept
         {
-#if defined X_OLD_CLANG || defined _MSC_VER
+#if defined _MSC_VER
             const std::array<std::size_t, sizeof...(E)> shape = {e.shape()[0]...};
             return std::make_tuple(
                 detail::make_xgenerator(

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -484,15 +484,6 @@ namespace xt
 
     namespace detail
     {
-#ifdef X_OLD_CLANG
-        template <class Functor, class I>
-        inline auto make_xgenerator(Functor&& f, std::initializer_list<I> shape) noexcept
-        {
-            using shape_type = std::vector<std::size_t>;
-            using type = xgenerator<Functor, typename Functor::value_type, shape_type>;
-            return type(std::forward<Functor>(f), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
-        }
-#else
         template <class Functor, class I, std::size_t L>
         inline auto make_xgenerator(Functor&& f, const I (&shape)[L]) noexcept
         {
@@ -500,7 +491,6 @@ namespace xt
             using type = xgenerator<Functor, typename Functor::value_type, shape_type>;
             return type(std::forward<Functor>(f), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
         }
-#endif
 
         template <class Functor, class S>
         inline auto make_xgenerator(Functor&& f, S&& shape) noexcept

--- a/include/xtensor/xindex_view.hpp
+++ b/include/xtensor/xindex_view.hpp
@@ -753,26 +753,13 @@ namespace xt
         using view_type = xindex_view<xclosure_t<E>, std::decay_t<I>>;
         return view_type(std::forward<E>(e), std::forward<I>(indices));
     }
-#ifdef X_OLD_CLANG
-    template <class E, class I>
-    inline auto index_view(E&& e, std::initializer_list<std::initializer_list<I>> indices) noexcept
-    {
-        std::vector<xindex> idx;
-        for (auto it = indices.begin(); it != indices.end(); ++it)
-        {
-            idx.emplace_back(xindex(it->begin(), it->end()));
-        }
-        using view_type = xindex_view<xclosure_t<E>, std::vector<xindex>>;
-        return view_type(std::forward<E>(e), std::move(idx));
-    }
-#else
+
     template <class E, std::size_t L>
     inline auto index_view(E&& e, const xindex (&indices)[L]) noexcept
     {
         using view_type = xindex_view<xclosure_t<E>, std::array<xindex, L>>;
         return view_type(std::forward<E>(e), to_array(indices));
     }
-#endif
 
     /**
      * @brief creates a view into \a e filtered by \a condition.

--- a/include/xtensor/xmanipulation.hpp
+++ b/include/xtensor/xmanipulation.hpp
@@ -238,20 +238,11 @@ namespace xt
     }
 
     /// @cond DOXYGEN_INCLUDE_SFINAE
-#ifdef X_OLD_CLANG
-    template <class E, class I, class Tag = check_policy::none>
-    inline auto transpose(E&& e, std::initializer_list<I> permutation, Tag check_policy = Tag())
-    {
-        dynamic_shape<I> perm(permutation);
-        return detail::transpose_impl(std::forward<E>(e), std::move(perm), check_policy);
-    }
-#else
     template <class E, class I, std::size_t N, class Tag = check_policy::none>
     inline auto transpose(E&& e, const I(&permutation)[N], Tag check_policy = Tag())
     {
         return detail::transpose_impl(std::forward<E>(e), permutation, check_policy);
     }
-#endif
     /// @endcond
 
     /************************************
@@ -449,21 +440,12 @@ namespace xt
     }
 
     /// @cond DOXYGEN_INCLUDE_SFINAE
-#ifdef X_OLD_CLANG
-    template <class E, class I, class Tag = check_policy::none>
-    inline auto squeeze(E&& e, std::initializer_list<I> axis, Tag check_policy = Tag())
-    {
-        dynamic_shape<I> ax(axis);
-        return detail::squeeze_impl(std::forward<E>(e), std::move(ax), check_policy);
-    }
-#else
     template <class E, class I, std::size_t N, class Tag = check_policy::none>
     inline auto squeeze(E&& e, const I(&axis)[N], Tag check_policy = Tag())
     {
         using arr_t = std::array<I, N>;
         return detail::squeeze_impl(std::forward<E>(e), xtl::forward_sequence<arr_t, decltype(axis)>(axis), check_policy);
     }
-#endif
 
     template <class E, class Tag = check_policy::none>
     inline auto squeeze(E&& e, std::size_t axis, Tag check_policy = Tag())

--- a/include/xtensor/xnorm.hpp
+++ b/include/xtensor/xnorm.hpp
@@ -348,17 +348,6 @@ namespace xt
      * norm functions for xexpressions *
      ***********************************/
 
-#ifdef X_OLD_CLANG
-#define XTENSOR_NORM_FUNCTION_AXES(NAME)                                              \
-    template <class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>                \
-    inline auto NAME(E&& e, std::initializer_list<I> axes, EVS es = EVS()) noexcept   \
-    {                                                                                 \
-        using axes_type = std::vector<typename std::decay_t<E>::size_type>;           \
-        return NAME(std::forward<E>(e),                                               \
-                xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);          \
-    }
-
-#else
 #define XTENSOR_NORM_FUNCTION_AXES(NAME)                                              \
     template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS> \
     inline auto NAME(E&& e, const I(&axes)[N], EVS es = EVS()) noexcept               \
@@ -367,7 +356,6 @@ namespace xt
         return NAME(std::forward<E>(e),                                               \
                 xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);          \
     }
-#endif
 
     namespace detail
     {
@@ -503,21 +491,12 @@ namespace xt
         return sqrt(norm_sq(std::forward<E>(e), std::forward<X>(axes), es));
     }
 
-#ifdef X_OLD_CLANG
-    template <class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>
-    inline auto norm_l2(E&& e, std::initializer_list<I> axes, EVS es = EVS()) noexcept
-    {
-        using axes_type = std::vector<typename std::decay_t<E>::size_type>;
-        return sqrt(norm_sq(std::forward<E>(e), xtl::forward_sequence<axes_type, decltype(axes)>(axes), es));
-    }
-#else
     template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
     inline auto norm_l2(E&& e, const I (&axes)[N], EVS es = EVS()) noexcept
     {
         using axes_type = std::array<typename std::decay_t<E>::size_type, N>;
         return sqrt(norm_sq(std::forward<E>(e), xtl::forward_sequence<axes_type, decltype(axes)>(axes), es));
     }
-#endif
 
     /**
      * @ingroup red_functions
@@ -567,21 +546,12 @@ namespace xt
         return norm_lp_to_p(std::forward<E>(e), p, arange(e.dimension()), es);
     }
 
-#ifdef X_OLD_CLANG
-    template <class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>
-    inline auto norm_lp_to_p(E&& e, double p, std::initializer_list<I> axes, EVS es = EVS()) noexcept
-    {
-        using axes_type = std::vector<typename std::decay_t<E>::size_type>;
-        return norm_lp_to_p(std::forward<E>(e), p, xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);
-    }
-#else
     template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
     inline auto norm_lp_to_p(E&& e, double p, const I (&axes)[N], EVS es = EVS()) noexcept
     {
         using axes_type = std::array<typename std::decay_t<E>::size_type, N>;
         return norm_lp_to_p(std::forward<E>(e), p, xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);
     }
-#endif
 
     /**
      * @ingroup red_functions
@@ -612,21 +582,12 @@ namespace xt
         return norm_lp(std::forward<E>(e), p, arange(e.dimension()), es);
     }
 
-#ifdef X_OLD_CLANG
-    template <class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>
-    inline auto norm_lp(E&& e, double p, std::initializer_list<I> axes, EVS es = EVS())
-    {
-        using axes_type = std::vector<typename std::decay_t<E>::size_type>;
-        return norm_lp(std::forward<E>(e), p, xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);
-    }
-#else
     template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
     inline auto norm_lp(E&& e, double p, const I (&axes)[N], EVS es = EVS())
     {
         using axes_type = std::array<typename std::decay_t<E>::size_type, N>;
         return norm_lp(std::forward<E>(e), p, xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);
     }
-#endif
 
     /**
      * @ingroup red_functions

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -101,75 +101,7 @@ namespace xt
         template <class T, class S, class E = random::default_engine_type>
         auto student_t(const S& shape, T n = 1.0,
                        E& engine = random::get_default_random_engine());
-#ifdef X_OLD_CLANG
-        template <class T, class I, class E = random::default_engine_type>
-        auto rand(std::initializer_list<I> shape, T lower = 0, T upper = 1,
-                  E& engine = random::get_default_random_engine());
 
-        template <class T, class I, class E = random::default_engine_type>
-        auto randint(std::initializer_list<I> shape,
-                     T lower = 0, T upper = (std::numeric_limits<T>::max)(),
-                     E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class E = random::default_engine_type>
-        auto randn(std::initializer_list<I> shape, 
-                   T mean = 0, T std_dev = 1,
-                   E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class D = double, class E = random::default_engine_type>
-        auto binomial(std::initializer_list<I> shape, 
-                      T trials = 1, D prob = 0.5,
-                      E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class D = double, class E = random::default_engine_type>
-        auto geometric(std::initializer_list<I> shape, D prob = 0.5, 
-                      E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class D = double, class E = random::default_engine_type>
-        auto negative_binomial(std::initializer_list<I> shape, T k = 1, D prob = 0.5,
-                               E& engine = random::get_default_random_engine()); 
-
-        template <class T, class I, class D = double, class E = random::default_engine_type>
-        auto poisson(std::initializer_list<I> shape, D rate = 1.0, 
-                     E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class E = random::default_engine_type>
-        auto exponential(std::initializer_list<I> shape, T rate = 1.0, 
-                         E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class E = random::default_engine_type>
-        auto gamma(std::initializer_list<I> shape, T alpha = 1.0, T beta = 1.0,
-                   E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class E = random::default_engine_type>
-        auto weibull(std::initializer_list<I> shape, T a = 1.0, T b = 1.0,
-                     E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class E = random::default_engine_type>
-        auto extreme_value(std::initializer_list<I> shape, T a = 0.0, T b = 1.0,
-                           E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class E = random::default_engine_type>
-        auto lognormal(std::initializer_list<I> shape, 
-                       T mean = 0, T std_dev = 1.0,
-                       E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class E = random::default_engine_type>
-        auto chi_squared(std::initializer_list<I> shape, T deg = 1.0,
-                         E& engine = random::get_default_random_engine());  
-
-        template <class T, class I, class E = random::default_engine_type>
-        auto cauchy(std::initializer_list<I> shape, T a = 0.0, T b = 1.0,
-                    E& engine = random::get_default_random_engine());
-
-        template <class T, class I, class E = random::default_engine_type>
-        auto fisher_f(std::initializer_list<I> shape, T m = 1.0, T n = 1.0,
-                      E& engine = random::get_default_random_engine());
-
-        template < class T, class I, class E = random::default_engine_type>
-        auto student_t(std::initializer_list<I> shape, T n = 1.0,
-                       E& engine = random::get_default_random_engine());
-#else
         template <class T, class I, std::size_t L, class E = random::default_engine_type>
         auto rand(const I (&shape)[L], T lower = 0, T upper = 1,
                   E& engine = random::get_default_random_engine());
@@ -233,7 +165,6 @@ namespace xt
         template <class T, class I, std::size_t L, class E = random::default_engine_type>
         auto student_t(const I (&shape)[L], T n = 1.0,
                        E& engine = random::get_default_random_engine());
-#endif
 
         template <class T, class E = random::default_engine_type>
         void shuffle(xexpression<T>& e, E& engine = random::get_default_random_engine());
@@ -619,119 +550,7 @@ namespace xt
             std::student_t_distribution<T> dist(n);
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
-#ifdef X_OLD_CLANG
-        template <class T, class I, class E>
-        inline auto rand(std::initializer_list<I> shape, T lower, T upper, E& engine)
-        {
-            std::uniform_real_distribution<T> dist(lower, upper);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
 
-        template <class T, class I, class E>
-        inline auto randint(std::initializer_list<I> shape, T lower, T upper, E& engine)
-        {
-            std::uniform_int_distribution<T> dist(lower, T(upper - 1));
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-
-        template <class T, class I, class E>
-        inline auto randn(std::initializer_list<I> shape, T mean, T std_dev, E& engine)
-        {
-            std::normal_distribution<T> dist(mean, std_dev);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-
-        template <class T, class I, class D, class E>
-        inline auto binomial(std::initializer_list<I> shape, T trials, D prob, E& engine)
-        {
-            std::binomial_distribution<T> dist(trials, prob);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-
-        template <class T, class I, class D, class E>
-        inline auto geometric(std::initializer_list<I> shape, D prob, E& engine)
-        {
-            std::geometric_distribution<T> dist(prob);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-        
-        template <class T, class I, class D, class E>
-        inline auto negative_binomial(std::initializer_list<I> shape, T k, D prob, E& engine)
-        {
-            std::negative_binomial_distribution<T> dist(k, prob);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
-        }
-
-        template <class T, class I, class D, class E>
-        inline auto poisson(std::initializer_list<I> shape, D rate, E& engine)
-        {
-            std::poisson_distribution<T> dist(rate);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
-        }
-
-        template <class T, class I, class E>
-        inline auto exponential(std::initializer_list<I> shape, T rate, E& engine)
-        {
-            std::exponential_distribution<T> dist(rate);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
-        }
-
-        template <class T, class I, class E>
-        inline auto gamma(std::initializer_list<I> shape, T alpha, T beta, E& engine)
-        {
-            std::gamma_distribution<T> dist(alpha, beta);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-
-        template <class T, class I, class E>
-        inline auto weibull(std::initializer_list<I> shape, T a, T b, E& engine)
-        {
-            std::weibull_distribution<T> dist(a, b);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-
-        template <class T, class I, class E>
-        inline auto extreme_value(std::initializer_list<I> shape, T a, T b, E& engine)
-        {
-            std::extreme_value_distribution<T> dist(a, b);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-
-        template <class T, class I, class E>
-        inline auto lognormal(std::initializer_list<I> shape, T mean, T std_dev, E& engine)
-        {
-            std::lognormal_distribution<T> dist(mean, std_dev);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-
-        template <class T, class I, class E>
-        inline auto chi_squared(std::initializer_list<I> shape, T deg, E& engine)
-        {
-            std::chi_squared_distribution<T> dist(deg);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-
-        template <class T, class I, class E>
-        inline auto cauchy(std::initializer_list<I> shape, T a, T b, E& engine)
-        {
-            std::cauchy_distribution<T> dist(a, b);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-
-        template <class T, class I, class E>
-        inline auto fisher_f(std::initializer_list<I> shape, T m, T n, E& engine)
-        {
-            std::fisher_f_distribution<T> dist(m, n);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-
-        template <class T, class I, class E>
-        inline auto student_t(std::initializer_list<I> shape, T n, E& engine)
-        {
-            std::student_t_distribution<T> dist(n);
-            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
-        }
-#else
         template <class T, class I, std::size_t L, class E>
         inline auto rand(const I (&shape)[L], T lower, T upper, E& engine)
         {
@@ -843,7 +662,6 @@ namespace xt
             std::student_t_distribution<T> dist(n);
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
-#endif
 
         /**
          * Randomly shuffle elements inplace in xcontainer along first axis.

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -18,9 +18,6 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
-#ifdef X_OLD_CLANG
-#include <vector>
-#endif
 
 #include <xtl/xfunctional.hpp>
 #include <xtl/xsequence.hpp>
@@ -883,24 +880,6 @@ namespace xt
         return reduce(make_xreducer_functor(std::forward<F>(f)), std::forward<E>(e), std::forward<EVS>(options));
     }
 
-#ifdef X_OLD_CLANG
-    template <class F, class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS,
-              XTL_REQUIRES(detail::is_xreducer_functors<F>)>
-    inline auto reduce(F&& f, E&& e, std::initializer_list<I> axes, EVS options = EVS())
-    {
-        using axes_type = std::vector<std::size_t>;
-        auto ax = xt::forward_normalize<axes_type>(e, axes);
-        return detail::reduce_impl(std::forward<F>(f), std::forward<E>(e), std::move(ax),
-                                   typename reducer_options<int, EVS>::evaluation_strategy{},
-                                   options);
-    }
-    template <class F, class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS,
-              XTL_REQUIRES(xtl::negation<detail::is_xreducer_functors<F>>)>
-    inline auto reduce(F&& f, E&& e, std::initializer_list<I> axes, EVS options = EVS())
-    {
-        return reduce(make_xreducer_functor(std::forward<F>(f)), std::forward<E>(e), axes, options);
-    }
-#else
     template <class F, class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS,
               XTL_REQUIRES(detail::is_xreducer_functors<F>)>
     inline auto reduce(F&& f, E&& e, const I (&axes)[N], EVS options = EVS())
@@ -917,7 +896,6 @@ namespace xt
     {
         return reduce(make_xreducer_functor(std::forward<F>(f)), std::forward<E>(e), axes, options);
     }
-#endif
 
     /********************
      * xreducer_stepper *

--- a/include/xtensor/xsort.hpp
+++ b/include/xtensor/xsort.hpp
@@ -431,19 +431,11 @@ namespace xt
         return ev;
     }
 
-#ifdef X_OLD_CLANG
-    template <class E, class I, class R = detail::flatten_sort_result_type_t<E>>
-    inline R partition(const xexpression<E>& e, std::initializer_list<I> kth_container, placeholders::xtuph tag)
-    {
-        return partition(e, xtl::forward_sequence<std::vector<std::size_t>, decltype(kth_container)>(kth_container), tag);
-    }
-#else
     template <class E, class I, std::size_t N, class R = detail::flatten_sort_result_type_t<E>>
     inline R partition(const xexpression<E>& e, const I(&kth_container)[N], placeholders::xtuph tag)
     {
         return partition(e, xtl::forward_sequence<std::array<std::size_t, N>, decltype(kth_container)>(kth_container), tag);
     }
-#endif
 
     template <class E, class R = detail::flatten_sort_result_type_t<E>>
     inline R partition(const xexpression<E>& e, std::size_t kth, placeholders::xtuph tag)
@@ -507,19 +499,12 @@ namespace xt
         return res;
     }
 
-#ifdef X_OLD_CLANG
-    template <class E, class I>
-    inline auto partition(const xexpression<E>& e, std::initializer_list<I> kth_container, std::ptrdiff_t axis = -1)
-    {
-        return partition(e, xtl::forward_sequence<std::vector<std::size_t>, decltype(kth_container)>(kth_container), axis);
-    }
-#else
     template <class E, class T, std::size_t N>
     inline auto partition(const xexpression<E>& e, const T(&kth_container)[N], std::ptrdiff_t axis = -1)
     {
         return partition(e, xtl::forward_sequence<std::array<std::size_t, N>, decltype(kth_container)>(kth_container), axis);
     }
-#endif
+
     template <class E>
     inline auto partition(const xexpression<E>& e, std::size_t kth, std::ptrdiff_t axis = -1)
     {
@@ -586,19 +571,11 @@ namespace xt
         return ev;
     }
 
-#ifdef X_OLD_CLANG
-    template <class E, class I>
-    inline auto argpartition(const xexpression<E>& e, std::initializer_list<I> kth_container, placeholders::xtuph tag)
-    {
-        return argpartition(e, xtl::forward_sequence<std::vector<std::size_t>, decltype(kth_container)>(kth_container), tag);
-    }
-#else
     template <class E, class I, std::size_t N>
     inline auto argpartition(const xexpression<E>& e, const I(&kth_container)[N], placeholders::xtuph tag)
     {
         return argpartition(e, xtl::forward_sequence<std::array<std::size_t, N>, decltype(kth_container)>(kth_container), tag);
     }
-#endif
 
     template <class E>
     inline auto argpartition(const xexpression<E>& e, std::size_t kth, placeholders::xtuph tag)
@@ -708,19 +685,11 @@ namespace xt
         return res;
     }
 
-#ifdef X_OLD_CLANG
-    template <class E, class I>
-    inline auto argpartition(const xexpression<E>& e, std::initializer_list<I> kth_container, std::ptrdiff_t axis = -1)
-    {
-        return argpartition(e, xtl::forward_sequence<std::vector<std::size_t>, decltype(kth_container)>(kth_container), axis);
-    }
-#else
     template <class E, class I, std::size_t N>
     inline auto argpartition(const xexpression<E>& e, const I(&kth_container)[N], std::ptrdiff_t axis = -1)
     {
         return argpartition(e, xtl::forward_sequence<std::array<std::size_t, N>, decltype(kth_container)>(kth_container), axis);
     }
-#endif
 
     template <class E>
     inline auto argpartition(const xexpression<E>& e, std::size_t kth, std::ptrdiff_t axis = -1)

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -698,7 +698,6 @@ namespace xt
         return reshape_view<L>(std::forward<E>(e), std::forward<S>(shape));
     }
 
-#if !defined(X_OLD_CLANG)
     template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E, class I, std::size_t N>
     inline auto reshape_view(E&& e, const I(&shape)[N], layout_type order)
     {
@@ -712,21 +711,6 @@ namespace xt
         using shape_type = std::array<std::size_t, N>;
         return reshape_view<L>(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
-#else
-    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E, class I>
-    inline auto reshape_view(E&& e, const std::initializer_list<I>& shape)
-    {
-        using shape_type = xt::dynamic_shape<std::size_t>;
-        return reshape_view<L>(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
-    }
-
-    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E, class I>
-    inline auto reshape_view(E&& e, const std::initializer_list<I>& shape, layout_type order)
-    {
-        using shape_type = xt::dynamic_shape<std::size_t>;
-        return reshape_view<L>(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape), order);
-    }
-#endif
 }
 
 #endif

--- a/include/xtensor/xtensor_config.hpp
+++ b/include/xtensor/xtensor_config.hpp
@@ -14,14 +14,6 @@
 #define XTENSOR_VERSION_MINOR 21
 #define XTENSOR_VERSION_PATCH 10
 
-// DETECT 3.6 <= clang < 3.8 for compiler bug workaround.
-#ifdef __clang__
-    #if __clang_major__ == 3 && __clang_minor__ < 8
-        #define X_OLD_CLANG
-        #include <initializer_list>
-        #include <vector>
-    #endif
-#endif
 
 // Define if the library is going to be using exceptions.
 #if (!defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND))

--- a/test/test_xadapt.cpp
+++ b/test/test_xadapt.cpp
@@ -385,15 +385,11 @@ namespace xt
     TEST(xtensor_adaptor, nice_syntax)
     {
         std::vector<int> a({1,2,3,4,5,6,7,8});
-#ifndef X_OLD_CLANG
+
         auto xa = adapt(&a[0], {2, 4});
         bool truthy = std::is_same<decltype(xa)::shape_type, std::array<std::size_t, 2>>::value;
         EXPECT_TRUE(truthy);
-#else
-        auto xa = adapt(&a[0], {2, 4});
-        bool truthy = std::is_same<decltype(xa)::shape_type, xt::dynamic_shape<size_t>>::value;
-        EXPECT_TRUE(truthy);
-#endif
+
         xa(0, 0) = 100;
         xa(1, 3) = 1000;
         EXPECT_EQ(a[0], 100);
@@ -466,7 +462,6 @@ namespace xt
         }
     }
 
-#ifndef X_OLD_CLANG
     TEST(xtensor_adaptor, smart_ptr)
     {
         auto data = std::vector<double>{1,2,3,4,5,6,7,8};
@@ -501,5 +496,4 @@ namespace xt
             auto obj = adapt_smart_ptr(unique_buf.get()->buf.data(), {2, 4}, std::move(unique_buf));
         }
     }
-#endif
 }

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -651,14 +651,13 @@ namespace xt
     {
 
         bool b = false;
-    #ifndef X_OLD_CLANG
+
         auto e1 = empty<double>({3, 4, 1});
         b = std::is_same<decltype(e1), xtensor<double, 3>>::value;
         EXPECT_TRUE(b);
         b = std::is_same<decltype(empty<int, layout_type::column_major>({3,3,3})),
                          xtensor<int, 3, layout_type::column_major>>::value;
         EXPECT_TRUE(b);
-    #endif
 
         auto es = empty<double>(std::array<std::size_t, 3>{3, 4, 1});
         b = std::is_same<decltype(es), xtensor<double, 3>>::value;

--- a/test/test_xeval.cpp
+++ b/test/test_xeval.cpp
@@ -54,10 +54,8 @@ namespace xt
         bool type_eq_3 = std::is_same<decltype(n), xtensor<int, 2>&&>::value;
         EXPECT_TRUE(type_eq_3);
 
-#ifndef X_OLD_CLANG
         auto&& i = eval(linspace(0, 100));
         bool type_eq_2 = std::is_same<decltype(i), xtensor<int, 1>&&>::value;
         EXPECT_TRUE(type_eq_2);
-#endif
     }
 }

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -373,9 +373,7 @@ namespace xt
             return istrue;
         };
 
-    #ifndef X_OLD_CLANG
         EXPECT_TRUE(is_arr(xa.shape()));
-    #endif
 
         xtensor<double, 3> a;
         a.resize({3, 3, 3});
@@ -394,10 +392,8 @@ namespace xt
         auto a_gd_2 = sum(a, {0, 2}, evaluation_strategy::immediate);
         EXPECT_EQ(a_lz, a_gd_2);
 
-    #ifndef X_OLD_CLANG
         EXPECT_TRUE(is_arr(a_gd_1.shape()));
         EXPECT_TRUE(is_arr(a_gd_2.shape()));
-    #endif
 
         a_lz = sum(a, {1, 2});
         a_gd_2 = sum(a, {1, 2}, evaluation_strategy::immediate);
@@ -438,10 +434,8 @@ namespace xt
         EXPECT_EQ(b_gd_2, a_gd_2);
         EXPECT_EQ(a_gd_2.dimension(), std::size_t(1));
 
-    #ifndef X_OLD_CLANG
         // EXPECT_TRUE(is_arr(a_gd_1.shape()));
         EXPECT_TRUE(is_arr(a_gd_2.shape()));
-    #endif
 
         a_lz = sum(a, {1, 2});
         a_gd_2 = sum(a, {1, 2}, evaluation_strategy::immediate);
@@ -551,17 +545,10 @@ namespace xt
     {
         xt::xtensor<double, 4> a = xt::reshape_view(xt::arange<double>(5 * 5 * 5 * 5), {5, 5, 5, 5});
 
-    #ifndef X_OLD_CLANG
         auto res = xt::sum(a, {0, 1}, xt::keep_dims | xt::evaluation_strategy::immediate);   
         EXPECT_EQ(res.shape(), (std::array<std::size_t, 4>{1, 1, 5, 5}));
         auto res2 = xt::sum(a, {0, 1}, xt::keep_dims);   
         EXPECT_EQ(res2.shape(), (std::array<std::size_t, 4>{1, 1, 5, 5}));
-    #else
-        auto res = xt::sum(a, {0, 1}, xt::keep_dims | xt::evaluation_strategy::immediate);   
-        EXPECT_EQ(res.shape(), (xt::dynamic_shape<std::size_t>{1, 1, 5, 5}));
-        auto res2 = xt::sum(a, {0, 1}, xt::keep_dims);   
-        EXPECT_EQ(res2.shape(), (xt::dynamic_shape<std::size_t>{1, 1, 5, 5}));
-    #endif
 
         xt::xarray<double> b = a;
         auto res3 = xt::sum(b, {0, 1}, xt::keep_dims | xt::evaluation_strategy::immediate);   

--- a/test/test_xstrided_view.cpp
+++ b/test/test_xstrided_view.cpp
@@ -696,12 +696,10 @@ namespace xt
         truthy = std::is_same<typename decltype(xv)::temporary_type, xtensor_fixed<double, xshape<3, 3>, XTENSOR_DEFAULT_LAYOUT>>();
         EXPECT_TRUE(truthy);
 
-#if !defined(X_OLD_CLANG)
         truthy = std::is_same<typename decltype(av)::temporary_type, xtensor<double, 2, XTENSOR_DEFAULT_LAYOUT>>();
         EXPECT_TRUE(truthy);
         truthy = std::is_same<typename decltype(av)::shape_type, typename decltype(e)::shape_type>::value;
         EXPECT_TRUE(truthy);
-#endif
 
         xarray<int> xa = {{1, 2, 3}, {4, 5, 6}};
         std::vector<std::size_t> new_shape = {3, 2};


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Proposition to drop support of Clang 3.* versions by removing patches specific to these compiler versions since they are not part of the [build matrix](https://github.com/xtensor-stack/xtensor/blob/master/.azure-pipelines/azure-pipelines-linux-clang.yml) anymore.

The changes made include:
- `OLD_CLANG`s pre processor definitions are removed
- Dedicated tests are removed
- `Reducer` macro is unified
- Documentation about Clang (compilers section) is updated

# Discussion

During refactoring, I noticed the `XTENSOR_NAN_REDUCER_FUNCTION` defined [here](https://github.com/xtensor-stack/xtensor/blob/2ed3b10afe9f5d16246aae4ddbfae6c35b2ff973/include/xtensor/xmath.hpp#L2419) is not used. The `XTENSOR_REDUCER_FUNCTION` is used instead (see [`nansum`](https://github.com/xtensor-stack/xtensor/blob/2ed3b10afe9f5d16246aae4ddbfae6c35b2ff973/include/xtensor/xmath.hpp#L2472) and [`nanprod`](https://github.com/xtensor-stack/xtensor/blob/2ed3b10afe9f5d16246aae4ddbfae6c35b2ff973/include/xtensor/xmath.hpp#L2490)).

Should we also drop this unused declaration?