### PR TITLE
Fix binary operators on complex

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -37,7 +37,7 @@ jobs:
           conda install cmake==3.14.0 ^
                         ninja ^
                         nlohmann_json ^
-                        xtl==0.6.21 ^
+                        xtl==0.6.22 ^
                         xsimd==7.4.8 ^
                         python=3.6
           conda list

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - cmake
-  - xtl=0.6.21
+  - xtl=0.6.22
   - xsimd=7.4.8
   - nlohmann_json

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -43,12 +43,21 @@ namespace xt
         }                                                                       \
     }
 
+#define DEFINE_COMPLEX_OVERLOAD(OP)                                                       \
+template <class T1, class T2, XTL_REQUIRES(xtl::negation<std::is_same<T1, T2>>)>          \
+constexpr auto operator OP(const std::complex<T1>& arg1, const std::complex<T2>& arg2)    \
+{                                                                                         \
+    using result_type = typename xtl::promote_type_t<std::complex<T1>, std::complex<T2>>; \
+    return (result_type(arg1) OP result_type(arg2));                                      \
+}
+
 #define BINARY_OPERATOR_FUNCTOR(NAME, OP)                                        \
     struct NAME                                                                  \
     {                                                                            \
         template <class T1, class T2>                                            \
         constexpr auto operator()(T1&& arg1, T2&& arg2) const                    \
         {                                                                        \
+            using xt::detail::operator OP;                                       \
             return (std::forward<T1>(arg1) OP std::forward<T2>(arg2));           \
         }                                                                        \
         template <class B>                                                       \
@@ -60,6 +69,24 @@ namespace xt
 
     namespace detail
     {
+        DEFINE_COMPLEX_OVERLOAD(+);
+        DEFINE_COMPLEX_OVERLOAD(-);
+        DEFINE_COMPLEX_OVERLOAD(*);
+        DEFINE_COMPLEX_OVERLOAD(/);
+        DEFINE_COMPLEX_OVERLOAD(%);
+        DEFINE_COMPLEX_OVERLOAD(||);
+        DEFINE_COMPLEX_OVERLOAD(&&);
+        DEFINE_COMPLEX_OVERLOAD(|);
+        DEFINE_COMPLEX_OVERLOAD(&);
+        DEFINE_COMPLEX_OVERLOAD(^);
+        DEFINE_COMPLEX_OVERLOAD(<<);
+        DEFINE_COMPLEX_OVERLOAD(>>);
+        DEFINE_COMPLEX_OVERLOAD(<);
+        DEFINE_COMPLEX_OVERLOAD(<=);
+        DEFINE_COMPLEX_OVERLOAD(>);
+        DEFINE_COMPLEX_OVERLOAD(>=);
+        DEFINE_COMPLEX_OVERLOAD(==);
+        DEFINE_COMPLEX_OVERLOAD(!=);
 
         UNARY_OPERATOR_FUNCTOR(identity, +);
         UNARY_OPERATOR_FUNCTOR(negate, -);

--- a/test/test_xmath_result_type.cpp
+++ b/test/test_xmath_result_type.cpp
@@ -241,8 +241,6 @@ namespace xt
         CHECK_RESULT_TYPE(adouble + aint, double);
         CHECK_RESULT_TYPE(adouble + adcomplex, std::complex<double>);
         CHECK_RESULT_TYPE(aulong + adouble, double);
+        CHECK_RESULT_TYPE(afcomplex + adcomplex, std::complex<double>);
     }
-
-
 }
-


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

The binary operators operating on `std::complex` of different base types (e.g. `std::complex<float>` and `std::complex<double>`) are not working.

This PR provides overloading of operators for this case. A unit test of *plus* operator between mixed complex types is also implemented.

# Discussion

Do we need to implement tests for all binary operators?