### PR TITLE
Fix reducers assignment

### DIFF
--- a/docs/source/compilers.rst
+++ b/docs/source/compilers.rst
@@ -70,7 +70,13 @@ Workarounds for this compiler bug arise in various files of the code base.
 Everywhere, the handling of `Clang < 3.8` is wrapped with checks for the
 ``X_OLD_CLANG`` macro.
 
-The support of `Clang < 4.0` is dropped in xtensor 0.22.
+**The support of `Clang < 4.0` is dropped in xtensor 0.22.**
+
+Clang-cl and ``std::get``
+-------------------------
+
+`Clang-cl` does not allow to call ``std::get`` with ``*this`` as parameter from a class inheriting from std::tuple.
+In that case, we explicitly upcast to ``std::tuple``.
 
 GCC < 5.1 and ``std::is_trivially_default_constructible``
 ---------------------------------------------------------

--- a/include/xtensor/xaccumulator.hpp
+++ b/include/xtensor/xaccumulator.hpp
@@ -25,11 +25,19 @@ namespace xt
 
 #define DEFAULT_STRATEGY_ACCUMULATORS evaluation_strategy::immediate_type
 
+    namespace detail
+    {
+        template <class V = void>
+        struct accumulator_identity: xtl::identity
+        {
+            using value_type = V;
+        };
+    }
     /**************
      * accumulate *
      **************/
 
-    template <class ACCUMULATE_FUNC, class INIT_FUNC = xtl::identity>
+    template <class ACCUMULATE_FUNC, class INIT_FUNC = detail::accumulator_identity<void>>
     struct xaccumulator_functor
         : public std::tuple<ACCUMULATE_FUNC, INIT_FUNC>
     {
@@ -37,6 +45,7 @@ namespace xt
         using base_type = std::tuple<ACCUMULATE_FUNC, INIT_FUNC>;
         using accumulate_functor_type = ACCUMULATE_FUNC;
         using init_functor_type = INIT_FUNC;
+        using init_value_type = typename init_functor_type::value_type;
 
         xaccumulator_functor()
             : base_type()
@@ -188,9 +197,10 @@ namespace xt
         template <class F, class E>
         inline auto accumulator_impl(F&& f, E&& e, std::size_t axis, evaluation_strategy::immediate_type)
         {
-            using accumulate_functor = std::decay_t<decltype(xt::get<0>(f))>;
-            using function_return_type = typename accumulate_functor::result_type;
-            using result_type = xaccumulator_return_type_t<std::decay_t<E>, function_return_type>;
+            using init_type = typename F::init_value_type;
+            using init_functor_type = typename F::init_functor_type;
+            using return_type = std::conditional_t<std::is_same<init_type, void>::value, typename std::decay_t<E>::value_type, init_type>;
+            using result_type = xaccumulator_return_type_t<std::decay_t<E>, return_type>;
 
             if (axis >= e.dimension())
             {
@@ -232,7 +242,8 @@ namespace xt
                 inner_loop_size = inner_loop_size - inner_stride;
 
                 // activate the init loop if we have an init function other than identity
-                if (!std::is_same<std::decay_t<decltype(xt::get<1>(f))>, xtl::identity>::value)
+                if (!std::is_same<std::decay_t<typename F::init_functor_type>, 
+                                  typename detail::accumulator_identity<init_type>>::value)
                 {
                     accumulator_init_with_f(xt::get<1>(f), result, axis);
                 }
@@ -255,10 +266,10 @@ namespace xt
         template <class F, class E>
         inline auto accumulator_impl(F&& f, E&& e, evaluation_strategy::immediate_type)
         {
-            using accumulate_functor = std::decay_t<decltype(xt::get<0>(f))>;
-            using T = typename accumulate_functor::result_type;
+            using init_type = typename F::init_value_type;
+            using return_type = std::conditional_t<std::is_same<init_type, void>::value, typename std::decay_t<E>::value_type, init_type>;
+            using result_type = xaccumulator_return_type_t<std::decay_t<E>, return_type>;
 
-            using result_type = xaccumulator_linear_return_type_t<std::decay_t<E>, T>;
             std::size_t sz = e.size();
             auto result = result_type::from_shape({sz});
 

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -342,7 +342,8 @@ namespace xt
         template <class T>
         static constexpr bool simd_size_impl() { return xt_simd::simd_traits<T>::size > 1 || (is_bool<T>::value && use_xsimd()); }
         static constexpr bool simd_size() { return simd_size_impl<e1_value_type>() && simd_size_impl<e2_value_type>(); }
-        static constexpr bool simd_interface() { return has_simd_interface<E2, requested_value_type>(); }
+        static constexpr bool simd_interface() { return has_simd_interface<E1, requested_value_type>() && 
+                                                        has_simd_interface<E2, requested_value_type>(); }
 
     public:
 

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -510,6 +510,8 @@ namespace xt
     template <class T>
     struct const_value
     {
+        using value_type = T;
+
         constexpr const_value() = default;
 
         constexpr const_value(T t)
@@ -522,8 +524,32 @@ namespace xt
             return m_value;
         }
 
+        template <class NT>
+        using rebind_t = const_value<NT>;
+
+        template <class NT>
+        const_value<NT> rebind() const;
+
         T m_value;
     };
+
+    namespace detail
+    {
+        template <class T, bool B>
+        struct evaluated_value_type
+        {
+            using type = T;
+        };
+
+        template <class T>
+        struct evaluated_value_type<T, true>
+        {
+            using type = typename std::decay_t<decltype(xt::eval(std::declval<T>()))>;
+        };
+
+        template <class T, bool B>
+        using evaluated_value_type_t = typename evaluated_value_type<T, B>::type;
+    }
 
     template <class REDUCE_FUNC, class INIT_FUNC = const_value<long int>, class MERGE_FUNC = REDUCE_FUNC>
     struct xreducer_functors
@@ -534,6 +560,7 @@ namespace xt
         using reduce_functor_type = REDUCE_FUNC;
         using init_functor_type = INIT_FUNC;
         using merge_functor_type = MERGE_FUNC;
+        using init_value_type = typename init_functor_type::value_type;
 
         xreducer_functors()
             : base_type()
@@ -556,6 +583,30 @@ namespace xt
         xreducer_functors(RF&& reduce_func, IF&& init_func, MF&& merge_func)
             : base_type(std::forward<RF>(reduce_func), std::forward<IF>(init_func), std::forward<MF>(merge_func))
         {
+        }
+
+        reduce_functor_type get_reduce()
+        {
+            return std::get<0>(*this);
+        }
+
+        init_functor_type get_init()
+        {
+            return std::get<1>(*this);
+        }
+
+        merge_functor_type get_merge()
+        {
+            return std::get<2>(*this);
+        }
+
+        template<class NT>
+        using rebind_t = xreducer_functors<REDUCE_FUNC, const_value<NT>, MERGE_FUNC>;
+
+        template<class NT>
+        rebind_t<NT> rebind()
+        {
+            return make_xreducer_functor(get_reduce(), get_init().template rebind<NT>(), get_merge());
         }
     };
 
@@ -634,8 +685,12 @@ namespace xt
         using init_functor_type = typename std::decay_t<F>::init_functor_type;
         using merge_functor_type = typename std::decay_t<F>::merge_functor_type;
         using substepper_type = typename xexpression_type::const_stepper;
-        using value_type = std::decay_t<decltype(std::declval<reduce_functor_type>()(
-            std::declval<init_functor_type>()(), *std::declval<substepper_type>()))>;
+        using raw_value_type = std::decay_t<decltype(std::declval<reduce_functor_type>()(
+                                                            std::declval<init_functor_type>()(), 
+                                                            *std::declval<substepper_type>())
+                                                    )>;
+        using value_type = typename detail::evaluated_value_type_t<raw_value_type, is_xexpression<raw_value_type>::value>;
+
         using reference = value_type;
         using const_reference = value_type;
         using size_type = typename xexpression_type::size_type;
@@ -680,9 +735,12 @@ namespace xt
 
         using self_type = xreducer<F, CT, X, O>;
         using inner_types = xcontainer_inner_types<self_type>;
+
         using reduce_functor_type = typename inner_types::reduce_functor_type;
         using init_functor_type = typename inner_types::init_functor_type;
         using merge_functor_type = typename inner_types::merge_functor_type;
+        using xreducer_functors_type = xreducer_functors<reduce_functor_type, init_functor_type, merge_functor_type>;
+
         using xexpression_type = typename inner_types::xexpression_type;
         using axes_type = X;
 
@@ -749,6 +807,11 @@ namespace xt
         template <class E, class Func, class Opts>
         rebind_t<E, Func, Opts> build_reducer(E&& e, Func&& func, Opts&& opts) const;
 
+        xreducer_functors_type functors() const
+        {
+            return xreducer_functors_type(m_reduce, m_init, m_merge);  // TODO: understand why make_xreducer_functor is throwing an error
+        }
+
         const O& options() const
         {
             return m_options;
@@ -780,11 +843,13 @@ namespace xt
 
             using reduce_functor_type = typename std::decay_t<F>::reduce_functor_type;
             using init_functor_type = typename std::decay_t<F>::init_functor_type;
+            using init_value_type = typename init_functor_type::value_type;
             using value_type = std::decay_t<decltype(std::declval<reduce_functor_type>()(
                 std::declval<init_functor_type>()(),
                 *std::declval<typename std::decay_t<E>::const_stepper>()))>;
-
-            using reducer_type = xreducer<F, const_xclosure_t<E>, xtl::const_closure_type_t<decltype(normalized_axes)>, reducer_options<value_type, std::decay_t<O>>>;
+            using evaluated_value_type = evaluated_value_type_t<value_type, is_xexpression<value_type>::value>;
+            
+            using reducer_type = xreducer<F, const_xclosure_t<E>, xtl::const_closure_type_t<decltype(normalized_axes)>, reducer_options<evaluated_value_type, std::decay_t<O>>>;
             return reducer_type(std::forward<F>(f), std::forward<E>(e), std::forward<decltype(normalized_axes)>(normalized_axes), std::forward<O>(options));
         }
 
@@ -983,7 +1048,58 @@ namespace xt
                                             fixed_shape<R...>,
                                             fixed_shape<detail::at<0, I...>::value, R...>>;
         };
+
+        /***************************
+         * helper for return types *
+         ***************************/
+
+        template <class T>
+        struct xreducer_size_type
+        {
+            using type = std::size_t;
+        };
+
+        template <class T>
+        using xreducer_size_type_t = typename xreducer_size_type<T>::type;
+
+
+        template <class T>
+        struct xreducer_temporary_type
+        {
+            using type = T;
+        };
+
+        template <class T>
+        using xreducer_temporary_type_t = typename xreducer_temporary_type<T>::type;
+
+        /********************************
+         * Default const_value rebinder *
+         ********************************/
+
+        template <class T, class U>
+        struct const_value_rebinder
+        {
+            static const_value<U> run(const const_value<T>& t)
+            {
+                return const_value<U>(t.m_value);
+            }
+        };        
     }
+
+    /*******************************************
+     * Init functor const_value implementation *
+     *******************************************/
+
+    template <class T>
+    template <class NT>
+    const_value<NT> const_value<T>::rebind() const
+    {
+        return detail::const_value_rebinder<T, NT>::run(*this);
+    }
+
+    /*****************************
+     * fixed_xreducer_shape_type *
+     *****************************/
 
     template <class S1, class S2>
     struct fixed_xreducer_shape_type;

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -585,19 +585,19 @@ namespace xt
         {
         }
 
-        reduce_functor_type get_reduce()
+        reduce_functor_type get_reduce() const
         {
-            return std::get<0>(*this);
+            return std::get<0>(upcast());
         }
 
-        init_functor_type get_init()
+        init_functor_type get_init() const
         {
-            return std::get<1>(*this);
+            return std::get<1>(upcast());
         }
 
-        merge_functor_type get_merge()
+        merge_functor_type get_merge() const
         {
-            return std::get<2>(*this);
+            return std::get<2>(upcast());
         }
 
         template<class NT>
@@ -607,6 +607,14 @@ namespace xt
         rebind_t<NT> rebind()
         {
             return make_xreducer_functor(get_reduce(), get_init().template rebind<NT>(), get_merge());
+        }
+
+    private:
+        
+        // Workaround for clang-cl
+        const base_type& upcast() const
+        {
+            return static_cast<const base_type&>(*this);
         }
     };
 

--- a/test/test_xmath_result_type.cpp
+++ b/test/test_xmath_result_type.cpp
@@ -39,6 +39,8 @@
 #include "xtensor/xrandom.hpp"
 #endif
 
+#include "xtl/xtype_traits.hpp"
+
 namespace xt
 {
     using std::size_t;
@@ -53,27 +55,239 @@ namespace xt
         using result_type = typename std::decay_t<decltype(EXPRESSION)>::value_type; \
         EXPECT_TRUE((std::is_same<result_type, EXPECTED_TYPE>::value));              \
     }
+
+template <class T1, class T2>
+using promote_t = xtl::promote_type_t<T1, T2>;
+
+template <class T, class E>
+void check_promoted_types(E&& e)
+{
+    using result_type = typename std::decay_t<decltype(e)>::value_type;
+    EXPECT_TRUE((std::is_same<result_type, promote_t<T, result_type>>::value));
+}
+
 #define ARRAY_TYPE(VALUE_TYPE)  \
     std::array<VALUE_TYPE, 2>
 
-#define CHECK_TEMPLATED_RESULT_TYPE(FUNC, INPUT)                                     \
-        CHECK_RESULT_TYPE(FUNC<unsigned char>(INPUT), int);                          \
-        CHECK_RESULT_TYPE(FUNC<signed char>(INPUT), int);                            \
-        CHECK_RESULT_TYPE(FUNC<char>(INPUT), int);                                   \
-        CHECK_RESULT_TYPE(FUNC<unsigned short>(INPUT), int);                         \
-        CHECK_RESULT_TYPE(FUNC<signed short>(INPUT), int);                           \
-        CHECK_RESULT_TYPE(FUNC<short>(INPUT), int);                                  \
-        CHECK_RESULT_TYPE(FUNC<unsigned int>(INPUT), unsigned int);                  \
-        CHECK_RESULT_TYPE(FUNC<signed int>(INPUT), signed int);                      \
-        CHECK_RESULT_TYPE(FUNC<int>(INPUT), int);                                    \
-        CHECK_RESULT_TYPE(FUNC<unsigned long long>(INPUT), unsigned long long);      \
-        CHECK_RESULT_TYPE(FUNC<signed long long>(INPUT), signed long long);          \
-        CHECK_RESULT_TYPE(FUNC<long long>(INPUT), long long);                        \
-        CHECK_RESULT_TYPE(FUNC<float>(INPUT), float);                                \
-        CHECK_RESULT_TYPE(FUNC<double>(INPUT), double);
+#define CHECK_TEMPLATED_RESULT_TYPE(FUNC, INPUT)                                   \
+        check_promoted_types<unsigned char>(FUNC<unsigned char>(INPUT));           \
+        check_promoted_types<signed char>(FUNC<signed char>(INPUT));               \
+        check_promoted_types<char>(FUNC<char>(INPUT));                             \
+        check_promoted_types<unsigned short>(FUNC<unsigned short>(INPUT));         \
+        check_promoted_types<signed short>(FUNC<signed short>(INPUT));             \
+        check_promoted_types<short>(FUNC<short>(INPUT));                           \
+        check_promoted_types<unsigned int>(FUNC<unsigned int>(INPUT));             \
+        check_promoted_types<signed int>(FUNC<signed int>(INPUT));                 \
+        check_promoted_types<int>(FUNC<int>(INPUT));                               \
+        check_promoted_types<unsigned long long>(FUNC<unsigned long long>(INPUT)); \
+        check_promoted_types<long long>(FUNC<signed long long>(INPUT));            \
+        check_promoted_types<long long>(FUNC<long long>(INPUT));                   \
+        check_promoted_types<float>(FUNC<float>(INPUT));                           \
+        check_promoted_types<double>(FUNC<double>(INPUT));
 
-    TEST(xmath, result_type)
-    {
+#define CHECK_STDDEV_TEMPLATED_RESULT_TYPE(FUNC, INPUT)                            \
+        {                                                                          \
+        using result_type = typename std::decay_t<decltype(INPUT)>::value_type;    \
+        using promo_type = std::conditional_t<std::is_integral<result_type>::value,\
+                                              double,                              \
+                                              float>;                              \
+                                                                                   \
+        check_promoted_types<promo_type>(FUNC<unsigned char>(INPUT));              \
+        check_promoted_types<promo_type>(FUNC<signed char>(INPUT));                \
+        check_promoted_types<promo_type>(FUNC<char>(INPUT));                       \
+        check_promoted_types<promo_type>(FUNC<unsigned short>(INPUT));             \
+        check_promoted_types<promo_type>(FUNC<signed short>(INPUT));               \
+        check_promoted_types<promo_type>(FUNC<short>(INPUT));                      \
+        check_promoted_types<promo_type>(FUNC<unsigned int>(INPUT));               \
+        check_promoted_types<promo_type>(FUNC<signed int>(INPUT));                 \
+        check_promoted_types<promo_type>(FUNC<int>(INPUT));                        \
+        check_promoted_types<promo_type>(FUNC<unsigned long long>(INPUT));         \
+        check_promoted_types<promo_type>(FUNC<signed long long>(INPUT));           \
+        check_promoted_types<promo_type>(FUNC<long long>(INPUT));                  \
+        check_promoted_types<float>(FUNC<float>(INPUT));                           \
+        check_promoted_types<double>(FUNC<double>(INPUT));                         \
+        }
+
+#define CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(INPUT)        \
+        CHECK_TEMPLATED_RESULT_TYPE(sum, INPUT)           \
+        CHECK_TEMPLATED_RESULT_TYPE(mean, INPUT)          \
+        CHECK_TEMPLATED_RESULT_TYPE(prod, INPUT)          \
+        CHECK_TEMPLATED_RESULT_TYPE(variance, INPUT)      \
+        CHECK_STDDEV_TEMPLATED_RESULT_TYPE(stddev, INPUT)
+
+    TEST(xmath, uchar_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<unsigned char> auchar(shape);
+
+        CHECK_RESULT_TYPE(auchar + auchar, int);
+        CHECK_RESULT_TYPE(2 * auchar, int);
+        CHECK_RESULT_TYPE(2.0 * auchar, double);
+        CHECK_RESULT_TYPE(sqrt(auchar), double);
+        CHECK_RESULT_TYPE(abs(auchar), unsigned char);
+        CHECK_RESULT_TYPE(sum(auchar), unsigned long long);
+        CHECK_RESULT_TYPE(mean(auchar), double);
+        CHECK_RESULT_TYPE(minmax(auchar), ARRAY_TYPE(unsigned char));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auchar);
+    }
+
+    TEST(xmath, short_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<short> ashort(shape);
+
+        CHECK_RESULT_TYPE(ashort + ashort, int);
+        CHECK_RESULT_TYPE(2 * ashort, int);
+        CHECK_RESULT_TYPE(2.0 * ashort, double);
+        CHECK_RESULT_TYPE(sqrt(ashort), double);
+        CHECK_RESULT_TYPE(abs(ashort), decltype(std::abs(short{})));
+        CHECK_RESULT_TYPE(sum(ashort), long long);
+        CHECK_RESULT_TYPE(mean(ashort), double);
+        CHECK_RESULT_TYPE(minmax(ashort), ARRAY_TYPE(short));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort);
+    }
+
+    TEST(xmath, ushort_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<unsigned short> aushort(shape);
+
+        CHECK_RESULT_TYPE(aushort + aushort, int);
+        CHECK_RESULT_TYPE(2u * aushort, unsigned int);
+        CHECK_RESULT_TYPE(2.0 * aushort, double);
+        CHECK_RESULT_TYPE(sqrt(aushort), double);
+        CHECK_RESULT_TYPE(abs(aushort), unsigned short);
+        CHECK_RESULT_TYPE(sum(aushort), unsigned long long);
+        CHECK_RESULT_TYPE(mean(aushort), double);
+        CHECK_RESULT_TYPE(minmax(aushort), ARRAY_TYPE(unsigned short));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aushort);
+    }
+
+    TEST(xmath, int_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<int> aint(shape);
+
+        CHECK_RESULT_TYPE(aint + aint, int);
+        CHECK_RESULT_TYPE(2 * aint, int);
+        CHECK_RESULT_TYPE(2.0 * aint, double);
+        CHECK_RESULT_TYPE(sqrt(aint), double);
+        CHECK_RESULT_TYPE(abs(aint), int);
+        CHECK_RESULT_TYPE(sum(aint), long long);
+        CHECK_RESULT_TYPE(mean(aint), double);
+        CHECK_RESULT_TYPE(minmax(aint), ARRAY_TYPE(int));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aint);
+    }
+
+    TEST(xmath, uint_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<unsigned int> auint(shape);
+  
+        CHECK_RESULT_TYPE(auint + auint, unsigned int);
+        CHECK_RESULT_TYPE(2u * auint, unsigned int);
+        CHECK_RESULT_TYPE(2.0 * auint, double);
+        CHECK_RESULT_TYPE(sqrt(auint), double);
+        CHECK_RESULT_TYPE(abs(auint), unsigned int);
+        CHECK_RESULT_TYPE(sum(auint), unsigned long long);
+        CHECK_RESULT_TYPE(mean(auint), double);
+        CHECK_RESULT_TYPE(minmax(auint), ARRAY_TYPE(unsigned int));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auint);
+    }
+
+    TEST(xmath, long_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<long long> along(shape);
+
+        CHECK_RESULT_TYPE(along + along, signed long long);
+        CHECK_RESULT_TYPE(2 * along, signed long long);
+        CHECK_RESULT_TYPE(2.0 * along, double);
+        CHECK_RESULT_TYPE(sqrt(along), double);
+        CHECK_RESULT_TYPE(abs(along), signed long long);
+        CHECK_RESULT_TYPE(sum(along), signed long long);
+        CHECK_RESULT_TYPE(mean(along), double);
+        CHECK_RESULT_TYPE(minmax(along), ARRAY_TYPE(signed long long));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(along);
+    }
+
+    TEST(xmath, ulong_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<unsigned long long> aulong(shape);
+    
+        CHECK_RESULT_TYPE(aulong + aulong, unsigned long long);
+        CHECK_RESULT_TYPE(2ul * aulong, unsigned long long);
+        CHECK_RESULT_TYPE(2.0 * aulong, double);
+        CHECK_RESULT_TYPE(sqrt(aulong), double);
+        CHECK_RESULT_TYPE(abs(aulong), unsigned long long);
+        CHECK_RESULT_TYPE(sum(aulong), unsigned long long);
+        CHECK_RESULT_TYPE(mean(aulong), double);
+        CHECK_RESULT_TYPE(minmax(aulong), ARRAY_TYPE(unsigned long long));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aulong);
+    }
+
+    TEST(xmath, float_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<float> afloat(shape);
+
+        CHECK_RESULT_TYPE(afloat + afloat, float);
+        CHECK_RESULT_TYPE(2.0f * afloat, float);
+        CHECK_RESULT_TYPE(2.0 * afloat, double);
+        CHECK_RESULT_TYPE(sqrt(afloat), float);
+        CHECK_RESULT_TYPE(abs(afloat), float);
+        CHECK_RESULT_TYPE(sum(afloat), double);
+        CHECK_RESULT_TYPE(mean(afloat), double);
+        CHECK_RESULT_TYPE(minmax(afloat), ARRAY_TYPE(float));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(afloat);
+    }
+
+    TEST(xmath, double_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<double> adouble(shape);
+
+        CHECK_RESULT_TYPE(adouble + adouble, double);
+        CHECK_RESULT_TYPE(2.0 * adouble, double);
+        CHECK_RESULT_TYPE(sqrt(adouble), double);
+        CHECK_RESULT_TYPE(abs(adouble), double);
+        CHECK_RESULT_TYPE(sum(adouble), double);
+        CHECK_RESULT_TYPE(mean(adouble), double);
+        CHECK_RESULT_TYPE(minmax(adouble), ARRAY_TYPE(double));
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(adouble);
+    }
+
+    TEST(xmath, float_complex_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<std::complex<float>> afcomplex(shape);
+
+        CHECK_RESULT_TYPE(afcomplex + afcomplex, std::complex<float>);
+        CHECK_RESULT_TYPE(std::complex<float>(2.0) * afcomplex, std::complex<float>);
+        CHECK_RESULT_TYPE(2.0f * afcomplex, std::complex<float>);
+        CHECK_RESULT_TYPE(sqrt(afcomplex), std::complex<float>);
+        CHECK_RESULT_TYPE(abs(afcomplex), float);
+        CHECK_RESULT_TYPE(sum(afcomplex), std::complex<double>);
+        CHECK_RESULT_TYPE(mean(afcomplex), std::complex<double>);
+    }
+
+    TEST(xmath, double_complex_result_type)
+    {        
+        shape_type shape = {3, 2};
+        xarray<std::complex<double>> adcomplex(shape);
+
+        CHECK_RESULT_TYPE(adcomplex + adcomplex, std::complex<double>);
+        CHECK_RESULT_TYPE(std::complex<double>(2.0) * adcomplex, std::complex<double>);
+        CHECK_RESULT_TYPE(2.0 * adcomplex, std::complex<double>);
+        CHECK_RESULT_TYPE(sqrt(adcomplex), std::complex<double>);
+        CHECK_RESULT_TYPE(abs(adcomplex), double);
+        CHECK_RESULT_TYPE(sum(adcomplex), std::complex<double>);
+        CHECK_RESULT_TYPE(mean(adcomplex), std::complex<double>);
+    }
+
+    TEST(xmath, mixed_result_type)
+    {        
         shape_type shape = {3, 2};
         xarray<unsigned char> auchar(shape);
         xarray<short> ashort(shape);
@@ -87,153 +301,6 @@ namespace xt
         xarray<std::complex<float>> afcomplex(shape);
         xarray<std::complex<double>> adcomplex(shape);
 
-#define CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(INPUT)                                   \
-        CHECK_TEMPLATED_RESULT_TYPE(mean, INPUT)                                     \
-        CHECK_TEMPLATED_RESULT_TYPE(variance, INPUT)
-// FIXME: the first 6 checks in "#define CHECK_TEMPLATED_RESULT_TYPE(FUNC, INPUT)" fail
-//        CHECK_TEMPLATED_RESULT_TYPE(stddev, INPUT)
-
-        /*****************
-         * unsigned char *
-         *****************/
-        CHECK_RESULT_TYPE(auchar + auchar, int);
-        CHECK_RESULT_TYPE(2 * auchar, int);
-        CHECK_RESULT_TYPE(2.0 * auchar, double);
-        CHECK_RESULT_TYPE(sqrt(auchar), double);
-        CHECK_RESULT_TYPE(abs(auchar), unsigned char);
-        CHECK_RESULT_TYPE(sum(auchar), unsigned long long);
-        CHECK_RESULT_TYPE(mean(auchar), double);
-        CHECK_RESULT_TYPE(minmax(auchar), ARRAY_TYPE(unsigned char));
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auchar);
-
-        /*********
-         * short *
-         *********/
-        CHECK_RESULT_TYPE(ashort + ashort, int);
-        CHECK_RESULT_TYPE(2 * ashort, int);
-        CHECK_RESULT_TYPE(2.0 * ashort, double);
-        CHECK_RESULT_TYPE(sqrt(ashort), double);
-        CHECK_RESULT_TYPE(abs(ashort), decltype(std::abs(short{})));
-        CHECK_RESULT_TYPE(sum(ashort), long long);
-        CHECK_RESULT_TYPE(mean(ashort), double);
-        CHECK_RESULT_TYPE(minmax(ashort), ARRAY_TYPE(short));
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort);
-
-        /******************
-         * unsigned short *
-         ******************/
-        CHECK_RESULT_TYPE(aushort + aushort, int);
-        CHECK_RESULT_TYPE(2u * aushort, unsigned int);
-        CHECK_RESULT_TYPE(2.0 * aushort, double);
-        CHECK_RESULT_TYPE(sqrt(aushort), double);
-        CHECK_RESULT_TYPE(abs(aushort), unsigned short);
-        CHECK_RESULT_TYPE(sum(aushort), unsigned long long);
-        CHECK_RESULT_TYPE(mean(aushort), double);
-        CHECK_RESULT_TYPE(minmax(aushort), ARRAY_TYPE(unsigned short));
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort);
-
-        /*******
-         * int *
-         *******/
-        CHECK_RESULT_TYPE(aint + aint, int);
-        CHECK_RESULT_TYPE(2 * aint, int);
-        CHECK_RESULT_TYPE(2.0 * aint, double);
-        CHECK_RESULT_TYPE(sqrt(aint), double);
-        CHECK_RESULT_TYPE(abs(aint), int);
-        CHECK_RESULT_TYPE(sum(aint), long long);
-        CHECK_RESULT_TYPE(mean(aint), double);
-        CHECK_RESULT_TYPE(minmax(aint), ARRAY_TYPE(int));
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aint);
-
-        /****************
-         * unsigned int *
-         ****************/
-        CHECK_RESULT_TYPE(auint + auint, unsigned int);
-        CHECK_RESULT_TYPE(2u * auint, unsigned int);
-        CHECK_RESULT_TYPE(2.0 * auint, double);
-        CHECK_RESULT_TYPE(sqrt(auint), double);
-        CHECK_RESULT_TYPE(abs(auint), unsigned int);
-        CHECK_RESULT_TYPE(sum(auint), unsigned long long);
-        CHECK_RESULT_TYPE(mean(auint), double);
-        CHECK_RESULT_TYPE(minmax(auint), ARRAY_TYPE(unsigned int));
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auint);
-
-        /**********************
-         * long long *
-         **********************/
-        CHECK_RESULT_TYPE(along + along, signed long long);
-        CHECK_RESULT_TYPE(2 * along, signed long long);
-        CHECK_RESULT_TYPE(2.0 * along, double);
-        CHECK_RESULT_TYPE(sqrt(along), double);
-        CHECK_RESULT_TYPE(abs(along), signed long long);
-        CHECK_RESULT_TYPE(sum(along), signed long long);
-        CHECK_RESULT_TYPE(mean(along), double);
-        CHECK_RESULT_TYPE(minmax(along), ARRAY_TYPE(signed long long));
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(along);
-
-        /**********************
-         * unsigned long long *
-         **********************/
-        CHECK_RESULT_TYPE(aulong + aulong, unsigned long long);
-        CHECK_RESULT_TYPE(2ul * aulong, unsigned long long);
-        CHECK_RESULT_TYPE(2.0 * aulong, double);
-        CHECK_RESULT_TYPE(sqrt(aulong), double);
-        CHECK_RESULT_TYPE(abs(aulong), unsigned long long);
-        CHECK_RESULT_TYPE(sum(aulong), unsigned long long);
-        CHECK_RESULT_TYPE(mean(aulong), double);
-        CHECK_RESULT_TYPE(minmax(aulong), ARRAY_TYPE(unsigned long long));
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aulong);
-
-        /*********
-         * float *
-         *********/
-        CHECK_RESULT_TYPE(afloat + afloat, float);
-        CHECK_RESULT_TYPE(2.0f * afloat, float);
-        CHECK_RESULT_TYPE(2.0 * afloat, double);
-        CHECK_RESULT_TYPE(sqrt(afloat), float);
-        CHECK_RESULT_TYPE(abs(afloat), float);
-        CHECK_RESULT_TYPE(sum(afloat), double);
-        CHECK_RESULT_TYPE(mean(afloat), double);
-        CHECK_RESULT_TYPE(minmax(afloat), ARRAY_TYPE(float));
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(afloat);
-
-        /**********
-         * double *
-         **********/
-        CHECK_RESULT_TYPE(adouble + adouble, double);
-        CHECK_RESULT_TYPE(2.0 * adouble, double);
-        CHECK_RESULT_TYPE(sqrt(adouble), double);
-        CHECK_RESULT_TYPE(abs(adouble), double);
-        CHECK_RESULT_TYPE(sum(adouble), double);
-        CHECK_RESULT_TYPE(mean(adouble), double);
-        CHECK_RESULT_TYPE(minmax(adouble), ARRAY_TYPE(double));
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(adouble);
-
-        /***********************
-         * std::complex<float> *
-         ***********************/
-        CHECK_RESULT_TYPE(afcomplex + afcomplex, std::complex<float>);
-        CHECK_RESULT_TYPE(std::complex<float>(2.0) * afcomplex, std::complex<float>);
-        CHECK_RESULT_TYPE(2.0f * afcomplex, std::complex<float>);
-        CHECK_RESULT_TYPE(sqrt(afcomplex), std::complex<float>);
-        CHECK_RESULT_TYPE(abs(afcomplex), float);
-        CHECK_RESULT_TYPE(sum(afcomplex), std::complex<double>);
-        CHECK_RESULT_TYPE(mean(afcomplex), std::complex<double>);
-
-        /************************
-         * std::complex<double> *
-         ************************/
-        CHECK_RESULT_TYPE(adcomplex + adcomplex, std::complex<double>);
-        CHECK_RESULT_TYPE(std::complex<double>(2.0) * adcomplex, std::complex<double>);
-        CHECK_RESULT_TYPE(2.0 * adcomplex, std::complex<double>);
-        CHECK_RESULT_TYPE(sqrt(adcomplex), std::complex<double>);
-        CHECK_RESULT_TYPE(abs(adcomplex), double);
-        CHECK_RESULT_TYPE(sum(adcomplex), std::complex<double>);
-        CHECK_RESULT_TYPE(mean(adcomplex), std::complex<double>);
-
-        /***************
-         * mixed types *
-         ***************/
         CHECK_RESULT_TYPE(auchar + aint, int);
         CHECK_RESULT_TYPE(ashort + aint, int);
         CHECK_RESULT_TYPE(aulong + aint, unsigned long long);

--- a/test/test_xnan_functions.cpp
+++ b/test/test_xnan_functions.cpp
@@ -21,6 +21,8 @@
 #include "xtensor/xmath.hpp"
 #include "xtensor/xstrided_view.hpp"
 
+#include "xtl/xtype_traits.hpp"
+
 namespace xt
 {
     using namespace std::complex_literals;
@@ -219,64 +221,80 @@ namespace xt
         xarray<float> afloat(shape);
         xarray<double> adouble(shape);
 
-#define CHECK_RESULT_TYPE_FOR_ALL(INPUT, RESULT_TYPE)                               \
-        CHECK_RESULT_TYPE(nansum(INPUT, {1, 2}), RESULT_TYPE);                      \
-        CHECK_RESULT_TYPE(nanmean(INPUT, {1, 2}), double);                          \
-        CHECK_RESULT_TYPE(nanvar(INPUT, {1, 2}), double);                           \
+#define CHECK_RESULT_TYPE_FOR_ALL(INPUT, RESULT_TYPE)             \
+        CHECK_RESULT_TYPE(nansum(INPUT, {1, 2}), RESULT_TYPE);    \
+        CHECK_RESULT_TYPE(nanmean(INPUT, {1, 2}), double);        \
+        CHECK_RESULT_TYPE(nanvar(INPUT, {1, 2}), double);         \
         CHECK_RESULT_TYPE(nanstd(INPUT, {1, 2}), double);
 
-#define CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(INPUT, RESULT_TYPE)                     \
-        CHECK_RESULT_TYPE(nansum<RESULT_TYPE>(INPUT, {1, 2}), RESULT_TYPE)          \
-        CHECK_RESULT_TYPE(nanmean<RESULT_TYPE>(INPUT, {1, 2}), RESULT_TYPE)         \
-        CHECK_RESULT_TYPE(nanvar<RESULT_TYPE>(INPUT, {1, 2}), RESULT_TYPE)          \
-        CHECK_RESULT_TYPE(nanstd<RESULT_TYPE>(INPUT, {1, 2}), RESULT_TYPE)
+#define CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(INPUT, TEMPLATE_TYPE, RESULT_TYPE, STD_TYPE)  \
+        CHECK_RESULT_TYPE(nansum<TEMPLATE_TYPE>(INPUT, {1, 2}), RESULT_TYPE)              \
+        CHECK_RESULT_TYPE(nanmean<TEMPLATE_TYPE>(INPUT, {1, 2}), RESULT_TYPE)             \
+        CHECK_RESULT_TYPE(nanvar<TEMPLATE_TYPE>(INPUT, {1, 2}), RESULT_TYPE)              \
+        CHECK_RESULT_TYPE(nanstd<TEMPLATE_TYPE>(INPUT, {1, 2}), STD_TYPE)
 
         /*********
          * short *
          *********/
-        CHECK_RESULT_TYPE_FOR_ALL(ashort, short);
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort, int);
+        CHECK_RESULT_TYPE_FOR_ALL(ashort, int);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort, short, int, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort, int, int, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort, double, double, double);
 
         /******************
          * unsigned short *
          ******************/
-        CHECK_RESULT_TYPE_FOR_ALL(aushort, unsigned short);
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aushort, unsigned int);
+        CHECK_RESULT_TYPE_FOR_ALL(aushort, int);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aushort, unsigned short, int, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aushort, int, int, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aushort, double, double, double);
 
         /*********
          * int *
          *********/
         CHECK_RESULT_TYPE_FOR_ALL(aint, int);
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aint, int);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aint, unsigned short, int, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aint, int, int, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aint, double, double, double);
 
         /****************
          * unsigned int *
          ****************/
         CHECK_RESULT_TYPE_FOR_ALL(auint, unsigned int);
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auint, unsigned int);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auint, unsigned int, unsigned int, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auint, unsigned int, unsigned int, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auint, double, double, double);
 
         /**********************
          * long long *
          **********************/
         CHECK_RESULT_TYPE_FOR_ALL(along, signed long long);
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(along, signed long long);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(along, int, signed long long, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(along, long, signed long long, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(along, signed long long, signed long long, double);
 
         /**********************
          * unsigned long long *
          **********************/
         CHECK_RESULT_TYPE_FOR_ALL(aulong, unsigned long long);
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aulong, unsigned long long);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aulong, unsigned int, unsigned long long, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aulong, unsigned long, unsigned long long, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aulong, unsigned long long, unsigned long long, double);
 
         /*********
          * float *
          *********/
         CHECK_RESULT_TYPE_FOR_ALL(afloat, float);
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(afloat, float);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(afloat, int, float, float);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(afloat, float, float, float);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(afloat, double, double, double);
 
         /**********
          * double *
          **********/
         CHECK_RESULT_TYPE_FOR_ALL(adouble, double);
-        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(adouble, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(adouble, float, double, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(adouble, double, double, double);
+        CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(adouble, long double, long double, long double);
     }
 }

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -153,13 +153,13 @@ namespace xt
     }
 #undef TEST_EXPRESSION_TAG
 
-#define TEST_VALUE_HAS_VALUE(INPUT, V_TYPE, OPTIONAL)                                  \
-    using result_type = std::conditional_t<OPTIONAL, xtl::xoptional<double>, double>;  \
-                                                                                       \
-    auto res = xt::sum(INPUT, feats.m_axes);                                           \
-    CHECK_RESULT_TYPE(res, result_type);                                               \
-    CHECK_TYPE(xt::value(res)(1, 1, 1), V_TYPE);                                       \
-    EXPECT_EQ(!OPTIONAL, xt::has_value(res)(0, 0, 0));                                 \
+#define TEST_VALUE_HAS_VALUE(INPUT, V_TYPE, OPTIONAL)                                      \
+    using result_type = std::conditional_t<OPTIONAL, xtl::xoptional<double>, double>;      \
+                                                                                           \
+    auto res = xt::sum(INPUT, feats.m_axes);                                               \
+    CHECK_RESULT_TYPE(res, result_type);                                                   \
+    CHECK_TYPE(xt::value(res)(1, 1, 1), V_TYPE);                                           \
+    EXPECT_EQ(!OPTIONAL, xt::has_value(res)(0, 0, 0));                                     \
     EXPECT_TRUE(xt::has_value(res)(1, 1, 1));
 
     TEST(xreducer, value_has_value)
@@ -173,19 +173,19 @@ namespace xt
         xreducer_opt_features feats;
         TEST_VALUE_HAS_VALUE(feats.m_array_of_optional, xtl::xoptional<double>, true);  // TODO: fail, the mask is not reflecting the missing values
     }
-
+*/
     TEST(xreducer_array_optional, value_has_value)
     {
        xreducer_opt_features feats;
-       TEST_VALUE_HAS_VALUE(feats.m_array_optional, double, true);  // TODO: fail, the value has type optional<T> instead of T
+       TEST_VALUE_HAS_VALUE(feats.m_array_optional, double, true);
     }
 
     TEST(xreducer_optional_assembly, value_has_value)
     {
         xreducer_opt_features feats;
-        TEST_VALUE_HAS_VALUE(feats.m_optional_assembly, double, true);  // TODO: fail, the value has type optional<T> instead of T
+        TEST_VALUE_HAS_VALUE(feats.m_optional_assembly, double, true);
     }
-*/
+
 #undef TEST_VALUE_HAS_VALUE
 
     TEST(xreducer, functor_type)
@@ -275,15 +275,53 @@ namespace xt
         xarray<double> expected = 12 * ones<double>({3, 4, 5});
         expected(1, 1, 1) = 24;
         EXPECT_EQ(expected, res);
+
+        xarray_optional<double> opt_expected = 12 * ones<double>({3, 4, 5});
+        opt_expected(1, 1, 1) = 24;
+
+        xreducer_opt_features::xarray_of_optional_type opt_res1 = res;
+        CHECK_RESULT_TYPE(opt_res1, xtl::xoptional<double>);
+        CHECK_TYPE(xt::value(opt_res1)(1, 1, 1), xtl::xoptional<double>);
+        EXPECT_EQ(xt::has_value(opt_res1), xt::full_like(res, true));
+        EXPECT_EQ(opt_expected, opt_res1);
+        
+        xreducer_opt_features::xarray_optional_type opt_res2 = res;
+        CHECK_RESULT_TYPE(opt_res2, xtl::xoptional<double>);
+        CHECK_TYPE(xt::value(opt_res2)(1, 1, 1), double);
+        EXPECT_EQ(xt::has_value(opt_res2), xt::full_like(res, true));
+        EXPECT_EQ(opt_expected, opt_res2);
+
+        xreducer_opt_features::optional_assembly_type opt_res3 = res;
+        CHECK_RESULT_TYPE(opt_res3, xtl::xoptional<double>);
+        CHECK_TYPE(xt::value(opt_res3)(1, 1, 1), double);
+        EXPECT_EQ(xt::has_value(opt_res3), xt::full_like(res, true));
+        EXPECT_EQ(opt_expected, opt_res3);
     }
 
 #define TEST_OPT_ASSIGNMENT(INPUT)                               \
     auto res = xt::sum(INPUT, feats.m_axes);                     \
+                                                                 \
     xreducer_opt_features::xarray_of_optional_type res1 = res;   \
+    CHECK_RESULT_TYPE(res1, xtl::xoptional<double>);             \
+    CHECK_TYPE(xt::value(res1)(1, 1, 1), xtl::xoptional<double>);\
+    EXPECT_EQ(res1(1, 1, 1), 24.);                               \
+    /* EXPECT_FALSE(xt::has_value(res1)(0, 0, 0)); */            \
+    EXPECT_TRUE(xt::has_value(res1)(1, 1, 1));                   \
+                                                                 \
     xreducer_opt_features::xarray_optional_type res2 = res;      \
-    xreducer_opt_features::optional_assembly_type res3 = res;
+    CHECK_RESULT_TYPE(res2, xtl::xoptional<double>);             \
+    CHECK_TYPE(xt::value(res2)(1, 1, 1), double);                \
+    EXPECT_EQ(res2(1, 1, 1), 24.);                               \
+    EXPECT_FALSE(xt::has_value(res2)(0, 0, 0));                  \
+    EXPECT_TRUE(xt::has_value(res2)(1, 1, 1));                   \
+                                                                 \
+    xreducer_opt_features::optional_assembly_type res3 = res;    \
+    CHECK_RESULT_TYPE(res3, xtl::xoptional<double>);             \
+    CHECK_TYPE(xt::value(res3)(1, 1, 1), double);                \
+    EXPECT_EQ(res3(1, 1, 1), 24.);                               \
+    EXPECT_FALSE(xt::has_value(res3)(0, 0, 0));                  \
+    EXPECT_TRUE(xt::has_value(res3)(1, 1, 1));
 
-/* TODO: fix assignment
     TEST(xreducer_array_of_optional, assign)
     {
         xreducer_opt_features feats;
@@ -293,17 +331,15 @@ namespace xt
     TEST(xreducer_array_optional, assign)
     {
         xreducer_opt_features feats;
-        TEST_OPT_ASSIGNMENT(feats.m_array_optional)
+        TEST_OPT_ASSIGNMENT(feats.m_array_optional) 
     }
-
+    
     TEST(xreducer_optional_assembly, assign)
     {
         xreducer_opt_features feats;
         TEST_OPT_ASSIGNMENT(feats.m_optional_assembly) 
     }
-*/
 #undef TEST_OPT_ASSIGNMENT
-
 
     TEST(xreducer, sum)
     {
@@ -371,7 +407,6 @@ namespace xt
     xarray_optional<double> res4 = xt::sum(INPUT, 1);                  \
     EXPECT_EQ(res3, res4); 
 
-/* TODO: fix assignment
     TEST(xreducer_array_of_optional, single_axis_sugar)
     {
         xreducer_opt_features feats;
@@ -389,7 +424,6 @@ namespace xt
         xreducer_opt_features feats;
         TEST_OPT_SINGLE_AXIS(feats.m_optional_assembly);        
     }
-*/
 #undef TEST_OPT_SINGLE_AXIS
 
     TEST(xreducer, sum2)
@@ -437,19 +471,19 @@ namespace xt
     auto res = xt::sum(INPUT);                \
     EXPECT_EQ(res(), xtl::missing<double>());
 
-    TEST(xreducer_array_of_optional, single_axis_sugar)
+    TEST(xreducer_array_of_optional, sum_all)
     {
         xreducer_opt_features feats;
         TEST_OPT_SUM_ALL(feats.m_array_of_optional);   
     }
 
-    TEST(xreducer_array_optional, single_axis_sugar)
+    TEST(xreducer_array_optional, sum_all)
     {
         xreducer_opt_features feats;
         TEST_OPT_SUM_ALL(feats.m_array_optional);       
     } 
 
-    TEST(xreducer_optional_assembly, single_axis_sugar)
+    TEST(xreducer_optional_assembly, sum_all)
     {
         xreducer_opt_features feats;
         TEST_OPT_SUM_ALL(feats.m_optional_assembly);        
@@ -463,12 +497,12 @@ namespace xt
         EXPECT_EQ(1ULL << 34, prod(c)());
     }
 
-#define TEST_OPT_PROD(INPUT)                         \
-    auto res1 = xt::prod(INPUT);                     \
-    EXPECT_EQ(res1(), xtl::missing<double>());       \
-                                                     \
-    auto res2 = xt::prod(INPUT, feats.m_axes);       \
-    EXPECT_EQ(res2(), xtl::missing<double>());       \
+#define TEST_OPT_PROD(INPUT)                     \
+    auto res1 = xt::prod(INPUT);                 \
+    EXPECT_EQ(res1(), xtl::missing<double>());   \
+                                                 \
+    auto res2 = xt::prod(INPUT, feats.m_axes);   \
+    EXPECT_EQ(res2(), xtl::missing<double>());   \
     EXPECT_EQ(res2(1, 1, 1), 4096.);
 
     TEST(xreducer_array_of_optional, prod)
@@ -513,12 +547,12 @@ namespace xt
         EXPECT_EQ(mean(rvalue_xarray(), {0})(), 1.5);
     }
 
-#define TEST_OPT_MEAN(INPUT)                         \
-    auto res1 = xt::mean(INPUT);                     \
-    EXPECT_EQ(res1(), xtl::missing<double>());       \
-                                                     \
-    auto res2 = xt::mean(INPUT, feats.m_axes);       \
-    EXPECT_EQ(res2(), xtl::missing<double>());       \
+#define TEST_OPT_MEAN(INPUT)                      \
+    auto res1 = xt::mean(INPUT);                  \
+    EXPECT_EQ(res1(), xtl::missing<double>());    \
+                                                  \
+    auto res2 = xt::mean(INPUT, feats.m_axes);    \
+    EXPECT_EQ(res2(), xtl::missing<double>());    \
     EXPECT_EQ(res2(1, 1, 1), 2.);
 
     TEST(xreducer_array_of_optional, mean)
@@ -564,15 +598,15 @@ namespace xt
         EXPECT_TRUE(all(equal(avg_d1, expect1)));
     }
 
-#define TEST_OPT_AVERAGE(INPUT)                      \
-    xt::xarray<double> all_weights = {{3, 3, 3},     \
-                                      {1, 1, 1}};    \
-    auto res1 = xt::average(INPUT, all_weights);     \
-    EXPECT_EQ(res1(), xtl::missing<double>());       \
-                                                     \
+#define TEST_OPT_AVERAGE(INPUT)                                            \
+    xt::xarray<double> all_weights = {{3, 3, 3},                           \
+                                      {1, 1, 1}};                          \
+    auto res1 = xt::average(INPUT, all_weights);                           \
+    EXPECT_EQ(res1(), xtl::missing<double>());                             \
+                                                                           \
     xtensor_optional<double, 1> expect = {1., 2., xtl::missing<double>()}; \
-    xt::xarray<double> weights = {2, 0};             \
-    auto res2 = xt::average(INPUT, weights, {0});    \
+    xt::xarray<double> weights = {2, 0};                                   \
+    auto res2 = xt::average(INPUT, weights, {0});                          \
     EXPECT_TRUE(all(equal(res2, expect)));
 
     TEST(xreducer_array_of_optional, average)
@@ -594,7 +628,6 @@ namespace xt
     }
 #undef TEST_OPT_AVERAGE
 
-
     TEST(xreducer, count_nonzero)
     {
         xarray<double> m = {{1, 0}, {3, 4}};
@@ -608,16 +641,15 @@ namespace xt
         EXPECT_TRUE(all(equal(res1, expect1)));
     }
 
-
-#define TEST_OPT_COUNT_NONZEROS(INPUT)               \
-    auto res0 = xt::count_nonzero(INPUT, {0});       \
-    xtensor_optional<std::size_t, 1> expect0 =       \
-            {2, 2, xtl::missing<std::size_t>()};     \
-    EXPECT_TRUE(all(equal(res0, expect0)));          \
-                                                     \
-    auto res1 = xt::count_nonzero(INPUT, {1});       \
-    xtensor_optional<std::size_t, 1> expect1 =       \
-            {2, xtl::missing<std::size_t>()};        \
+#define TEST_OPT_COUNT_NONZEROS(INPUT)             \
+    auto res0 = xt::count_nonzero(INPUT, {0});     \
+    xtensor_optional<std::size_t, 1> expect0 =     \
+            {2, 2, xtl::missing<std::size_t>()};   \
+    EXPECT_TRUE(all(equal(res0, expect0)));        \
+                                                   \
+    auto res1 = xt::count_nonzero(INPUT, {1});     \
+    xtensor_optional<std::size_t, 1> expect1 =     \
+            {2, xtl::missing<std::size_t>()};      \
     EXPECT_TRUE(all(equal(res1, expect1)));
 
 /*  TODO: fix policy, missing values should lead to a missing value result
@@ -1035,9 +1067,11 @@ namespace xt
     {
         xt::xtensor_fixed<float, xt::xshape<3>> a = {1, 2, 3}, b = {1, 2, 3};
         xt::xtensor<xt::xtensor_fixed<float, xt::xshape<3>>, 1> c = {a, b};
+
         auto res = xt::sum(c)();
         EXPECT_EQ(res, a * 2.);
+
+        xt::xtensor_fixed<float, xt::xshape<3>> res1 = res;
+        EXPECT_EQ(res1, a * 2.);
     }
-
 }
-


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

Fix the assignment of `xreducers` operating on optional arrays (incl. `xarray<xoptional<T>>`, `xarray_optional<T>` and `xoptional_assembly<T>`.
Change return policy of reducers and accumulators to non casting to the init type, even when init type is passed explicitely using the optional template parameter. Refactor accumulators accordingly.

PR also includes:
- disambiguish init and result types naming
- update and extend testing

Let me know if it should be good to explain the return type policy in the docs!