### PR TITLE
Support initialized list for chunked_array shapes

### DIFF
--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -338,12 +338,9 @@ namespace xt
     xchunked_array<xarray<xarray<T>>, EXT> chunked_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, layout_type chunk_memory_layout)
     {
         using sh_type = std::vector<std::size_t>;
-        sh_type sh = xtl::make_sequence<sh_type>(shape.size());
-        std::copy(shape.begin(), shape.end(), sh.begin());
-        sh_type ch_sh = xtl::make_sequence<sh_type>(chunk_shape.size());
-        std::copy(chunk_shape.begin(), chunk_shape.end(), ch_sh.begin());
-        using chunk_storage = xarray<xarray<T, L>>;
-        return xchunked_array<chunk_storage, EXT>(chunk_storage(), std::move(sh), std::move(ch_sh), chunk_memory_layout);
+        auto sh = xtl::forward_sequence<sh_type, std::initializer_list<S>>(shape);
+        auto ch_sh = xtl::forward_sequence<sh_type, std::initializer_list<S>>(chunk_shape);
+        return chunked_array<T, L, EXT, sh_type>(std::move(sh), std::move(ch_sh), chunk_memory_layout);
     }
 
     template <layout_type L, class EXT, class E, class S>

--- a/include/xtensor/xchunked_array.hpp
+++ b/include/xtensor/xchunked_array.hpp
@@ -234,6 +234,9 @@ namespace xt
     template <class T, layout_type L = XTENSOR_DEFAULT_LAYOUT, class EXT = empty_extension, class S>
     xchunked_array<xarray<xarray<T>>, EXT> chunked_array(S&& shape, S&& chunk_shape, layout_type chunk_memory_layout = XTENSOR_DEFAULT_LAYOUT);
 
+    template <class T, layout_type L = XTENSOR_DEFAULT_LAYOUT, class EXT = empty_extension, class S>
+    xchunked_array<xarray<xarray<T>>, EXT> chunked_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, layout_type chunk_memory_layout = XTENSOR_DEFAULT_LAYOUT);
+
     /**
      * Creates an in-memory chunked array.
      * This function returns a ``xchunked_array<xarray<T>>`` initialized from an expression.
@@ -329,6 +332,18 @@ namespace xt
     {
         using chunk_storage = xarray<xarray<T, L>>;
         return xchunked_array<chunk_storage, EXT>(chunk_storage(), std::forward<S>(shape), std::forward<S>(chunk_shape), chunk_memory_layout);
+    }
+
+    template <class T, layout_type L, class EXT, class S>
+    xchunked_array<xarray<xarray<T>>, EXT> chunked_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, layout_type chunk_memory_layout)
+    {
+        using sh_type = std::vector<std::size_t>;
+        sh_type sh = xtl::make_sequence<sh_type>(shape.size());
+        std::copy(shape.begin(), shape.end(), sh.begin());
+        sh_type ch_sh = xtl::make_sequence<sh_type>(chunk_shape.size());
+        std::copy(chunk_shape.begin(), chunk_shape.end(), ch_sh.begin());
+        using chunk_storage = xarray<xarray<T, L>>;
+        return xchunked_array<chunk_storage, EXT>(chunk_storage(), std::move(sh), std::move(ch_sh), chunk_memory_layout);
     }
 
     template <layout_type L, class EXT, class E, class S>

--- a/test/test_xchunked_array.cpp
+++ b/test/test_xchunked_array.cpp
@@ -20,9 +20,7 @@ namespace xt
 
     TEST(xchunked_array, indexed_access)
     {
-        std::vector<size_t> shape = {10, 10, 10};
-        std::vector<size_t> chunk_shape = {2, 3, 4};
-        auto a = chunked_array<double>(shape, chunk_shape);
+        auto a = chunked_array<double>({10, 10, 10}, {2, 3, 4});
 
         std::vector<size_t> idx = {3, 9, 8};
         double val;


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

This allows to write:
```cpp
auto a = chunked_array<int>({4, 4}, {2, 2});
```