### PR TITLE
Bazel build

### DIFF
--- a/include/xtensor/xadapt.hpp
+++ b/include/xtensor/xadapt.hpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <type_traits>
 
-#include <xtl/xsequence.hpp>
+#include "xtl/xsequence.hpp"
 
 #include "xarray.hpp"
 #include "xtensor.hpp"

--- a/include/xtensor/xarray.hpp
+++ b/include/xtensor/xarray.hpp
@@ -14,7 +14,7 @@
 #include <initializer_list>
 #include <utility>
 
-#include <xtl/xsequence.hpp>
+#include "xtl/xsequence.hpp"
 
 #include "xbuffer_adaptor.hpp"
 #include "xcontainer.hpp"

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -14,8 +14,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <xtl/xcomplex.hpp>
-#include <xtl/xsequence.hpp>
+#include "xtl/xcomplex.hpp"
+#include "xtl/xsequence.hpp"
 
 #include "xexpression.hpp"
 #include "xiterator.hpp"

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -18,7 +18,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <xtl/xsequence.hpp>
+#include "xtl/xsequence.hpp"
 
 #include "xaccessible.hpp"
 #include "xexpression.hpp"

--- a/include/xtensor/xbuffer_adaptor.hpp
+++ b/include/xtensor/xbuffer_adaptor.hpp
@@ -16,7 +16,7 @@
 #include <memory>
 #include <stdexcept>
 
-#include <xtl/xclosure.hpp>
+#include "xtl/xclosure.hpp"
 
 #include "xtensor_config.hpp"
 #include "xstorage.hpp"

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -22,9 +22,9 @@
 #include <utility>
 #include <vector>
 
-#include <xtl/xclosure.hpp>
-#include <xtl/xsequence.hpp>
-#include <xtl/xtype_traits.hpp>
+#include "xtl/xclosure.hpp"
+#include "xtl/xsequence.hpp"
+#include "xtl/xtype_traits.hpp"
 
 #include "xbroadcast.hpp"
 #include "xfunction.hpp"

--- a/include/xtensor/xcomplex.hpp
+++ b/include/xtensor/xcomplex.hpp
@@ -13,7 +13,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <xtl/xcomplex.hpp>
+#include "xtl/xcomplex.hpp"
 
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xexpression.hpp"

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -16,8 +16,8 @@
 #include <numeric>
 #include <stdexcept>
 
-#include <xtl/xmeta_utils.hpp>
-#include <xtl/xsequence.hpp>
+#include "xtl/xmeta_utils.hpp"
+#include "xtl/xsequence.hpp"
 
 #include "xaccessible.hpp"
 #include "xiterable.hpp"

--- a/include/xtensor/xdynamic_view.hpp
+++ b/include/xtensor/xdynamic_view.hpp
@@ -9,8 +9,8 @@
 #ifndef XTENSOR_DYNAMIC_VIEW_HPP
 #define XTENSOR_DYNAMIC_VIEW_HPP
 
-#include <xtl/xsequence.hpp>
-#include <xtl/xvariant.hpp>
+#include "xtl/xsequence.hpp"
+#include "xtl/xvariant.hpp"
 
 #include "xexpression.hpp"
 #include "xiterable.hpp"

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -14,9 +14,9 @@
 #include <type_traits>
 #include <vector>
 
-#include <xtl/xclosure.hpp>
-#include <xtl/xmeta_utils.hpp>
-#include <xtl/xtype_traits.hpp>
+#include "xtl/xclosure.hpp"
+#include "xtl/xmeta_utils.hpp"
+#include "xtl/xtype_traits.hpp"
 
 #include "xlayout.hpp"
 #include "xshape.hpp"

--- a/include/xtensor/xfixed.hpp
+++ b/include/xtensor/xfixed.hpp
@@ -16,7 +16,7 @@
 #include <utility>
 #include <vector>
 
-#include <xtl/xsequence.hpp>
+#include "xtl/xsequence.hpp"
 
 #include "xcontainer.hpp"
 #include "xstrides.hpp"

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -18,8 +18,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <xtl/xsequence.hpp>
-#include <xtl/xtype_traits.hpp>
+#include "xtl/xsequence.hpp"
+#include "xtl/xtype_traits.hpp"
 
 #include "xaccessible.hpp"
 #include "xexpression_traits.hpp"

--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -16,7 +16,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <xtl/xproxy_wrapper.hpp>
+#include "xtl/xproxy_wrapper.hpp"
 
 #include "xaccessible.hpp"
 #include "xexpression.hpp"

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -17,7 +17,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <xtl/xsequence.hpp>
+#include "xtl/xsequence.hpp"
 
 #include "xaccessible.hpp"
 #include "xexpression.hpp"

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -17,9 +17,9 @@
 #include <numeric>
 #include <vector>
 
-#include <xtl/xiterator_base.hpp>
-#include <xtl/xmeta_utils.hpp>
-#include <xtl/xsequence.hpp>
+#include "xtl/xiterator_base.hpp"
+#include "xtl/xmeta_utils.hpp"
+#include "xtl/xsequence.hpp"
 
 #include "xexception.hpp"
 #include "xlayout.hpp"

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -20,8 +20,8 @@
 #include <complex>
 #include <type_traits>
 
-#include <xtl/xcomplex.hpp>
-#include <xtl/xtype_traits.hpp>
+#include "xtl/xcomplex.hpp"
+#include "xtl/xtype_traits.hpp"
 
 #include "xaccumulator.hpp"
 #include "xeval.hpp"

--- a/include/xtensor/xnorm.hpp
+++ b/include/xtensor/xnorm.hpp
@@ -16,7 +16,7 @@
 #include <complex>
 #include <cstdlib>
 
-#include <xtl/xtype_traits.hpp>
+#include "xtl/xtype_traits.hpp"
 
 #include "xmath.hpp"
 #include "xoperation.hpp"

--- a/include/xtensor/xnpy.hpp
+++ b/include/xtensor/xnpy.hpp
@@ -14,8 +14,8 @@
 // Derived from https://github.com/llohse/libnpy by Leon Merten Lohse,
 // relicensed from MIT License with permission
 
-#include <xtl/xsequence.hpp>
-#include <xtl/xplatform.hpp>
+#include "xtl/xsequence.hpp"
+#include "xtl/xplatform.hpp"
 
 #include <algorithm>
 #include <complex>

--- a/include/xtensor/xoffset_view.hpp
+++ b/include/xtensor/xoffset_view.hpp
@@ -10,7 +10,7 @@
 #ifndef XTENSOR_OFFSET_VIEW_HPP
 #define XTENSOR_OFFSET_VIEW_HPP
 
-#include <xtl/xcomplex.hpp>
+#include "xtl/xcomplex.hpp"
 
 #include "xtensor/xfunctor_view.hpp"
 

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -14,7 +14,7 @@
 #include <functional>
 #include <type_traits>
 
-#include <xtl/xsequence.hpp>
+#include "xtl/xsequence.hpp"
 
 #include "xfunction.hpp"
 #include "xscalar.hpp"

--- a/include/xtensor/xoptional.hpp
+++ b/include/xtensor/xoptional.hpp
@@ -13,8 +13,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <xtl/xoptional.hpp>
-#include <xtl/xoptional_sequence.hpp>
+#include "xtl/xoptional.hpp"
+#include "xtl/xoptional_sequence.hpp"
 
 #include "xarray.hpp"
 #include "xbroadcast.hpp"

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -19,8 +19,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <xtl/xfunctional.hpp>
-#include <xtl/xsequence.hpp>
+#include "xtl/xfunctional.hpp"
+#include "xtl/xsequence.hpp"
 
 #include "xaccessible.hpp"
 #include "xbuilder.hpp"

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -14,7 +14,7 @@
 #include <cstddef>
 #include <utility>
 
-#include <xtl/xtype_traits.hpp>
+#include "xtl/xtype_traits.hpp"
 
 #include "xaccessible.hpp"
 #include "xexpression.hpp"

--- a/include/xtensor/xset_operation.hpp
+++ b/include/xtensor/xset_operation.hpp
@@ -14,7 +14,7 @@
 #include <functional>
 #include <type_traits>
 
-#include <xtl/xsequence.hpp>
+#include "xtl/xsequence.hpp"
 
 #include "xfunction.hpp"
 #include "xutils.hpp"

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -15,7 +15,7 @@
 #include <utility>
 #include <map>
 
-#include <xtl/xtype_traits.hpp>
+#include "xtl/xtype_traits.hpp"
 
 #include "xstorage.hpp"
 #include "xtensor_config.hpp"

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -16,8 +16,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <xtl/xsequence.hpp>
-#include <xtl/xvariant.hpp>
+#include "xtl/xsequence.hpp"
+#include "xtl/xvariant.hpp"
 
 #include "xexpression.hpp"
 #include "xiterable.hpp"

--- a/include/xtensor/xstrided_view_base.hpp
+++ b/include/xtensor/xstrided_view_base.hpp
@@ -12,7 +12,7 @@
 
 #include <type_traits>
 
-#include <xtl/xsequence.hpp>
+#include "xtl/xsequence.hpp"
 
 #include "xaccessible.hpp"
 #include "xtensor_forward.hpp"

--- a/include/xtensor/xstrides.hpp
+++ b/include/xtensor/xstrides.hpp
@@ -15,7 +15,7 @@
 #include <limits>
 #include <numeric>
 
-#include <xtl/xsequence.hpp>
+#include "xtl/xsequence.hpp"
 
 #include "xexception.hpp"
 #include "xshape.hpp"

--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -25,7 +25,7 @@
 #include <memory>
 #include <vector>
 
-#include <xtl/xoptional_sequence.hpp>
+#include "xtl/xoptional_sequence.hpp"
 
 #include "xlayout.hpp"
 #include "xtensor_config.hpp"

--- a/include/xtensor/xtensor_simd.hpp
+++ b/include/xtensor/xtensor_simd.hpp
@@ -11,7 +11,7 @@
 #define XTENSOR_SIMD_HPP
 
 #include <vector>
-#include <xtl/xdynamic_bitset.hpp>
+#include "xtl/xdynamic_bitset.hpp"
 
 #include "xutils.hpp"
 

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -23,10 +23,10 @@
 #include <utility>
 #include <vector>
 
-#include <xtl/xfunctional.hpp>
-#include <xtl/xsequence.hpp>
-#include <xtl/xmeta_utils.hpp>
-#include <xtl/xtype_traits.hpp>
+#include "xtl/xfunctional.hpp"
+#include "xtl/xsequence.hpp"
+#include "xtl/xmeta_utils.hpp"
+#include "xtl/xtype_traits.hpp"
 
 #include "xtensor_config.hpp"
 

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -17,10 +17,10 @@
 #include <type_traits>
 #include <utility>
 
-#include <xtl/xclosure.hpp>
-#include <xtl/xsequence.hpp>
-#include <xtl/xmeta_utils.hpp>
-#include <xtl/xtype_traits.hpp>
+#include "xtl/xclosure.hpp"
+#include "xtl/xsequence.hpp"
+#include "xtl/xmeta_utils.hpp"
+#include "xtl/xtype_traits.hpp"
 
 #include "xaccessible.hpp"
 #include "xarray.hpp"


### PR DESCRIPTION
When building xtensor with Bazel, we cannot rely on system headers, Bazel uses its own sandbox with all the dependencies.

This PR changes the way xtl headers are included for Bazel support.

# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
