### PR TITLE
Add as_strided free function

### DIFF
--- a/test/test_xeval.cpp
+++ b/test/test_xeval.cpp
@@ -58,4 +58,248 @@ namespace xt
         bool type_eq_2 = std::is_same<decltype(i), xtensor<int, 1>&&>::value;
         EXPECT_TRUE(type_eq_2);
     }
+
+
+#define EXPECT_LAYOUT(EXPRESSION, LAYOUT)                         \
+  EXPECT_TRUE((decltype(EXPRESSION)::static_layout == LAYOUT)) 
+
+#define HAS_DATA_INTERFACE(EXPRESSION)                            \
+  has_data_interface<std::decay_t<decltype(EXPRESSION)>>::value
+
+#define EXPECT_XARRAY(EXPRESSION)                                    \
+  EXPECT_TRUE(!detail::is_array<                                     \
+                        typename std::decay_t<decltype(EXPRESSION)   \
+                                >::shape_type>::value) 
+
+#define EXPECT_XTENSOR(EXPRESSION)                                   \
+  EXPECT_TRUE(detail::is_array<                                      \
+                        typename std::decay_t<decltype(EXPRESSION)   \
+                                >::shape_type>::value == true) 
+
+
+    TEST(utils, has_same_layout)
+    {
+        xt::xtensor<double, 1, layout_type::row_major> ten1 {1., 2., 3.2};
+        EXPECT_TRUE(detail::has_same_layout<layout_type::row_major>(ten1));
+        EXPECT_FALSE(detail::has_same_layout<layout_type::column_major>(ten1));
+        EXPECT_TRUE(detail::has_same_layout<layout_type::any>(ten1));
+
+        xt::xtensor<double, 1, layout_type::column_major> ten2 {1., 2., 3.2};
+        EXPECT_TRUE(detail::has_same_layout<layout_type::column_major>(ten2));
+        EXPECT_FALSE(detail::has_same_layout<layout_type::row_major>(ten2));
+        EXPECT_TRUE(detail::has_same_layout<layout_type::any>(ten2));
+        
+        EXPECT_FALSE((detail::has_same_layout(ten1, ten2)));
+        EXPECT_TRUE((detail::has_same_layout(ten1, xt::xtensor<double, 1, layout_type::row_major>({1., 2., 3.2}))));
+        EXPECT_TRUE((detail::has_same_layout(ten2, xt::xtensor<double, 1, layout_type::column_major>({1., 2., 3.2}))));
+    }
+
+    TEST(utils, has_fixed_dims)
+    {
+        xt::xtensor<double, 1> ten {1., 2., 3.2};
+        EXPECT_TRUE((detail::has_fixed_dims<xt::xtensor<double, 1>>()));
+        EXPECT_TRUE(detail::has_fixed_dims(ten));
+
+        xt::xarray<double> arr {1., 2., 3.2};
+        EXPECT_FALSE((detail::has_fixed_dims<xt::xarray<double>>()));
+        EXPECT_FALSE(detail::has_fixed_dims(arr));
+    }
+
+    TEST(utils, as_xarray_container_t)
+    {
+        using array_type = xt::xarray<double, layout_type::row_major>;
+
+        detail::as_xarray_container_t<array_type, layout_type::column_major> arr;
+        EXPECT_XARRAY(arr);
+        EXPECT_LAYOUT(arr, layout_type::column_major);
+    }
+
+    TEST(utils, as_xtensor_container_t)
+    {
+        using tensor_type = xt::xtensor<double, 1, layout_type::row_major>;
+
+        detail::as_xtensor_container_t<tensor_type, layout_type::column_major> ten;
+        EXPECT_XTENSOR(ten);
+        EXPECT_LAYOUT(ten, layout_type::column_major);
+    }
+
+    namespace testing
+    { // avoid collision with fixture class
+
+        class as_strided: public ::testing::Test
+        {
+            protected:
+
+                xt::xtensor<double, 1, layout_type::row_major> ten {1., 2., 3.2};
+                xt::xarray<double, layout_type::row_major> arr {1., 2., 3.2};
+        };
+
+        TEST_F(as_strided, array_reference)
+        {
+            EXPECT_LAYOUT(arr, layout_type::row_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(arr));
+            EXPECT_XARRAY(arr);
+            EXPECT_EQ(arr(2), 3.2);
+        }
+
+        TEST_F(as_strided, tensor_reference)
+        {
+            EXPECT_LAYOUT(ten, layout_type::row_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(ten));
+            EXPECT_XTENSOR(ten);
+            EXPECT_EQ(ten(2), 3.2);
+        }
+
+        TEST_F(as_strided, array_layout_unchanged)
+        {
+            auto res_lvalue = xt::as_strided<layout_type::row_major>(arr);
+            EXPECT_LAYOUT(res_lvalue, layout_type::row_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_lvalue));
+            EXPECT_XARRAY(res_lvalue);
+            EXPECT_EQ(res_lvalue(2), 3.2);
+
+            auto res_rvalue = xt::as_strided<layout_type::row_major>(
+                                xt::xarray<double, layout_type::row_major>({1., 2., 3.2})
+                                );
+            EXPECT_LAYOUT(res_rvalue, layout_type::row_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_rvalue));
+            EXPECT_XARRAY(res_rvalue);
+            EXPECT_EQ(res_rvalue(2), 3.2);
+        }
+
+        TEST_F(as_strided, tensor_layout_unchanged)
+        {
+            auto res_lvalue = xt::as_strided<layout_type::row_major>(ten);
+            EXPECT_LAYOUT(res_lvalue, layout_type::row_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_lvalue));
+            EXPECT_XTENSOR(res_lvalue);
+            EXPECT_EQ(res_lvalue(2), 3.2);
+
+            auto res_rvalue = xt::as_strided<layout_type::row_major>(
+                                xt::xtensor<double, 1, layout_type::row_major>({1., 2., 3.2})
+                                );
+            EXPECT_LAYOUT(res_rvalue, layout_type::row_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_rvalue));
+            EXPECT_XTENSOR(res_rvalue);
+            EXPECT_EQ(res_rvalue(2), 3.2);
+        }
+
+        TEST_F(as_strided, array_layout_change)
+        {
+            auto res_lvalue = xt::as_strided<layout_type::column_major>(arr);
+            EXPECT_LAYOUT(res_lvalue, layout_type::column_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_lvalue));
+            EXPECT_XARRAY(res_lvalue);
+            EXPECT_EQ(res_lvalue(2), 3.2);
+
+            auto res_rvalue = xt::as_strided<layout_type::column_major>(
+                                xt::xarray<double, layout_type::row_major>({1., 2., 3.2})
+                                );
+            EXPECT_LAYOUT(res_rvalue, layout_type::column_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_rvalue));
+            EXPECT_XARRAY(res_rvalue);
+            EXPECT_EQ(res_rvalue(2), 3.2);
+        }
+
+        TEST_F(as_strided, tensor_layout_changed)
+        {
+            auto res_lvalue = xt::as_strided<layout_type::column_major>(ten);
+            EXPECT_LAYOUT(res_lvalue, layout_type::column_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_lvalue));
+            EXPECT_XTENSOR(res_lvalue);
+            EXPECT_EQ(res_lvalue(2), 3.2);
+
+            auto res_rvalue = xt::as_strided<layout_type::column_major>(
+                                xt::xtensor<double, 1, layout_type::row_major>({1., 2., 3.2})
+                                );
+            EXPECT_LAYOUT(res_rvalue, layout_type::column_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_rvalue));
+            EXPECT_XTENSOR(res_rvalue);
+            EXPECT_EQ(res_rvalue(2), 3.2);
+        }
+
+        TEST_F(as_strided, array_no_data_interface_layout_unchanged)
+        {
+            auto array_cast = xt::cast<int>(arr);
+            EXPECT_FALSE(HAS_DATA_INTERFACE(array_cast));
+            EXPECT_XARRAY(array_cast);
+
+            auto res_lvalue = xt::as_strided<layout_type::row_major>(array_cast);
+            EXPECT_LAYOUT(res_lvalue, layout_type::row_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_lvalue));
+            EXPECT_XARRAY(res_lvalue);
+            EXPECT_EQ(res_lvalue(2), 3);
+
+            auto res_rvalue = xt::as_strided<layout_type::row_major>(
+                                xt::cast<int>(arr)
+                                );
+            EXPECT_LAYOUT(res_rvalue, layout_type::row_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_rvalue));
+            EXPECT_XARRAY(res_rvalue);
+            EXPECT_EQ(res_rvalue(2), 3);
+        }
+
+        TEST_F(as_strided, tensor_no_data_interface_layout_unchanged)
+        {
+            auto tensor_cast = xt::cast<int>(ten);
+            EXPECT_FALSE(HAS_DATA_INTERFACE(tensor_cast));
+            EXPECT_XTENSOR(tensor_cast);
+
+            auto res_lvalue = xt::as_strided<layout_type::row_major>(tensor_cast);
+            EXPECT_LAYOUT(res_lvalue, layout_type::row_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_lvalue));
+            EXPECT_XTENSOR(res_lvalue);
+            EXPECT_EQ(res_lvalue(2), 3);
+
+            auto res_rvalue = xt::as_strided<layout_type::row_major>(
+                                xt::cast<int>(ten)
+                                );
+            EXPECT_LAYOUT(res_rvalue, layout_type::row_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_rvalue));
+            EXPECT_XTENSOR(res_rvalue);
+            EXPECT_EQ(res_rvalue(2), 3);
+        }
+
+        TEST_F(as_strided, array_no_data_interface_layout_changed)
+        {
+            auto array_cast = xt::cast<int>(arr);
+            EXPECT_FALSE(HAS_DATA_INTERFACE(array_cast));
+            EXPECT_XARRAY(array_cast);
+
+            auto res_lvalue = xt::as_strided<layout_type::column_major>(array_cast);
+            EXPECT_LAYOUT(res_lvalue, layout_type::column_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_lvalue));
+            EXPECT_XARRAY(res_lvalue);
+            EXPECT_EQ(res_lvalue(2), 3);
+
+            auto res_rvalue = xt::as_strided<layout_type::column_major>(
+                                xt::cast<int>(arr)
+                                );
+            EXPECT_LAYOUT(res_rvalue, layout_type::column_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_rvalue));
+            EXPECT_XARRAY(res_rvalue);
+            EXPECT_EQ(res_rvalue(2), 3);
+        }
+
+        TEST_F(as_strided, tensor_no_data_interface_layout_changed)
+        {
+            auto tensor_cast = xt::cast<int>(ten);
+            EXPECT_FALSE(HAS_DATA_INTERFACE(tensor_cast));
+            EXPECT_XTENSOR(tensor_cast);
+
+            auto res_lvalue = xt::as_strided<layout_type::column_major>(tensor_cast);
+            EXPECT_LAYOUT(res_lvalue, layout_type::column_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_lvalue));
+            EXPECT_XTENSOR(res_lvalue);
+            EXPECT_EQ(res_lvalue(2), 3);
+
+            auto res_rvalue = xt::as_strided<layout_type::column_major>(
+                                xt::cast<int>(ten)
+                                );
+            EXPECT_LAYOUT(res_rvalue, layout_type::column_major);
+            EXPECT_TRUE(HAS_DATA_INTERFACE(res_rvalue));
+            EXPECT_XTENSOR(res_rvalue);
+            EXPECT_EQ(res_rvalue(2), 3);
+        }
+    }
 }


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Add `as_strided` free function to evaluate `xexpression`s that don't have data interface or don't have the expected layout.

The implementation is broadly inspired from [xtensor-blas utils](https://github.com/xtensor-stack/xtensor-blas/blob/master/include/xtensor-blas/xblas_utils.hpp) and may be useful in other contexts. This is the main reason of this PR.

Details:
- add docstrings
- add tests

# Discussion

`has_data_interface` has been used in SFINAE to discriminate `xexpression`s that hold data or not, instead of `is_container` which is used in `xt::eval`. Those 2 conditions may or may not be equivalent.

Let me know if it's preferable to switch to `is_container` @SylvainCorlay .