### PR TITLE
Fix histogram compatibility with containers beyond xtensor

### DIFF
--- a/include/xtensor/xhistogram.hpp
+++ b/include/xtensor/xhistogram.hpp
@@ -176,10 +176,8 @@ namespace xt
 
         auto n = data.size();
 
-        auto bin_edges = histogram_bin_edges(data, xt::ones<value_type>({ n }), bins);
-
         return detail::histogram_imp(std::forward<E1>(data),
-                                     std::forward<E1>(bin_edges),
+                                     histogram_bin_edges(data, xt::ones<value_type>({ n }), bins),
                                      xt::ones<value_type>({ n }),
                                      density,
                                      true);
@@ -198,10 +196,8 @@ namespace xt
     template <class E1, class E2>
     inline auto histogram(E1&& data, std::size_t bins, E2&& weights, bool density = false)
     {
-        auto bin_edges = histogram_bin_edges(data, weights, bins);
-
         return detail::histogram_imp(std::forward<E1>(data),
-                                     std::forward<E1>(bin_edges),
+                                     histogram_bin_edges(data, weights, bins),
                                      std::forward<E2>(weights),
                                      density,
                                      true);

--- a/test/test_xhistogram.cpp
+++ b/test/test_xhistogram.cpp
@@ -38,6 +38,15 @@ namespace xt
             EXPECT_EQ(count(0), 2.);
             EXPECT_EQ(count(1), 2.);
         }
+
+        {
+            xt::xarray<double> arr = {1., 1., 2., 2.};
+            xt::xtensor<double, 1> count = xt::histogram(arr, std::size_t(2));
+
+            EXPECT_EQ(count.size(), std::size_t(2) );
+            EXPECT_EQ(count(0), 2.);
+            EXPECT_EQ(count(1), 2.);
+        }
     }
 
     TEST(xhistogram, bincount)


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->

Since `histogram_bin_edges` returns a `xtensor`, the two histogram overloads will not work if `data` is other containers like `pytensor`, `xarray`, etc.
