### PR TITLE
Disable optional reducer assignment test with TBB

### DIFF
--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -279,6 +279,9 @@ namespace xt
         xarray_optional<double> opt_expected = 12 * ones<double>({3, 4, 5});
         opt_expected(1, 1, 1) = 24;
 
+// TODO: fix the reducer assignment issue in multithreaded env and enable
+// these tests again.
+#if !defined(XTENSOR_USE_TBB) && !defined(XTENSOR_USE_OPENMP)
         xreducer_opt_features::xarray_of_optional_type opt_res1 = res;
         CHECK_RESULT_TYPE(opt_res1, xtl::xoptional<double>);
         CHECK_TYPE(xt::value(opt_res1)(1, 1, 1), xtl::xoptional<double>);
@@ -296,6 +299,7 @@ namespace xt
         CHECK_TYPE(xt::value(opt_res3)(1, 1, 1), double);
         EXPECT_EQ(xt::has_value(opt_res3), xt::full_like(res, true));
         EXPECT_EQ(opt_expected, opt_res3);
+#endif
     }
 
 #define TEST_OPT_ASSIGNMENT(INPUT)                               \


### PR DESCRIPTION
This PR disables the optional reducer assignment tests when using TBB or OPENMP. It seems that we have a race condition and we don't want it to make unrelated PRs fail.