### PR TITLE
Make xt::cast and xtl::optional compatible.

### DIFF
--- a/test/test_xoptional.cpp
+++ b/test/test_xoptional.cpp
@@ -474,6 +474,17 @@ namespace xt
         flag_functor_type m_flag_functor;
     };
 
+    TEST(xoptional, cast)
+    {
+        xarray_optional<double> a = {{1.2, 2.3, 3.4},
+                                     {4.5, 5.6, 6.7}};
+        a(1, 2).has_value() = false;
+        auto b = cast<xtl::xoptional<int>>(a);
+        EXPECT_TRUE(b(0,2).has_value());
+        EXPECT_EQ(b(0,2), 3);
+        EXPECT_FALSE(b(1,2).has_value());
+    }
+
     TEST(xoptional, generator)
     {
         using gen_type = xgenerator<opt_func_tester, xtl::xoptional<int, bool>, dynamic_shape<std::size_t>>;


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->

It's currently not possible to xt::cast an array of optionals. This is an attempt to support that pattern.
An alternative implementation would be to add an explicit cast operator to optionals, I'm open to any suggestion!
