### PR TITLE
Remove reducer big_promote_type

### DIFF
--- a/include/xtensor/xexpression_traits.hpp
+++ b/include/xtensor/xexpression_traits.hpp
@@ -180,6 +180,19 @@ namespace xt
 
     template <class... C>
     using common_tensor_type_t = typename common_tensor_type<C...>::type;
+
+    /**************************
+     * big_promote_value_type *
+     **************************/
+
+    template <class E>
+    struct big_promote_value_type
+    {
+        using type = xtl::big_promote_type_t<typename std::decay_t<E>::value_type>;
+    };
+
+    template <class E>
+    using big_promote_value_type_t = typename big_promote_value_type<E>::type;
 }
 
 #endif

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -365,46 +365,46 @@ namespace detail {
     }
 }
 
-#define XTENSOR_REDUCER_FUNCTION(NAME, FUNCTOR, INIT_VALUE_TYPE, INIT)                                            \
-    template <class T = void, class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,                            \
-              XTL_REQUIRES(xtl::negation<is_reducer_options<X>>, xtl::negation<xtl::is_integral<X>>)>             \
-    inline auto NAME(E&& e, X&& axes, EVS es = EVS())                                                             \
-    {                                                                                                             \
-        using result_type = std::conditional_t<std::is_same<T, void>::value, INIT_VALUE_TYPE, T>;                 \
-        using functor_type = FUNCTOR;                                                                             \
-        using init_value_fct = xt::const_value<result_type>;                                                      \
-        return xt::reduce(make_xreducer_functor(functor_type(),                                                   \
-                          init_value_fct(detail::fill_init<result_type>(INIT))),                                  \
-                          std::forward<E>(e),                                                                     \
-                          std::forward<X>(axes), es);                                                             \
-    }                                                                                                             \
-                                                                                                                  \
-    template <class T = void, class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,                            \
-              XTL_REQUIRES(xtl::negation<is_reducer_options<X>>, xtl::is_integral<X>)>                            \
-    inline auto NAME(E&& e, X axis, EVS es = EVS())                                                               \
-    {                                                                                                             \
-        return NAME(std::forward<E>(e), {axis}, es);                                                              \
-    }                                                                                                             \
-                                                                                                                  \
-    template <class T = void, class E, class EVS = DEFAULT_STRATEGY_REDUCERS,                                     \
-              XTL_REQUIRES(is_reducer_options<EVS>)>                                                              \
-    inline auto NAME(E&& e, EVS es = EVS())                                                                       \
-    {                                                                                                             \
-        using result_type = std::conditional_t<std::is_same<T, void>::value, INIT_VALUE_TYPE, T>;                 \
-        using functor_type = FUNCTOR;                                                                             \
-        using init_value_fct = xt::const_value<result_type>;                                                      \
-        return xt::reduce(make_xreducer_functor(functor_type(),                                                   \
-                          init_value_fct(detail::fill_init<result_type>(INIT))), std::forward<E>(e), es);         \
-    }                                                                                                             \
-                                                                                                                  \
-    template <class T = void, class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>             \
-    inline auto NAME(E&& e, const I (&axes)[N], EVS es = EVS())                                                   \
-    {                                                                                                             \
-        using result_type = std::conditional_t<std::is_same<T, void>::value, INIT_VALUE_TYPE, T>;                 \
-        using functor_type = FUNCTOR;                                                                             \
-        using init_value_fct = xt::const_value<result_type>;                                                      \
-        return xt::reduce(make_xreducer_functor(functor_type(),                                                   \
-                          init_value_fct(detail::fill_init<result_type>(INIT))), std::forward<E>(e), axes, es);   \
+#define XTENSOR_REDUCER_FUNCTION(NAME, FUNCTOR, INIT_VALUE_TYPE, INIT)                                               \
+    template <class T = void, class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,                               \
+              XTL_REQUIRES(xtl::negation<is_reducer_options<X>>, xtl::negation<xtl::is_integral<X>>)>                \
+    inline auto NAME(E&& e, X&& axes, EVS es = EVS())                                                                \
+    {                                                                                                                \
+        using init_value_type = std::conditional_t<std::is_same<T, void>::value, INIT_VALUE_TYPE, T>;                \
+        using functor_type = FUNCTOR;                                                                                \
+        using init_value_fct = xt::const_value<init_value_type>;                                                     \
+        return xt::reduce(make_xreducer_functor(functor_type(),                                                      \
+                          init_value_fct(detail::fill_init<init_value_type>(INIT))),                                 \
+                          std::forward<E>(e),                                                                        \
+                          std::forward<X>(axes), es);                                                                \
+    }                                                                                                                \
+                                                                                                                     \
+    template <class T = void, class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,                               \
+              XTL_REQUIRES(xtl::negation<is_reducer_options<X>>, xtl::is_integral<X>)>                               \
+    inline auto NAME(E&& e, X axis, EVS es = EVS())                                                                  \
+    {                                                                                                                \
+        return NAME(std::forward<E>(e), {axis}, es);                                                                 \
+    }                                                                                                                \
+                                                                                                                     \
+    template <class T = void, class E, class EVS = DEFAULT_STRATEGY_REDUCERS,                                        \
+              XTL_REQUIRES(is_reducer_options<EVS>)>                                                                 \
+    inline auto NAME(E&& e, EVS es = EVS())                                                                          \
+    {                                                                                                                \
+        using init_value_type  = std::conditional_t<std::is_same<T, void>::value, INIT_VALUE_TYPE, T>;               \
+        using functor_type = FUNCTOR;                                                                                \
+        using init_value_fct = xt::const_value<init_value_type >;                                                    \
+        return xt::reduce(make_xreducer_functor(functor_type(),                                                      \
+                          init_value_fct(detail::fill_init<init_value_type >(INIT))), std::forward<E>(e), es);       \
+    }                                                                                                                \
+                                                                                                                     \
+    template <class T = void, class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>                \
+    inline auto NAME(E&& e, const I (&axes)[N], EVS es = EVS())                                                      \
+    {                                                                                                                \
+        using init_value_type  = std::conditional_t<std::is_same<T, void>::value, INIT_VALUE_TYPE, T>;               \
+        using functor_type = FUNCTOR;                                                                                \
+        using init_value_fct = xt::const_value<init_value_type >;                                                    \
+        return xt::reduce(make_xreducer_functor(functor_type(),                                                      \
+                          init_value_fct(detail::fill_init<init_value_type >(INIT))), std::forward<E>(e), axes, es); \
     }
 
     /*******************
@@ -1839,9 +1839,13 @@ namespace detail {
      * @param e an \ref xexpression
      * @param axes the axes along which the sum is performed (optional)
      * @param es evaluation strategy of the reducer
+     * @tparam T the value type used for internal computation. The default is
+     *           `E::value_type`. `T` is also used for determining the value type
+     *           of the result, which is the type of `T() + E::value_type()`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xreducer
      */
-    XTENSOR_REDUCER_FUNCTION(sum, detail::plus, xtl::big_promote_type_t<typename std::decay_t<E>::value_type>, 0)
+    XTENSOR_REDUCER_FUNCTION(sum, detail::plus, typename std::decay_t<E>::value_type, 0)
 
     /**
      * @ingroup red_functions
@@ -1855,9 +1859,13 @@ namespace detail {
      *             The divisor used in calculations is N - ddof, where N represents the number of
                    elements. By default ddof is zero.
      * @param es evaluation strategy of the reducer
+     * @tparam T the value type used for internal computation. The default is `E::value_type`.
+     *           `T` is also used for determining the value type of the result, which is the type
+     *           of `T() * E::value_type()`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xreducer
      */
-    XTENSOR_REDUCER_FUNCTION(prod, detail::multiplies, xtl::big_promote_type_t<typename std::decay_t<E>::value_type>, 1)
+    XTENSOR_REDUCER_FUNCTION(prod, detail::multiplies, typename std::decay_t<E>::value_type, 1)
 
     namespace detail
     {
@@ -1915,6 +1923,10 @@ namespace detail {
      * @param e an \ref xexpression
      * @param axes the axes along which the mean is computed (optional)
      * @param es the evaluation strategy (optional)
+     * @tparam T the value type used for internal computation. The default is
+     *           `E::value_type`. `T` is also used for determining the value type
+     *           of the result, which is the type of `T() + E::value_type()`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xexpression
      */
     template <class T = void, class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,
@@ -1946,11 +1958,15 @@ namespace detail {
      * @param e an \ref xexpression
      * @param weights \ref xexpression containing weights associated with the values in \ref e
      * @param axes the axes along which the mean is computed (optional)
+     * @tparam T the value type used for internal computation. The default is
+     *           `E::value_type`. `T`is also used for determining the value type of the result,
+     *           which is the type of `T() + E::value_type().
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xexpression
      *
      * @sa mean
      */
-    template <class E, class W, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,
+    template <class T = void, class E, class W, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,
               XTL_REQUIRES(is_reducer_options<EVS>, xtl::negation<xtl::is_integral<X>>)>
     inline auto average(E&& e, W&& weights, X&& axes, EVS ev = EVS())
     {
@@ -1979,19 +1995,19 @@ namespace detail {
 
         constexpr layout_type L = default_assignable_layout(std::decay_t<W>::static_layout);
         auto weights_view = reshape_view<L>(std::forward<W>(weights), std::move(broadcast_shape));
-        auto scl = sum(weights_view, ax, xt::evaluation_strategy::immediate);
-        return sum(std::forward<E>(e) * std::move(weights_view), std::move(ax), ev) / std::move(scl);
+        auto scl = sum<T>(weights_view, ax, xt::evaluation_strategy::immediate);
+        return sum<T>(std::forward<E>(e) * std::move(weights_view), std::move(ax), ev) / std::move(scl);
     }
 
-    template <class E, class W, class X, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    template <class T = void, class E, class W, class X, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
     inline auto average(E&& e, W&& weights, const X(&axes)[N], EVS ev = EVS())
     {
         // need to select the X&& overload and forward to different type
         using ax_t = std::array<std::size_t, N>;
-        return average(std::forward<E>(e), std::forward<W>(weights), xt::forward_normalize<ax_t>(e, axes), ev);
+        return average<T>(std::forward<E>(e), std::forward<W>(weights), xt::forward_normalize<ax_t>(e, axes), ev);
     }
 
-    template <class E, class W, class EVS = DEFAULT_STRATEGY_REDUCERS,
+    template <class T = void, class E, class W, class EVS = DEFAULT_STRATEGY_REDUCERS,
               XTL_REQUIRES(is_reducer_options<EVS>)>
     inline auto average(E&& e, W&& weights, EVS ev = EVS())
     {
@@ -2000,15 +2016,15 @@ namespace detail {
             XTENSOR_THROW(std::runtime_error, "Weights need to have the same shape as expression.");
         }
 
-        auto div = sum(weights, evaluation_strategy::immediate)();
-        auto s = sum(std::forward<E>(e) * std::forward<W>(weights), ev) / std::move(div);
+        auto div = sum<T>(weights, evaluation_strategy::immediate)();
+        auto s = sum<T>(std::forward<E>(e) * std::forward<W>(weights), ev) / std::move(div);
         return s;
     }
 
-    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS, XTL_REQUIRES(is_reducer_options<EVS>)>
+    template <class T = void, class E, class EVS = DEFAULT_STRATEGY_REDUCERS, XTL_REQUIRES(is_reducer_options<EVS>)>
     inline auto average(E&& e, EVS ev = EVS())
     {
-        return mean(e, ev);
+        return mean<T>(e, ev);
     }
 
     namespace detail
@@ -2047,7 +2063,6 @@ namespace detail {
               XTL_REQUIRES(is_reducer_options<EVS>)>
     inline auto stddev(E&& e, EVS es = EVS())
     {
-        using result_type = std::conditional_t<std::is_same<T, void>::value, double, T>;
         return sqrt(variance<T>(std::forward<E>(e), es));
     }
 
@@ -2067,6 +2082,10 @@ namespace detail {
      *             The divisor used in calculations is N - ddof, where N represents the number of
                    elements. By default ddof is zero.
      * @param es evaluation strategy to use (lazy (default), or immediate)
+     * @tparam T the value type used for internal computation. The default is
+     *           `E::value_type`. `T`is also used for determining the value type of the result,
+     *           which is the type of `T() + E::value_type()`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xexpression
      *
      * @sa stddev, mean
@@ -2112,6 +2131,10 @@ namespace detail {
      * @param e an \ref xexpression
      * @param axes the axes along which the standard deviation is computed (optional)
      * @param es evaluation strategy to use (lazy (default), or immediate)
+     * @tparam T the value type used for internal computation. The default is
+     *           `E::value_type`. `T`is also used for determining the value type of the result,
+     *           which is the type of `T() + E::value_type()`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xexpression
      *
      * @sa variance, mean
@@ -2200,22 +2223,26 @@ namespace detail {
      * \em axis (or flattened).
      * @param e an \ref xexpression
      * @param axis the axes along which the cumulative sum is computed (optional)
+     * @tparam T the value type used for internal computation. The default is
+     *           `E::value_type`. `T`is also used for determining the value type of the result,
+     *           which is the type of `T() + E::value_type()`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xarray<T>
      */
-    template <class E>
+    template <class T = void, class E>
     inline auto cumsum(E&& e, std::ptrdiff_t axis)
     {
-        using result_type = xtl::big_promote_type_t<typename std::decay_t<E>::value_type>;
-        return accumulate(make_xaccumulator_functor(detail::plus(), detail::accumulator_identity<result_type>()), 
+        using init_value_type = std::conditional_t<std::is_same<T, void>::value, typename std::decay_t<E>::value_type, T>;
+        return accumulate(make_xaccumulator_functor(detail::plus(), detail::accumulator_identity<init_value_type>()), 
                           std::forward<E>(e),
                           axis);
     }
 
-    template <class E>
+    template <class T = void, class E>
     inline auto cumsum(E&& e)
     {
-        using result_type = xtl::big_promote_type_t<typename std::decay_t<E>::value_type>;
-        return accumulate(make_xaccumulator_functor(detail::plus(), detail::accumulator_identity<result_type>()), 
+        using init_value_type = std::conditional_t<std::is_same<T, void>::value, typename std::decay_t<E>::value_type, T>;
+        return accumulate(make_xaccumulator_functor(detail::plus(), detail::accumulator_identity<init_value_type>()), 
                           std::forward<E>(e));
     }
 
@@ -2227,22 +2254,26 @@ namespace detail {
      * \em axis (or flattened).
      * @param e an \ref xexpression
      * @param axis the axes along which the cumulative product is computed (optional)
+     * @tparam T the value type used for internal computation. The default is
+     *           `E::value_type`. `T`is also used for determining the value type of the result,
+     *           which is the type of `T() * E::value_type()`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xarray<T>
      */
-    template <class E>
+    template <class T = void, class E>
     inline auto cumprod(E&& e, std::ptrdiff_t axis)
     {
-        using result_type = xtl::big_promote_type_t<typename std::decay_t<E>::value_type>;
-        return accumulate(make_xaccumulator_functor(detail::multiplies(), detail::accumulator_identity<result_type>()), 
+        using init_value_type = std::conditional_t<std::is_same<T, void>::value, typename std::decay_t<E>::value_type, T>;
+        return accumulate(make_xaccumulator_functor(detail::multiplies(), detail::accumulator_identity<init_value_type>()), 
                           std::forward<E>(e), 
                           axis);
     }
 
-    template <class E>
+    template <class T = void, class E>
     inline auto cumprod(E&& e)
     {
-        using result_type = xtl::big_promote_type_t<typename std::decay_t<E>::value_type>;
-        return accumulate(make_xaccumulator_functor(detail::multiplies(), detail::accumulator_identity<result_type>()), 
+        using init_value_type = std::conditional_t<std::is_same<T, void>::value, typename std::decay_t<E>::value_type, T>;
+        return accumulate(make_xaccumulator_functor(detail::multiplies(), detail::accumulator_identity<init_value_type>()), 
                           std::forward<E>(e));
     }
 
@@ -2366,6 +2397,8 @@ namespace detail {
      * @param e an \ref xexpression
      * @param axes the axes along which the sum is performed (optional)
      * @param es evaluation strategy of the reducer (optional)
+     * @tparam T the result type. The default is `E::value_type`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xreducer
      */
     XTENSOR_REDUCER_FUNCTION(nansum, detail::nan_plus, typename std::decay_t<E>::value_type, 0)
@@ -2379,6 +2412,8 @@ namespace detail {
      * @param e an \ref xexpression
      * @param axes the axes along which the sum is performed (optional)
      * @param es evaluation strategy of the reducer (optional)
+     * @tparam T the result type. The default is `E::value_type`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xreducer
      */
     XTENSOR_REDUCER_FUNCTION(nanprod, detail::nan_multiplies, typename std::decay_t<E>::value_type, 1)
@@ -2472,20 +2507,22 @@ namespace detail {
      * \em axis, replacing nan with 0.
      * @param e an \ref xexpression
      * @param axis the axis along which the elements are accumulated (optional)
+     * @tparam T the result type. The default is `E::value_type`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an xaccumulator
      */
-    template <class E>
+    template <class T = void, class E>
     inline auto nancumsum(E&& e, std::ptrdiff_t axis)
     {
-        using result_type = xtl::big_promote_type_t<typename std::decay_t<E>::value_type>;
-        return accumulate(make_xaccumulator_functor(detail::nan_plus(), detail::nan_init<result_type, 0>()), std::forward<E>(e), axis);
+        using init_value_type = std::conditional_t<std::is_same<T, void>::value, typename std::decay_t<E>::value_type, T>;
+        return accumulate(make_xaccumulator_functor(detail::nan_plus(), detail::nan_init<init_value_type, 0>()), std::forward<E>(e), axis);
     }
 
-    template <class E>
+    template <class T = void, class E>
     inline auto nancumsum(E&& e)
     {
-        using result_type = xtl::big_promote_type_t<typename std::decay_t<E>::value_type>;
-        return accumulate(make_xaccumulator_functor(detail::nan_plus(), detail::nan_init<result_type, 0>()), std::forward<E>(e));
+        using init_value_type = std::conditional_t<std::is_same<T, void>::value, typename std::decay_t<E>::value_type, T>;
+        return accumulate(make_xaccumulator_functor(detail::nan_plus(), detail::nan_init<init_value_type, 0>()), std::forward<E>(e));
     }
 
     /**
@@ -2496,20 +2533,22 @@ namespace detail {
      * \em axis, replacing nan with 1.
      * @param e an \ref xexpression
      * @param axis the axis along which the elements are accumulated (optional)
+     * @tparam T the result type. The default is `E::value_type`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an xaccumulator
      */
-    template <class E>
+    template <class T = void, class E>
     inline auto nancumprod(E&& e, std::ptrdiff_t axis)
     {
-        using result_type = xtl::big_promote_type_t<typename std::decay_t<E>::value_type>;
-        return accumulate(make_xaccumulator_functor(detail::nan_multiplies(), detail::nan_init<result_type, 1>()), std::forward<E>(e), axis);
+        using init_value_type = std::conditional_t<std::is_same<T, void>::value, typename std::decay_t<E>::value_type, T>;
+        return accumulate(make_xaccumulator_functor(detail::nan_multiplies(), detail::nan_init<init_value_type, 1>()), std::forward<E>(e), axis);
     }
 
-    template <class E>
+    template <class T = void, class E>
     inline auto nancumprod(E&& e)
     {
-        using result_type = xtl::big_promote_type_t<typename std::decay_t<E>::value_type>;
-        return accumulate(make_xaccumulator_functor(detail::nan_multiplies(), detail::nan_init<result_type, 1>()), std::forward<E>(e));
+        using init_value_type = std::conditional_t<std::is_same<T, void>::value, typename std::decay_t<E>::value_type, T>;
+        return accumulate(make_xaccumulator_functor(detail::nan_multiplies(), detail::nan_init<init_value_type, 1>()), std::forward<E>(e));
     }
 
     namespace detail
@@ -2556,6 +2595,8 @@ namespace detail {
      * @param e an \ref xexpression
      * @param axes the axes along which the mean is computed (optional)
      * @param es the evaluation strategy (optional)
+     * @tparam T the result type. The default is `E::value_type`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xexpression
      */
     template <class T = void, class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,
@@ -2618,6 +2659,8 @@ namespace detail {
      * @param e an \ref xexpression
      * @param axes the axes along which the variance is computed (optional)
      * @param es evaluation strategy to use (lazy (default), or immediate)
+     * @tparam T the result type. The default is `E::value_type`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xexpression
      *
      * @sa nanstd, nanmean
@@ -2655,6 +2698,8 @@ namespace detail {
      * @param e an \ref xexpression
      * @param axes the axes along which the standard deviation is computed (optional)
      * @param es evaluation strategy to use (lazy (default), or immediate)
+     * @tparam T the result type. The default is `E::value_type`.
+     *           You can pass `big_promote_value_type_t<E>` to avoid overflow in computation.
      * @return an \ref xexpression
      *
      * @sa nanvar, nanmean

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -49,6 +49,20 @@ constexpr auto operator OP(const std::complex<T1>& arg1, const std::complex<T2>&
 {                                                                                         \
     using result_type = typename xtl::promote_type_t<std::complex<T1>, std::complex<T2>>; \
     return (result_type(arg1) OP result_type(arg2));                                      \
+}                                                                                         \
+                                                                                          \
+template <class T1, class T2, XTL_REQUIRES(xtl::negation<std::is_same<T1, T2>>)>          \
+constexpr auto operator OP(const T1& arg1, const std::complex<T2>& arg2)                  \
+{                                                                                         \
+    using result_type = typename xtl::promote_type_t<T1, std::complex<T2>>;               \
+    return (result_type(arg1) OP result_type(arg2));                                      \
+}                                                                                         \
+                                                                                          \
+template <class T1, class T2, XTL_REQUIRES(xtl::negation<std::is_same<T1, T2>>)>          \
+constexpr auto operator OP(const std::complex<T1>& arg1, const T2& arg2)                  \
+{                                                                                         \
+    using result_type = typename xtl::promote_type_t<std::complex<T1>, T2>;               \
+    return (result_type(arg1) OP result_type(arg2));                                      \
 }
 
 #define BINARY_OPERATOR_FUNCTOR(NAME, OP)                                        \

--- a/test/test_xaccumulator.cpp
+++ b/test/test_xaccumulator.cpp
@@ -22,10 +22,10 @@ namespace xt
     TEST(xaccumulator, one_d)
     {
         xt::xarray<short> a = { short(1), short(2), short(3), short(4)};
-        xt::xarray<long> expected = { 1, 3, 6, 10};
+        xt::xarray<int> expected = { 1, 3, 6, 10};
         auto no_axis = cumsum(a);
         auto with_axis = cumsum(a, 0);
-        bool promotion_works = std::is_same<decltype(no_axis)::value_type, long long>::value;
+        bool promotion_works = std::is_same<decltype(no_axis)::value_type, short>::value;
         EXPECT_TRUE(promotion_works);
         EXPECT_TRUE(all(equal(no_axis, expected)));
 
@@ -208,7 +208,7 @@ namespace xt
     TEST(xaccumulator, xfixed)
     {
         xtensor_fixed<float, xshape<2, 4, 3>> a = xt::random::rand<float>({2, 4, 3});
-        auto res = cumsum(a, 1);
+        auto res = cumsum<double>(a, 1);
 
         bool truth = std::is_same<decltype(res), xtensor_fixed<double, xshape<2, 4, 3>>>::value;
         EXPECT_TRUE(truth);

--- a/test/test_xmath_result_type.cpp
+++ b/test/test_xmath_result_type.cpp
@@ -125,7 +125,7 @@ void check_promoted_types(E&& e)
         CHECK_RESULT_TYPE(2.0 * auchar, double);
         CHECK_RESULT_TYPE(sqrt(auchar), double);
         CHECK_RESULT_TYPE(abs(auchar), unsigned char);
-        CHECK_RESULT_TYPE(sum(auchar), unsigned long long);
+        CHECK_RESULT_TYPE(sum(auchar), int);
         CHECK_RESULT_TYPE(mean(auchar), double);
         CHECK_RESULT_TYPE(minmax(auchar), ARRAY_TYPE(unsigned char));
         CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auchar);
@@ -141,7 +141,7 @@ void check_promoted_types(E&& e)
         CHECK_RESULT_TYPE(2.0 * ashort, double);
         CHECK_RESULT_TYPE(sqrt(ashort), double);
         CHECK_RESULT_TYPE(abs(ashort), decltype(std::abs(short{})));
-        CHECK_RESULT_TYPE(sum(ashort), long long);
+        CHECK_RESULT_TYPE(sum(ashort), int);
         CHECK_RESULT_TYPE(mean(ashort), double);
         CHECK_RESULT_TYPE(minmax(ashort), ARRAY_TYPE(short));
         CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(ashort);
@@ -157,7 +157,7 @@ void check_promoted_types(E&& e)
         CHECK_RESULT_TYPE(2.0 * aushort, double);
         CHECK_RESULT_TYPE(sqrt(aushort), double);
         CHECK_RESULT_TYPE(abs(aushort), unsigned short);
-        CHECK_RESULT_TYPE(sum(aushort), unsigned long long);
+        CHECK_RESULT_TYPE(sum(aushort), int);
         CHECK_RESULT_TYPE(mean(aushort), double);
         CHECK_RESULT_TYPE(minmax(aushort), ARRAY_TYPE(unsigned short));
         CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aushort);
@@ -173,7 +173,7 @@ void check_promoted_types(E&& e)
         CHECK_RESULT_TYPE(2.0 * aint, double);
         CHECK_RESULT_TYPE(sqrt(aint), double);
         CHECK_RESULT_TYPE(abs(aint), int);
-        CHECK_RESULT_TYPE(sum(aint), long long);
+        CHECK_RESULT_TYPE(sum(aint), int);
         CHECK_RESULT_TYPE(mean(aint), double);
         CHECK_RESULT_TYPE(minmax(aint), ARRAY_TYPE(int));
         CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(aint);
@@ -189,7 +189,7 @@ void check_promoted_types(E&& e)
         CHECK_RESULT_TYPE(2.0 * auint, double);
         CHECK_RESULT_TYPE(sqrt(auint), double);
         CHECK_RESULT_TYPE(abs(auint), unsigned int);
-        CHECK_RESULT_TYPE(sum(auint), unsigned long long);
+        CHECK_RESULT_TYPE(sum(auint), unsigned int);
         CHECK_RESULT_TYPE(mean(auint), double);
         CHECK_RESULT_TYPE(minmax(auint), ARRAY_TYPE(unsigned int));
         CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(auint);
@@ -237,7 +237,7 @@ void check_promoted_types(E&& e)
         CHECK_RESULT_TYPE(2.0 * afloat, double);
         CHECK_RESULT_TYPE(sqrt(afloat), float);
         CHECK_RESULT_TYPE(abs(afloat), float);
-        CHECK_RESULT_TYPE(sum(afloat), double);
+        CHECK_RESULT_TYPE(sum(afloat), float);
         CHECK_RESULT_TYPE(mean(afloat), double);
         CHECK_RESULT_TYPE(minmax(afloat), ARRAY_TYPE(float));
         CHECK_TEMPLATED_RESULT_TYPE_FOR_ALL(afloat);
@@ -268,7 +268,7 @@ void check_promoted_types(E&& e)
         CHECK_RESULT_TYPE(2.0f * afcomplex, std::complex<float>);
         CHECK_RESULT_TYPE(sqrt(afcomplex), std::complex<float>);
         CHECK_RESULT_TYPE(abs(afcomplex), float);
-        CHECK_RESULT_TYPE(sum(afcomplex), std::complex<double>);
+        CHECK_RESULT_TYPE(sum(afcomplex), std::complex<float>);
         CHECK_RESULT_TYPE(mean(afcomplex), std::complex<double>);
     }
 

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -498,7 +498,7 @@ namespace xt
     {
         // check that there is no overflow
         xarray<uint8_t> c = 2 * ones<uint8_t>({34});
-        EXPECT_EQ(1ULL << 34, prod(c)());
+        EXPECT_EQ(1ULL << 34, prod<long long>(c)());
     }
 
 #define TEST_OPT_PROD(INPUT)                     \
@@ -868,9 +868,9 @@ namespace xt
         EXPECT_TRUE(b_fx_2 == sum(c, {0, 1}));
         EXPECT_EQ(b_fx_3, sum(c, {0, 1, 2}));
 
-        truth = std::is_same<std::decay_t<decltype(b_fx_1)>, xtensor_fixed<long long, xshape<5>>>::value;
+        truth = std::is_same<std::decay_t<decltype(b_fx_1)>, xtensor_fixed<int, xshape<5>>>::value;
         EXPECT_TRUE(truth);
-        truth = std::is_same<std::decay_t<decltype(b_fx_3)>, xtensor_fixed<long long, xshape<>>>::value;
+        truth = std::is_same<std::decay_t<decltype(b_fx_3)>, xtensor_fixed<int, xshape<>>>::value;
         EXPECT_TRUE(truth);
 
         truth = std::is_same<xshape<1, 3>, typename fixed_xreducer_shape_type<xshape<1, 5, 3>, xshape<1>>::type>();


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Remove use of `xtl::big_promote_type_t` for `reducer`s and `accumulator`s init value type.
The result type is then only driven by the init value type and the expression value type, given the C++ binary operators rules.

This change is backward incompatible.