### PR TITLE
Documentation improvement Part #C

### DIFF
--- a/docs/source/adaptor.rst
+++ b/docs/source/adaptor.rst
@@ -20,8 +20,8 @@ The following example shows how to bring an ``std::vector`` into the expression 
 
     #include <cstddef>
     #include <vector>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xadapt.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xadapt.hpp>
 
     std::vector<double> v = {1., 2., 3., 4., 5., 6. };
     std::vector<std::size_t> shape = { 2, 3 };
@@ -50,7 +50,7 @@ ownership of the array:
 .. code::
 
     #include <cstddef>
-    #include "xtensor/xadapt.hpp"
+    #include <xtensor/xadapt.hpp>
 
     void compute(double* data, std::size_t size)
     {
@@ -82,8 +82,8 @@ the ownership of the array, meaning it will be deleted when the adaptor is destr
 .. code::
 
     #include <cstddef>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xadapt.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xadapt.hpp>
 
     void compute(double*& data, std::size_t size)
     {
@@ -119,8 +119,8 @@ adaptor before calling ``compute`` and pass it to the function:
 .. code::
 
     #include <cstddef>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xadapt.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xadapt.hpp>
 
     template <class A>
     void compute(A& a)
@@ -154,8 +154,8 @@ Adapting C arrays allocated on the stack is as simple as adapting ``std::vector`
 
     #include <cstddef>
     #include <vector>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xadapt.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xadapt.hpp>
 
     double v[6] = {1., 2., 3., 4., 5., 6. };
     std::vector<std::size_t> shape = { 2, 3 };

--- a/docs/source/container.rst
+++ b/docs/source/container.rst
@@ -29,7 +29,7 @@ The following example shows how to initialize a multi-dimensional array of dynam
 .. code::
 
     #include <vector>
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     std::vector<size_t> shape = { 3, 2, 4 };
     std::vector<size_t> strides = { 8, 4, 1 };
@@ -40,7 +40,7 @@ However, this requires to carefully compute the strides to avoid buffer overflow
 .. code::
 
     #include <vector>
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     std::vector<size_t> shape = { 3, 2, 4 };
     xt::xarray<double, xt::layout_type::dynamic> a(shape, xt::layout_type::row_major);
@@ -50,7 +50,7 @@ If the layout of the array can be fixed at compile time, we can make it even sim
 .. code::
 
     #include <vector>
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     std::vector<size_t> shape = { 3, 2, 4 };
     xt::xarray<double, xt::layout_type::row_major> a(shape);
@@ -75,7 +75,7 @@ Let's use ``xtensor`` instead of ``xarray`` in the previous example:
 .. code::
 
     #include <array>
-    #include "xtensor/xtensor.hpp"
+    #include <xtensor/xtensor.hpp>
 
     std::array<size_t, 3> shape = { 3, 2, 4 };
     xt::xtensor<double, 3> a(shape);
@@ -86,7 +86,7 @@ Or when using ``xtensor_fixed``:
 
 .. code::
 
-    #include "xtensor/xfixed.hpp"
+    #include <xtensor/xfixed.hpp>
 
     xt::xtensor_fixed<double, xt::xshape<3, 2, 4>> a();
     // or xt::xtensor_fixed<double, xt::xshape<3, 2, 4>, xt::layout_type::row_major>()
@@ -107,7 +107,7 @@ compatible with the old one, that is, the number of elements in the container mu
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<int> a = { 1, 2, 3, 4, 5, 6, 7, 8};
     // The following two lines ...
@@ -124,7 +124,7 @@ values in the ``shape``:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
     xt::xarray<int> a = { 1, 2, 3, 4, 5, 6, 7, 8};
     a.reshape({2, -1});
     // a.shape() return {2, 4}
@@ -151,8 +151,8 @@ automatically and applies the "temporary variable rule" by default. A mechanism 
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xnoalias.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xnoalias.hpp>
 
     // a, b, and c are xt::xarrays previously initialized
     xt::noalias(b) = a + c;
@@ -167,7 +167,7 @@ The aliasing phenomenon is illustrated in the following example:
 .. code::
 
     #include <vector>
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     std::vector<size_t> a_shape = {3, 2, 4};
     xt::xarray<double> a(a_shape);

--- a/docs/source/developer/concepts.rst
+++ b/docs/source/developer/concepts.rst
@@ -26,7 +26,7 @@ class whose template parameter is ``A`` and should forward this parameter to ``x
 
 .. code::
 
-    #include "xtensor/xexpression.hpp"
+    #include <xtensor/xexpression.hpp>
 
     template <class T>
     class B : public xexpression<T>
@@ -111,7 +111,7 @@ given shape:
     #include <algorithm>
     #include <iterator>
     #include <iostream>
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     int main(int argc, char* argv[])
     {
@@ -146,8 +146,8 @@ The first overload is meant for computed assignment involving a scalar; it allow
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xio.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xio.hpp>
 
     int main(int argc, char* argv)
     {

--- a/docs/source/expression.rst
+++ b/docs/source/expression.rst
@@ -126,7 +126,7 @@ You can access the elements of any ``xexpression`` with ``operator()``:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<double> a = {{1., 2., 3.}, {4., 5., 6.}};
     auto f = 2 * a;
@@ -143,7 +143,7 @@ of the expression:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<double> a = {{1., 2., 3.}, {4., 5., 6.}};
 
@@ -167,7 +167,7 @@ Shape
 .. code::
 
     #include <vector>
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     using array_type = xt::xarray<double>;
     using shape_type = array_type::shape_type;

--- a/docs/source/external-structures.rst
+++ b/docs/source/external-structures.rst
@@ -179,7 +179,7 @@ strides based on the shape and the layout, so the implementation of the ``resize
 
 .. code::
 
-    #include "xtensor/xstrides.hpp" // for utility functions
+    #include <xtensor/xstrides.hpp> // for utility functions
 
     template <class T>
     void resize(const shape_type& shape)

--- a/docs/source/file_loading.rst
+++ b/docs/source/file_loading.rst
@@ -28,8 +28,8 @@ save data in the Comma-separated value format. The reference documentation is :d
     #include <fstream>
     #include <iostream>
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xcsv.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xcsv.hpp>
 
     int main()
     {
@@ -59,8 +59,8 @@ Reference documentation for the functions used is found here :doc:`api/xnpy`.
     #include <iostream>
     #include <fstream>
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xnpy.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xnpy.hpp>
 
     int main()
     {
@@ -85,8 +85,8 @@ The reference documentation is found :doc:`api/xjson`.
 
 .. code::
 
-    #include "xtensor/xjson.hpp"
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xjson.hpp>
+    #include <xtensor/xarray.hpp>
 
     int main()
     {

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -16,9 +16,9 @@ First example
 .. code::
 
     #include <iostream>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xio.hpp"
-    #include "xtensor/xview.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xio.hpp>
+    #include <xtensor/xview.hpp>
 
     int main(int argc, char* argv[])
     {
@@ -142,8 +142,8 @@ This second example initializes a 1-dimensional array and reshapes it in-place:
 .. code::
 
     #include <iostream>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xio.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xio.hpp>
 
     int main(int argc, char* argv[])
     {
@@ -177,7 +177,7 @@ When compiled and run, this produces the following output:
 
   .. code-block:: cpp
 
-      std::cout << xt::adapt(arr.shape()); // with: #include "xtensor/xadapt.hpp"
+      std::cout << xt::adapt(arr.shape()); // with: #include <xtensor/xadapt.hpp>
 
 Third example: index access
 ---------------------------
@@ -185,8 +185,8 @@ Third example: index access
 .. code::
 
     #include <iostream>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xio.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xio.hpp>
 
     int main(int argc, char* argv[])
     {
@@ -219,9 +219,9 @@ This last example shows how to broadcast the ``xt::pow`` universal function:
 .. code::
 
     #include <iostream>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xmath.hpp"
-    #include "xtensor/xio.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xmath.hpp>
+    #include <xtensor/xio.hpp>
 
     int main(int argc, char* argv[])
     {

--- a/docs/source/operator.rst
+++ b/docs/source/operator.rst
@@ -58,7 +58,7 @@ and an element-wise ternary function (similar to the ``: ?`` ternary operator):
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<bool> b = { false, true, true, false };
     xt::xarray<int> a1 = { 1,   2,  3,  4 };
@@ -86,7 +86,7 @@ C++ inequality operators: they are element-wise operators returning boolean
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<int> a1 = {  1, 12,  3, 14 };
     xt::xarray<int> a2 = { 11,  2, 13, 4  };
@@ -103,7 +103,7 @@ function.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<int> a1 = {  1,  2, 3, 4};
     xt::xarray<int> a2 = { 11, 12, 3, 4};
@@ -151,7 +151,7 @@ performed via ``cast``, which performs an element-wise ``static_cast``.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<int> a = { 3, 5, 7 };
 
@@ -171,8 +171,8 @@ axes removed.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xmath.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xmath.hpp>
 
     xt::xarray<double> a = xt::ones<double>({3, 2, 4, 6, 5});
     xt::xarray<double> res = xt::sum(a, {1, 3});
@@ -183,8 +183,8 @@ You can also call the ``reduce`` generator with your own reducing function:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xreducer.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xreducer.hpp>
 
     xt::xarray<double> arr = some_init_function({3, 2, 4, 6, 5});
     xt::xarray<double> res = xt::reduce([](double a, double b) { return a*a + b*b; },
@@ -197,8 +197,8 @@ build the ``xreducer_functors`` object, the last function can be omitted:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xreducer.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xreducer.hpp>
 
     xt::xarray<double> arr = some_init_function({3, 2, 4, 6, 5});
     xt::xarray<double> res = xt::reduce(xt::make_xreducer_functor([](double a, double b) { return a*a + b*b; },
@@ -212,8 +212,8 @@ the evaluation and get the result:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xreducer.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xreducer.hpp>
 
     xt::xarray<double> arr = some_init_function({3, 2, 4, 6, 5});
     double res = xt::reduce([](double a, double b) { return a*a + b*b; }, arr)();
@@ -230,8 +230,8 @@ computation:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xreducer.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xreducer.hpp>
 
     xt::xarray<int> arr = some_init_function({3, 2, 4, 6, 5});
     auto s1 = xt::sum<short>(arr); // No effect, short + int = int
@@ -242,8 +242,8 @@ as shown below:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xreducer.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xreducer.hpp>
     
     template <class E>
     void my_computation(E&& e)
@@ -262,8 +262,8 @@ or ``xtensor``.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xmath.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xmath.hpp>
 
     xt::xarray<double> a = xt::ones<double>({5, 8, 3});
     xt::xarray<double> res = xt::cumsum(a, 1);
@@ -276,8 +276,8 @@ function. For example, the implementation of cumsum is as follows:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xaccumulator.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xaccumulator.hpp>
 
     xt::xarray<double> arr = some_init_function({5, 5, 5});
     xt::xarray<double> res = xt::accumulate([](double a, double b) { return a + b; },
@@ -290,8 +290,8 @@ with the same rules as those for reducers:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xaccumulator.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xaccumulator.hpp>
 
     xt::xarray<int> arr = some_init_function({5, 5, 5});
     auto r1 = xt::cumsum<short>(a, 1);
@@ -320,8 +320,8 @@ Choosing an evaluation_strategy is straightforward. For reducers:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xreducer.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xreducer.hpp>
 
     xt::xarray<double> a = xt::ones<double>({3, 2, 4, 6, 5});
     auto res = xt::sum(a, {1, 3}, xt::evaluation_strategy::immediate);
@@ -348,8 +348,8 @@ arguments:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xvectorize.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xvectorize.hpp>
 
     int f(int a, int b)
     {

--- a/docs/source/quickref/basic.rst
+++ b/docs/source/quickref/basic.rst
@@ -27,7 +27,7 @@ Tensor with dynamic shape:
 
 .. code::
 
-    #include "xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<double>::shape_type shape = {2, 3};
     xt::xarray<double> a0(shape);
@@ -39,7 +39,7 @@ Tensor with static number of dimensions:
 
 .. code::
 
-    #include "xtensor.hpp"
+    #include <xtensor/xtensor.hpp>
 
     xt::xtensor<double, 2>::shape_type shape = {2, 3};
     xt::xtensor<double, 2> a0(shape);
@@ -51,7 +51,7 @@ Tensor with fixed shape:
 
 .. code::
 
-    #include "xfixed.hpp"
+    #include <xtensor/xfixed.hpp>
 
     xt::xtensor_fixed<double, xt::xshape<2, 3>> = {{1., 2., 3.}, {4., 5., 6.}};
 
@@ -59,7 +59,7 @@ In-memory chunked tensor with dynamic shape:
 
 .. code::
 
-    #include "xtensor/xchunked_array.hpp"
+    #include <xtensor/xchunked_array.hpp>
 
     std::vector<std::size_t> shape = {10, 10, 10};
     std::vector<std::size_t> chunk_shape = {2, 3, 4};
@@ -70,10 +70,10 @@ Output
 
 .. code::
 
-    #include "xarray.hpp"
-    #include "xfixed.hpp"
-    #include "xio.hpp"
-    #include "xtensor.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xfixed.hpp>
+    #include <xtensor/xio.hpp>
+    #include <xtensor/xtensor.hpp>
 
     xt::xarray<double> a = {{1., 2.}, {3., 4.}};
     std::cout << a << std::endl;

--- a/docs/source/quickref/chunked_arrays.rst
+++ b/docs/source/quickref/chunked_arrays.rst
@@ -33,7 +33,7 @@ An in-memory chunked array has the following type:
 
 .. code::
 
-    #include "xtensor/xchunked_array.hpp"
+    #include <xtensor/xchunked_array.hpp>
 
     using data_type = double;
     // don't use this code:
@@ -44,7 +44,7 @@ use the `chunked_array` factory function:
 
 .. code::
 
-    #include "xtensor/xchunked_array.hpp"
+    #include <xtensor/xchunked_array.hpp>
 
     std::vector<std::size_t> shape = {10, 10, 10};
     std::vector<std::size_t> chunk_shape = {2, 3, 4};

--- a/docs/source/quickref/iterator.rst
+++ b/docs/source/quickref/iterator.rst
@@ -14,7 +14,7 @@ Default iteration
 
     #include <iostream>
     #include <iterator>
-    #include "xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<int> a = {{1, 2, 3}, {4, 5, 6}};
     std::copy(a.begin(), a.end(), std::ostream_iterator<int>(std::cout, ", "));
@@ -27,7 +27,7 @@ Specified traversal order
 
     #include <iostream>
     #include <iterator>
-    #include "xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<int> a = {{1, 2, 3}, {4, 5, 6}};
     std::copy(a.begin<layout_type::row_major>(),
@@ -47,7 +47,7 @@ Broacasting iteration
 
     #include <iostream>
     #include <iterator>
-    #include "xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<int> a = {{1, 2, 3}, {4, 5, 6}};
     using shape_type = xt::dynamic_shape<std::size_t>;
@@ -73,9 +73,9 @@ Iterating over axis 0:
 
 .. code::
 
-    #include "xarray.hpp"
-    #include "xaxis_slice_iterator.hpp"
-    #include "xio.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xaxis_slice_iterator.hpp>
+    #include <xtensor/xio.hpp>
 
     xarray<int> a = {{{1, 2, 3, 4},
                       {5, 6, 7, 8},
@@ -108,9 +108,9 @@ Iterating over axis 1:
 
 .. code::
 
-    #include "xarray.hpp"
-    #include "xaxis_slice_iterator.hpp"
-    #include "xio.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xaxis_slice_iterator.hpp>
+    #include <xtensor/xio.hpp>
 
     xarray<int> a = {{{1, 2, 3, 4},
                       {5, 6, 7, 8},
@@ -139,9 +139,9 @@ Iterating over axis 2:
 
 .. code::
 
-    #include "xarray.hpp"
-    #include "xaxis_slice_iterator.hpp"
-    #include "xio.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xaxis_slice_iterator.hpp>
+    #include <xtensor/xio.hpp>
 
     xarray<int> a = {{{1, 2, 3, 4},
                       {5, 6, 7, 8},
@@ -171,9 +171,9 @@ Iterating over axis 0:
 
 .. code::
 
-    #include "xarray.hpp"
-    #include "xaxis_iterator.hpp"
-    #include "xio.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xaxis_iterator.hpp>
+    #include <xtensor/xio.hpp>
 
     xarray<int> a = {{{1, 2, 3, 4},
                       {5, 6, 7, 8},
@@ -200,9 +200,9 @@ Iterating over axis 1:
 
 .. code::
 
-    #include "xarray.hpp"
-    #include "xaxis_iterator.hpp"
-    #include "xio.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xaxis_iterator.hpp>
+    #include <xtensor/xio.hpp>
 
     xarray<int> a = {{{1, 2, 3, 4},
                       {5, 6, 7, 8},
@@ -229,9 +229,9 @@ Iterating over axis 2:
 
 .. code::
 
-    #include "xarray.hpp"
-    #include "xaxis_iterator.hpp"
-    #include "xio.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xaxis_iterator.hpp>
+    #include <xtensor/xio.hpp>
 
     xarray<int> a = {{{1, 2, 3, 4},
                       {5, 6, 7, 8},

--- a/docs/source/quickref/manipulation.rst
+++ b/docs/source/quickref/manipulation.rst
@@ -12,7 +12,7 @@ atleast_Nd
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     xt::xarray<int> a0 = 123;
     auto r1 = xt::atleast_1d(a0);
@@ -27,7 +27,7 @@ expand_dims
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     xt::xarray<int> a = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
     auto r0 = xt::expand_dims(a, 0);
@@ -39,7 +39,7 @@ flip
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     xt::xarray<int> a = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
     auto f0 = xt::flip(a, 0);
@@ -50,7 +50,7 @@ repeat
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     xt::xarray<int> a = {{1, 2}, {3, 4}};
     auto r0 = xt::repeat(a, 3, 1);
@@ -61,7 +61,7 @@ roll
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     xt::xarray<int> a = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
     auto t0 = xt::roll(a, 2);
@@ -72,7 +72,7 @@ rot90
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     xt::xarray<int> a = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
     auto r0 = xt::rot90<1>(a);
@@ -85,7 +85,7 @@ split
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     xt::xarray<int> a = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
     auto s0 = xt::split(a, 3);
@@ -96,7 +96,7 @@ hsplit
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     xt::xarray<int> a = {{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}};
     auto res = xt::hsplit(a, 2);
@@ -106,7 +106,7 @@ vsplit
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     xt::xarray<int> a = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}};
     auto res = xt::vsplit(a, 2);
@@ -116,7 +116,7 @@ squeeze
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     auto b = xt::xarray<double>::from_shape({3, 3, 1, 1, 2, 1, 3});
     auto sq0 = xt::xqueeze(b);
@@ -128,7 +128,7 @@ trim_zeros
 
 .. code::
 
-    #include "xmanipulation.hpp"
+    #include <xtensor/xmanipulation.hpp>
 
     xt::xarray<int> a = {0, 0, 0, 1, 3, 0};
     auto t0 = xt::trim_zeros(a);

--- a/docs/source/related.rst
+++ b/docs/source/related.rst
@@ -36,10 +36,10 @@ Example 1: Use an algorithm of the C++ library on a numpy array in-place
 .. code::
 
     #include <numeric>                        // Standard library import for std::accumulate
-    #include "pybind11/pybind11.h"            // Pybind11 import to define Python bindings
-    #include "xtensor/xmath.hpp"              // xtensor import for the C++ universal functions
+    #include <pybind11/pybind11.h>            // Pybind11 import to define Python bindings
+    #include <xtensor/xmath.hpp>              // xtensor import for the C++ universal functions
     #define FORCE_IMPORT_ARRAY                // numpy C api loading
-    #include "xtensor-python/pyarray.hpp"     // Numpy bindings
+    #include <xtensor-python/pyarray.hpp>     // Numpy bindings
 
     double sum_of_sines(xt::pyarray<double> &m)
     {
@@ -84,9 +84,9 @@ Example 2: Create a universal function from a C++ scalar function
 
 .. code::
 
-    #include "pybind11/pybind11.h"
+    #include <pybind11/pybind11.h>
     #define FORCE_IMPORT_ARRAY
-    #include "xtensor-python/pyvectorize.hpp"
+    #include <xtensor-python/pyvectorize.hpp>
     #include <numeric>
     #include <cmath>
 
@@ -168,8 +168,8 @@ Example 1: Use an algorithm of the C++ library with a Julia array
 
     #include <numeric>                        // Standard library import for std::accumulate
     #include <cxx_wrap.hpp>                   // CxxWrap import to define Julia bindings
-    #include "xtensor-julia/jltensor.hpp"     // Import the jltensor container definition
-    #include "xtensor/xmath.hpp"              // xtensor import for the C++ universal functions
+    #include <xtensor-julia/jltensor.hpp>     // Import the jltensor container definition
+    #include <xtensor/xmath.hpp>              // xtensor import for the C++ universal functions
 
     double sum_of_sines(xt::jltensor<double, 2> m)
     {
@@ -208,7 +208,7 @@ Example 2: Create a numpy-style universal function from a C++ scalar function
 .. code::
 
     #include <cxx_wrap.hpp>
-    #include "xtensor-julia/jlvectorize.hpp"
+    #include <xtensor-julia/jlvectorize.hpp>
 
     double scalar_func(double i, double j)
     {
@@ -280,8 +280,8 @@ Example 1: Use an algorithm of the C++ library on a R array in-place
 .. code::
 
     #include <numeric>                    // Standard library import for std::accumulate
-    #include "xtensor/xmath.hpp"          // xtensor import for the C++ universal functions
-    #include "xtensor-r/rarray.hpp"       // R bindings
+    #include <xtensor/xmath.hpp>          // xtensor import for the C++ universal functions
+    #include <xtensor-r/rarray.hpp>       // R bindings
     #include <Rcpp.h>
 
     using namespace Rcpp;

--- a/docs/source/scalar.rst
+++ b/docs/source/scalar.rst
@@ -16,7 +16,7 @@ array containing the scalar value:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<double> a = {{0., 1., 2.}, {3., 4., 5.}};
     double s = 1.2;
@@ -36,7 +36,7 @@ Assuming that the scalar assignment does not resize the array, we have the follo
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<double> a = {{0., 1., 2.}, {3., 4., 5.}};
     double s = 1.2;
@@ -48,7 +48,7 @@ This is not consistent with the behavior of the copy constructor from a scalar:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<double> a(1.2);
     std::cout << a << std::endl;
@@ -59,7 +59,7 @@ a scalar:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
+    #include <xtensor/xarray.hpp>
 
     xt::xarray<double> a = {{0., 1., 2.}, {3., 4., 5.}};
     a = 1.2;

--- a/docs/source/view.rst
+++ b/docs/source/view.rst
@@ -33,8 +33,8 @@ Slices can be specified in the following ways:
 .. code::
 
     #include <vector>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xview.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xview.hpp>
 
     std::vector<size_t> shape = {3, 2, 4};
     xt::xarray<int> a(shape);
@@ -70,8 +70,8 @@ The range function supports the placeholder ``_`` syntax:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xview.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xview.hpp>
 
     using namespace xt::placeholders;  // required for `_` to work
 
@@ -86,8 +86,8 @@ you are actually also altering the underlying expression.
 .. code::
 
     #include <vector>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xview.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xview.hpp>
 
     std::vector<size_t> shape = {3, 2, 4};
     xt::xarray<int> a(shape, 0);
@@ -101,8 +101,8 @@ The convenient methods ``row`` and ``col`` are available for 2-D expressions:
 .. code::
 
     #include <vector>
-    #include "xtensor/xtensor.hpp"
-    #include "xtensor/xview.hpp"
+    #include <xtensor/xtensor.hpp>
+    #include <xtensor/xview.hpp>
 
     xt::xtensor<double, 2> a = {{1, 2}, {3, 4}};
     auto r = xt::row(a, 0);
@@ -120,8 +120,8 @@ all the slice types. The strided view does not support the slices returned by th
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xstrided_view.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xstrided_view.hpp>
 
     auto a = xt::xarray<int>::from_shape({3, 2, 3, 4, 5});
 
@@ -144,8 +144,8 @@ Since ``xtensor 0.16.3``, a new range syntax can be used with strided views:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xstrided_view.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xstrided_view.hpp>
 
     using namespace xt::placeholders;
 
@@ -164,8 +164,8 @@ a transposed view on a expression with a dynamic layout throws an exception.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xstrided_view.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xstrided_view.hpp>
 
     xt::xarray<int> a = { {0, 1, 2}, {3, 4, 5} };
     auto tr = xt::transpose(a);
@@ -186,8 +186,8 @@ uses the layout of the expression.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xstrided_view.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xstrided_view.hpp>
 
     xt::xarray<int> a = { {0, 1, 2}, {3, 4, 5} };
     auto flc = xt::ravel<layout_type::column_major>(a);
@@ -209,8 +209,8 @@ the view modifies the underlying expression.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xstrided_view.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xstrided_view.hpp>
 
     auto a = xt::xarray<int>::from_shape({3, 2, 4});
     auto v = xt::reshape_view(a, { 4, 2, 3 });
@@ -231,8 +231,8 @@ slice is involved.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xdynamic_view.hpp
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xdynamic_view.hp>
 
     auto a = xt::xarray<int>::from_shape({3, 2, 3, 4, 5});
     xt::xdynamic_slice_vector sv({xt::range(0, 1), xt::newaxis()});
@@ -256,8 +256,8 @@ with the ``index_view`` helper function.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xindex_view.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xindex_view.hpp>
 
     xt::xarray<double> a = {{1, 5, 3}, {4, 5, 6}};
     auto b = xt::index_view(a, {{0,0}, {1, 0}, {0, 1}});
@@ -270,8 +270,8 @@ of the list of indices:
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xindex_view.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xindex_view.hpp>
 
     xt::xarray<double> a = {{1, 5, 3}, {4, 5, 6}};
     using index_type = std::array<std::size_t, 2>;
@@ -289,8 +289,8 @@ the elements of the underlying ``xexpression`` are not copied. Filters should be
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xindex_view.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xindex_view.hpp>
 
     xt::xarray<double> a = {{1, 5, 3}, {4, 5, 6}};
     auto v = xt::filter(a, a >= 5);
@@ -308,8 +308,8 @@ computed scalar assignments.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xindex_view.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xindex_view.hpp>
 
     xt::xarray<double> a = {{1, 5, 3}, {4, 5, 6}};
     filtration(a, a >= 5) += 100;
@@ -322,8 +322,8 @@ Masked views are multidimensional views that apply a mask on an ``xexpression``.
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xmasked_view.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xmasked_view.hpp>
 
     xt::xarray<double> a = {{1, 5, 3}, {4, 5, 6}};
     xt::xarray<bool> mask = {{true, false, false}, {false, true, false}};
@@ -344,8 +344,8 @@ built with the ``broadcast`` helper function.
 .. code::
 
     #include <vector>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xbroadcast.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xbroadcast.hpp>
 
     std::vector<size_t> s1 = { 2, 3 };
     std::vector<size_t> s2 = { 3, 2, 3 };
@@ -371,8 +371,8 @@ The returned value is an expression holding a closure on the passed argument.
 .. code::
 
     #include <complex>
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xcomplex.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xcomplex.hpp>
 
     using namespace std::complex_literals;
 
@@ -391,8 +391,8 @@ of ``rhs``. However, since views *cannot be resized*, when assigning an expressi
 
 .. code::
 
-    #include "xtensor/xarray.hpp"
-    #include "xtensor/xview.hpp"
+    #include <xtensor/xarray.hpp>
+    #include <xtensor/xview.hpp>
 
     xarray<double> a = {{0., 1., 2.}, {3., 4., 5.}};
     double b = 1.2;


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] ~Tests have been added for new features or bug fixes.~
- [x] ~API of new functions and classes are documented.~

# Description
For everyone sake, I thought it would be easier to split #2248 in multiple PR.
Here we change all `#include` statements in the doc to use the format `#include <xtensor/...>`