### PR TITLE
Added missing shape_type in xfunctor_stepper

### DIFF
--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -594,6 +594,8 @@ namespace xt
         using size_type = typename ST::size_type;
         using difference_type = typename ST::difference_type;
 
+        using shape_type = typename ST::shape_type;
+
         xfunctor_stepper() = default;
         xfunctor_stepper(const ST&, functor_type*);
 


### PR DESCRIPTION
# Checklist

- [ ] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
