### PR TITLE
adding xt::adapt(xt::sequence_view).

### DIFF
--- a/include/xtensor/xadapt.hpp
+++ b/include/xtensor/xadapt.hpp
@@ -403,6 +403,11 @@ namespace xt
         return adapt(std::forward<C>(ptr), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
 
+    template<class E, std::ptrdiff_t Start, std::ptrdiff_t End>
+    inline auto adapt(const xt::sequence_view<E, Start, End>& view) {
+        return adapt(&view.front(), {view.size()});
+    }
+
     /*****************************
      * smart_ptr adapter builder *
      *****************************/


### PR DESCRIPTION
Usually when working with tensor shapes, we use `xt::adapt`. This works great, since shapes are always containers, except when using `xt::view` with `xt::all()` in all dimensions, the shape returned will be `xt::sequence_view`, which you cannot adapt correctly.
So this pull request allows the following:

```
auto shape = xt::adapt(xt::view(tensor, xt::all()).shape());
```