### PR TITLE
Fix simd assign_data

### DIFF
--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -375,7 +375,7 @@ namespace xt
         using traits = xassign_traits<E1, E2>;
 
         bool linear_assign = traits::linear_assign(de1, de2, trivial);
-        constexpr bool simd_assign = traits::simd_linear_assign();
+        constexpr bool simd_assign = traits::simd_assign();
         constexpr bool simd_linear_assign = traits::simd_linear_assign();
         constexpr bool simd_strided_assign = traits::simd_strided_assign();
         if (linear_assign)

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -912,14 +912,12 @@ namespace xt
         std::size_t dim = shape.size();
         if (m_shape.size() != dim || !std::equal(std::begin(shape), std::end(shape), std::begin(m_shape)) || force)
         {
-            if (D::static_layout == layout_type::dynamic && m_layout == layout_type::dynamic)
-            {
-                m_layout = XTENSOR_DEFAULT_LAYOUT;  // fall back to default layout
-            }
+            layout_type layout = (D::static_layout == layout_type::dynamic && m_layout == layout_type::dynamic) ? XTENSOR_DEFAULT_LAYOUT : m_layout;
             m_shape = xtl::forward_sequence<shape_type, S>(shape);
+
             resize_container(m_strides, dim);
             resize_container(m_backstrides, dim);
-            size_type data_size = compute_strides<D::static_layout>(m_shape, m_layout, m_strides, m_backstrides);
+            size_type data_size = compute_strides<D::static_layout>(m_shape, layout, m_strides, m_backstrides);
             detail::resize_data_container(this->storage(), data_size);
         }
     }

--- a/test/test_xmanipulation.cpp
+++ b/test/test_xmanipulation.cpp
@@ -137,6 +137,34 @@ namespace xt
         EXPECT_EQ(iter, view.end());
     }
 
+    TEST(xmanipulation, flatten_simd_linear_assign_trait)
+    {
+        xtensor<double, 3> a = linspace<double>(1., 100., 100).reshape({2, 5, 10});
+        auto v = view(a, range(0, 2), range(0, 3), range(0, 3));
+
+        {
+            auto e = flatten<XTENSOR_DEFAULT_LAYOUT>(a);
+            xtensor<double, 1> fl = e;
+            using assign_traits = xassign_traits<decltype(fl), decltype(e)>;
+        
+        #if XTENSOR_USE_XSIMD
+            EXPECT_TRUE(assign_traits::simd_linear_assign());
+            EXPECT_TRUE(assign_traits::simd_linear_assign(fl, e));
+        #else
+            EXPECT_FALSE(assign_traits::simd_linear_assign());
+            EXPECT_FALSE(assign_traits::simd_linear_assign(fl, e));
+        #endif
+        }
+
+        {
+            auto e = flatten<XTENSOR_DEFAULT_LAYOUT>(v);
+            xtensor<double, 1> fl = e;
+            using assign_traits = xassign_traits<decltype(fl), decltype(e)>;
+            EXPECT_FALSE(assign_traits::simd_linear_assign());
+            EXPECT_FALSE(assign_traits::simd_linear_assign(fl, e));
+        }
+    }
+
     TEST(xmanipulation, flatnonzero)
     {
         xt::xtensor<int, 1> a = arange(-2, 3);


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Fix `simd_assign` trait in `xexpression_assigner_base<xtensor_expression_tag>::assign_data` method.

Also fix `xstrided_container` layout that is currently overriden by the `resize` method. Since there is no guarantee that the storage is contiguous, the `layout` property must not be overriden.

# Discussion

The current notion of storage `layout` mixes :
- the storage layout itself
- the data contiguity
  - `layout_type::row_major` and `layout_type::column_major` *implies* the data are contiguous
  - `layout_type::dynamic` *implies* the data are **not** contiguous

Maybe there is opportunity to distinguish those 2 notions to improve performances on `layout_type::dynamic` layout.
@SylvainCorlay @JohanMabille 