### PR TITLE
fix more on -Wunused-local-typedef warning

### DIFF
--- a/include/xtensor/xaxis_iterator.hpp
+++ b/include/xtensor/xaxis_iterator.hpp
@@ -104,7 +104,6 @@ namespace xt
         auto derive_xstrided_view(CT&& e, typename std::decay_t<CT>::size_type axis, typename std::decay_t<CT>::size_type offset)
         {
             using xexpression_type = std::decay_t<CT>;
-            using size_type = typename xexpression_type::size_type;
             using shape_type = typename xexpression_type::shape_type;
             using strides_type = typename xexpression_type::strides_type;
 
@@ -237,7 +236,7 @@ namespace xt
     /**
      * Checks equality of the xaxis_slice_iterator and \c rhs.
      *
-     * @param 
+     * @param
      * @return true if the iterators are equivalent, false otherwise
      */
     template <class CT>
@@ -290,7 +289,7 @@ namespace xt
      *
      * @param e the expession to iterate over
      * @param axis the axis to iterate over
-     * @return an instance of xaxis_iterator 
+     * @return an instance of xaxis_iterator
      */
     template <class E>
     inline auto axis_begin(E&& e, typename std::decay_t<E>::size_type axis)
@@ -320,7 +319,7 @@ namespace xt
      *
      * @param e the expession to iterate over
      * @param axis the axis to iterate over
-     * @return an instance of xaxis_iterator 
+     * @return an instance of xaxis_iterator
      */
     template <class E>
     inline auto axis_end(E&& e, typename std::decay_t<E>::size_type axis)

--- a/include/xtensor/xhistogram.hpp
+++ b/include/xtensor/xhistogram.hpp
@@ -494,10 +494,12 @@ namespace xt
             return n;
         }
 
+        #ifdef XTENSOR_ENABLE_ASSERT
         using value_type = typename std::decay_t<E>::value_type;
 
         XTENSOR_ASSERT(xt::all(weights >= static_cast<value_type>(0)));
         XTENSOR_ASSERT(xt::sum(weights)() > static_cast<value_type>(0));
+        #endif
 
         xt::xtensor<double, 1> P = xt::cast<double>(weights) / static_cast<double>(xt::sum(weights)());
         xt::xtensor<size_t, 1> n = xt::ceil(static_cast<double>(N) * P);


### PR DESCRIPTION
fix more on `-Wunused-local-typedef` warning.

The second typedef is not used if `XTENSOR_ENABLE_ASSERT` is not defined.