### PR TITLE
Add two more overloads for histogram

### DIFF
--- a/docs/source/api/xhistogram.rst
+++ b/docs/source/api/xhistogram.rst
@@ -36,7 +36,13 @@ Further overloads
 .. doxygenfunction:: xt::histogram(E1&&, std::size_t, bool)
    :project: xtensor
 
+.. doxygenfunction:: xt::histogram(E1&&, std::size_t, E2, E2, bool)
+   :project: xtensor
+
 .. doxygenfunction:: xt::histogram(E1&&, std::size_t, E2&&, bool)
+   :project: xtensor
+
+.. doxygenfunction:: xt::histogram(E1&&, std::size_t, E2&&, E3, E3, bool)
    :project: xtensor
 
 .. doxygenfunction:: xt::histogram_bin_edges(E1&&, E2, E2, std::size_t, histogram_algorithm)

--- a/include/xtensor/xhistogram.hpp
+++ b/include/xtensor/xhistogram.hpp
@@ -200,6 +200,31 @@ namespace xt
      *
      * @param data The data.
      * @param bins The number of bins.
+     * @param left The lower-most edge.
+     * @param right The upper-most edge.
+     * @param density If true the resulting integral is normalized to 1. [default: false]
+     * @return An one-dimensional xarray<double>, length: bin_edges.size()-1.
+     */
+    template <class R = double, class E1, class E2>
+    inline auto histogram(E1&& data, std::size_t bins, E2 left, E2 right, bool density = false)
+    {
+        using value_type = typename std::decay_t<E1>::value_type;
+
+        auto n = data.size();
+
+        return detail::histogram_imp<R>(std::forward<E1>(data),
+                                        histogram_bin_edges(data, left, right, bins),
+                                        xt::ones<value_type>({ n }),
+                                        density,
+                                        true);
+    }
+
+    /**
+     * @ingroup histogram
+     * @brief Compute the histogram of a set of data.
+     *
+     * @param data The data.
+     * @param bins The number of bins.
      * @param weights Weight factors corresponding to each data-point.
      * @param density If true the resulting integral is normalized to 1. [default: false]
      * @return An one-dimensional xarray<double>, length: bin_edges.size()-1.
@@ -212,6 +237,28 @@ namespace xt
                                      std::forward<E2>(weights),
                                      density,
                                      true);
+    }
+
+    /**
+     * @ingroup histogram
+     * @brief Compute the histogram of a set of data.
+     *
+     * @param data The data.
+     * @param bins The number of bins.
+     * @param left The lower-most edge.
+     * @param right The upper-most edge.
+     * @param weights Weight factors corresponding to each data-point.
+     * @param density If true the resulting integral is normalized to 1. [default: false]
+     * @return An one-dimensional xarray<double>, length: bin_edges.size()-1.
+     */
+    template <class R = double, class E1, class E2, class E3>
+    inline auto histogram(E1&& data, std::size_t bins, E2&& weights, E3 left, E3 right, bool density = false)
+    {
+        return detail::histogram_imp<R>(std::forward<E1>(data),
+                                        histogram_bin_edges(data, weights, left, right, bins),
+                                        std::forward<E2>(weights),
+                                        density,
+                                        true);
     }
 
     /**

--- a/include/xtensor/xhistogram.hpp
+++ b/include/xtensor/xhistogram.hpp
@@ -157,18 +157,18 @@ namespace xt
      * @param density If true the resulting integral is normalized to 1. [default: false]
      * @return An one-dimensional xarray<double>, length: bin_edges.size()-1.
      */
-    template <class E1, class E2>
+    template <class R = double, class E1, class E2>
     inline auto histogram(E1&& data, E2&& bin_edges, bool density = false)
     {
         using value_type = typename std::decay_t<E1>::value_type;
 
         auto n = data.size();
 
-        return detail::histogram_imp(std::forward<E1>(data),
-                                     std::forward<E2>(bin_edges),
-                                     xt::ones<value_type>({ n }),
-                                     density,
-                                     false);
+        return detail::histogram_imp<R>(std::forward<E1>(data),
+                                        std::forward<E2>(bin_edges),
+                                        xt::ones<value_type>({ n }),
+                                        density,
+                                        false);
     }
 
     /**
@@ -180,18 +180,18 @@ namespace xt
      * @param density If true the resulting integral is normalized to 1. [default: false]
      * @return An one-dimensional xarray<double>, length: bin_edges.size()-1.
      */
-    template <class E1>
+    template <class R = double, class E1>
     inline auto histogram(E1&& data, std::size_t bins = 10, bool density = false)
     {
         using value_type = typename std::decay_t<E1>::value_type;
 
         auto n = data.size();
 
-        return detail::histogram_imp(std::forward<E1>(data),
-                                     histogram_bin_edges(data, xt::ones<value_type>({ n }), bins),
-                                     xt::ones<value_type>({ n }),
-                                     density,
-                                     true);
+        return detail::histogram_imp<R>(std::forward<E1>(data),
+                                        histogram_bin_edges(data, xt::ones<value_type>({ n }), bins),
+                                        xt::ones<value_type>({ n }),
+                                        density,
+                                        true);
     }
 
     /**
@@ -229,14 +229,14 @@ namespace xt
      * @param density If true the resulting integral is normalized to 1. [default: false]
      * @return An one-dimensional xarray<double>, length: bin_edges.size()-1.
      */
-    template <class E1, class E2>
+    template <class R = double, class E1, class E2>
     inline auto histogram(E1&& data, std::size_t bins, E2&& weights, bool density = false)
     {
-        return detail::histogram_imp(std::forward<E1>(data),
-                                     histogram_bin_edges(data, weights, bins),
-                                     std::forward<E2>(weights),
-                                     density,
-                                     true);
+        return detail::histogram_imp<R>(std::forward<E1>(data),
+                                        histogram_bin_edges(data, weights, bins),
+                                        std::forward<E2>(weights),
+                                        density,
+                                        true);
     }
 
     /**

--- a/test/test_xhistogram.cpp
+++ b/test/test_xhistogram.cpp
@@ -40,6 +40,27 @@ namespace xt
         }
 
         {
+            xt::xtensor<double, 1> count = xt::histogram(data, size_t(2), 0.5, 1.5);
+
+            EXPECT_EQ(count.size(), std::size_t(2));
+            EXPECT_EQ(count(0), 0.);
+            EXPECT_EQ(count(1), 2.);
+        }
+
+        {
+            // test specifying return type as well
+            auto count = xt::histogram<float>(
+                    data, size_t(2), xt::xtensor<double, 1>({1., 2., 1., 1.}), 0.5, 1.5);
+
+            EXPECT_EQ(count.size(), std::size_t(2));
+            EXPECT_EQ(count(0), 0.f);
+            EXPECT_EQ(count(1), 3.f);
+            bool is_same_type = std::is_same<decltype(count)::value_type, float>::value;
+            EXPECT_TRUE(is_same_type);
+        }
+
+        {
+            // test input being a container other than xtensor
             xt::xarray<double> arr = {1., 1., 2., 2.};
             xt::xtensor<double, 1> count = xt::histogram(arr, std::size_t(2));
 


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->

I think two more overloads would be required to make `histogram` work better with the fast equal-bin implementation. If you agree, I will add the unittest and the documentation. 
