### PR TITLE
Fix linespace with only one point

### DIFF
--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -214,7 +214,7 @@ namespace xt
             {
                 buf[i] = static_cast<R>(start + step * mult_type(i));
             }
-            if (num > 0 && endpoint)
+            if (endpoint && num > 1)
             {
                 buf[num-1] = static_cast<R>(stop);
             }

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -246,7 +246,10 @@ namespace xt
         xt::xarray<double> c = linspace<double>(0., 2., 1, true);
         EXPECT_EQ(c.dimension(), size_t(1));
         EXPECT_EQ(c.shape(), expected_shape);
-        EXPECT_EQ(0., b(0));
+        EXPECT_EQ(0., c(0));
+
+        auto d = linspace<double>(0., 2., 1, true);
+        EXPECT_EQ(c, d);
     }
 
     TEST(xbuilder, linspace_n_samples_endpoint)
@@ -284,6 +287,15 @@ namespace xt
         xarray<int> expected = {0, 0, 1, 2, 3, 4, 5, 5, 6, 7, 8, 9, 10};
 
         ASSERT_TRUE(all(equal(ls, expected)));
+    }
+
+    TEST(xbuilder, linspace_double)
+    {
+        // access_imp will also be tested here
+        double at_end = 99.78730976641236;
+        xt::xarray<double> a = xt::linspace(0., at_end, 100);
+        auto b = xt::linspace(0., at_end, 100);
+        EXPECT_EQ(a, b);
     }
 
     TEST(xbuilder, logspace)
@@ -689,14 +701,5 @@ namespace xt
         EXPECT_TRUE(b);
         b = std::is_same<decltype(ed3), xarray<double>>::value;
         EXPECT_TRUE(b);
-    }
-
-    TEST(xbuilder, linspace_double)
-    {
-        // access_imp will also be tested here
-        double at_end = 99.78730976641236;
-        xt::xarray<double> a = xt::linspace(0., at_end, 100);
-        auto b = xt::linspace(0., at_end, 100);
-        EXPECT_EQ(a, b);
     }
 }


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->

A follow up for #2306

If `linspace` only have one point, the only element should not be set to the `stop` value. There is an oversight in my previous implementation. However, there is also a bug in the original test, which failed to catch the bug :-)