### PR TITLE
Performance fix: set m_strides_computed = true after computing

### DIFF
--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -1232,6 +1232,7 @@ namespace xt
         if (!m_strides_computed)
         {
             compute_strides(std::integral_constant<bool, has_trivial_strides>{});
+            m_strides_computed = true;
         }
         return m_data_offset;
     }


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.

# Description

This fixes a performance issue. Not sure what kind of test to add for that. Also, this might not be the only place where updating the `m_strides_computed` was forgotten. It's just what we saw when we profiled the code.