### PR TITLE
Adding `front()` and `back()` convenience methods

### DIFF
--- a/include/xtensor/xaccessible.hpp
+++ b/include/xtensor/xaccessible.hpp
@@ -55,6 +55,9 @@ namespace xt
         template <class... Args>
         bool in_bounds(Args... args) const;
 
+        const_reference front() const;
+        const_reference back() const;
+
     protected:
 
         xconst_accessible() = default;
@@ -102,9 +105,14 @@ namespace xt
         template <class... Args>
         reference periodic(Args... args);
 
+        reference front();
+        reference back();
+
         using base_type::at;
         using base_type::operator[];
         using base_type::periodic;
+        using base_type::front;
+        using base_type::back;
 
     protected:
 
@@ -213,6 +221,24 @@ namespace xt
     }
 
     /**
+     * Returns a constant reference to first the element of the expression
+     */
+    template <class D>
+    inline auto xconst_accessible<D>::front() const -> const_reference
+    {
+        return *derived_cast().begin();
+    }
+
+    /**
+     * Returns a constant reference to last the element of the expression
+     */
+    template <class D>
+    inline auto xconst_accessible<D>::back() const -> const_reference
+    {
+        return *std::prev(derived_cast().end());
+    }
+
+    /**
      * Returns ``true`` only if the the specified position is a valid entry in the expression.
      * @param args a list of indices specifying the position in the expression.
      * @return bool
@@ -291,6 +317,24 @@ namespace xt
     {
         normalize_periodic(derived_cast().shape(), args...);
         return derived_cast()(static_cast<size_type>(args)...);
+    }
+
+    /**
+     * Returns a reference to the first element of the expression.
+     */
+    template <class D>
+    inline auto xaccessible<D>::front() -> reference
+    {
+        return *derived_cast().begin();
+    }
+
+    /**
+     * Returns a reference to the last element of the expression.
+     */
+    template <class D>
+    inline auto xaccessible<D>::back() -> reference
+    {
+        return *std::prev(derived_cast().end());
     }
 
     template <class D>

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -143,6 +143,8 @@ namespace xt
         using accessible_base::operator[];
         using accessible_base::periodic;
         using accessible_base::in_bounds;
+        using accessible_base::front;
+        using accessible_base::back;
 
         template <class It>
         reference element(It first, It last);

--- a/include/xtensor/xdynamic_view.hpp
+++ b/include/xtensor/xdynamic_view.hpp
@@ -188,6 +188,8 @@ namespace xt
         using base_type::at;
         using base_type::periodic;
         using base_type::in_bounds;
+        using base_type::front;
+        using base_type::back;
 
         template <class It>
         reference element(It first, It last);

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -271,6 +271,8 @@ namespace xt
         using accessible_base::operator[];
         using accessible_base::periodic;
         using accessible_base::in_bounds;
+        using accessible_base::front;
+        using accessible_base::back;
 
         template <class It>
         const_reference element(It first, It last) const;

--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -178,6 +178,8 @@ namespace xt
         using accessible_base::at;
         using accessible_base::operator[];
         using accessible_base::periodic;
+        using accessible_base::front;
+        using accessible_base::back;
 
         using accessible_base::in_bounds;
 

--- a/include/xtensor/xmasked_view.hpp
+++ b/include/xtensor/xmasked_view.hpp
@@ -191,6 +191,8 @@ namespace xt
         using accessible_base::operator[];
         using accessible_base::periodic;
         using accessible_base::in_bounds;
+        using accessible_base::front;
+        using accessible_base::back;
 
         template <class It>
         reference element(It first, It last);

--- a/include/xtensor/xoptional_assembly_base.hpp
+++ b/include/xtensor/xoptional_assembly_base.hpp
@@ -177,6 +177,12 @@ namespace xt
         template <class... Args>
         const_reference periodic(Args... args) const;
 
+        reference front();
+        const_reference front() const;
+
+        reference back();
+        const_reference back() const;
+
         reference flat(size_type args);
         const_reference flat(size_type args) const;
 
@@ -660,6 +666,42 @@ namespace xt
     inline auto xoptional_assembly_base<D>::periodic(Args... args) const -> const_reference
     {
         return const_reference(value().periodic(args...), has_value().periodic(args...));
+    }
+
+    /**
+     * Returns a reference to the first element of the optional assembly.
+     */
+    template <class D>
+    inline auto xoptional_assembly_base<D>::front() -> reference
+    {
+        return reference(value().front(), has_value().front());
+    }
+
+    /**
+     * Returns a constant reference to the first element of the optional assembly.
+     */
+    template <class D>
+    inline auto xoptional_assembly_base<D>::front() const -> const_reference
+    {
+        return const_reference(value().front(), has_value().front());
+    }
+
+    /**
+     * Returns a reference to the last element of the optional assembly.
+     */
+    template <class D>
+    inline auto xoptional_assembly_base<D>::back() -> reference
+    {
+        return reference(value().back(), has_value().back());
+    }
+
+    /**
+     * Returns a constant reference to the last element of the optional assembly.
+     */
+    template <class D>
+    inline auto xoptional_assembly_base<D>::back() const -> const_reference
+    {
+        return const_reference(value().back(), has_value().back());
     }
 
     /**

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -173,6 +173,8 @@ namespace xt
         using accessible_base::operator[];
         using accessible_base::periodic;
         using accessible_base::in_bounds;
+        using accessible_base::front;
+        using accessible_base::back;
 
         template <class It>
         reference element(It, It) noexcept;

--- a/test/test_xarray.cpp
+++ b/test/test_xarray.cpp
@@ -324,6 +324,18 @@ namespace xt
         EXPECT_EQ(a, b);
     }
 
+    TEST(xarray, front)
+    {
+        xt::xarray<size_t> a = {{1,2,3}, {4,5,6}};
+        EXPECT_EQ(a.front(), 1);
+    }
+
+    TEST(xarray, back)
+    {
+        xt::xarray<size_t> a = {{1,2,3}, {4,5,6}};
+        EXPECT_EQ(a.back(), 6);
+    }
+
     TEST(xarray, flat)
     {
         {

--- a/test/test_xfunction.cpp
+++ b/test/test_xfunction.cpp
@@ -271,6 +271,22 @@ namespace xt
         }
     }
 
+    TEST(xfunction, front)
+    {
+        xfunction_features f;
+        int a = (f.m_a + f.m_a).front();
+        int b = f.m_a.front() + f.m_a.front();
+        EXPECT_EQ(a, b);
+    }
+
+    TEST(xfunction, back)
+    {
+        xfunction_features f;
+        int a = (f.m_a + f.m_a).back();
+        int b = f.m_a.back() + f.m_a.back();
+        EXPECT_EQ(a, b);
+    }
+
     TEST(xfunction, flat)
     {
         xfunction_features f;

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -1464,6 +1464,24 @@ namespace xt
         EXPECT_EQ(a, b);
     }
 
+    TEST(xview, front)
+    {
+        xt::xtensor<size_t,2> a = {{1,2,3}, {4,5,6}};
+        auto v = xt::view(a, 0, xt::all());
+        auto w = xt::view(a, 1, xt::all());
+        EXPECT_EQ(v.front(), 1);
+        EXPECT_EQ(w.front(), 4);
+    }
+
+    TEST(xview, back)
+    {
+        xt::xtensor<size_t,2> a = {{1,2,3}, {4,5,6}};
+        auto v = xt::view(a, 0, xt::all());
+        auto w = xt::view(a, 1, xt::all());
+        EXPECT_EQ(v.back(), 3);
+        EXPECT_EQ(w.back(), 6);
+    }
+
     TEST(xview, flat)
     {
         xt::xtensor<size_t, 2, xt::layout_type::row_major> a = {{0,1,2}, {3,4,5}};


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Adding `front()` and `back()` convenience methods

Fixes https://github.com/xtensor-stack/xtensor/issues/2282