### PR TITLE
Initial draft for a specialized computed_assign for xfixed

### DIFF
--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -74,6 +74,30 @@ namespace xt
         static void assign_data(xexpression<E1>& e1, const xexpression<E2>& e2, bool trivial);
     };
 
+    namespace detail{
+
+        template<class S>
+        struct is_fixed_shape : public std::false_type
+        {
+        };
+
+        template<std::size_t ... X>
+        struct is_fixed_shape<xt::fixed_shape< X ...>> : public std::true_type
+        {
+        };
+
+        template<class E>
+        using has_fixed_shape = is_fixed_shape<typename E::shape_type>;
+
+        template<class E>
+        using enable_if_has_fixed_shape_t = std::enable_if_t<has_fixed_shape<E>::value>;
+
+        template<class E>
+        using enable_if_has_no_fixed_shape_t = std::enable_if_t<!has_fixed_shape<E>::value>;
+
+    }
+
+
     template <class Tag>
     class xexpression_assigner : public xexpression_assigner_base<Tag>
     {
@@ -84,7 +108,12 @@ namespace xt
         template <class E1, class E2>
         static void assign_xexpression(E1& e1, const E2& e2);
 
-        template <class E1, class E2>
+
+
+        template <class E1, class E2, typename detail::enable_if_has_no_fixed_shape_t<E1> * = nullptr>
+        static void computed_assign(xexpression<E1>& e1, const xexpression<E2>& e2);
+
+        template <class E1, class E2, typename detail::enable_if_has_fixed_shape_t<E1> * = nullptr>
         static void computed_assign(xexpression<E1>& e1, const xexpression<E2>& e2);
 
         template <class E1, class E2, class F>
@@ -415,7 +444,7 @@ namespace xt
     }
 
     template <class Tag>
-    template <class E1, class E2>
+    template <class E1, class E2, typename detail::enable_if_has_no_fixed_shape_t<E1> *>
     inline void xexpression_assigner<Tag>::computed_assign(xexpression<E1>& e1, const xexpression<E2>& e2)
     {
         using shape_type = typename E1::shape_type;
@@ -441,6 +470,39 @@ namespace xt
         else
         {
             base_type::assign_data(e1, e2, trivial_broadcast);
+        }
+    }
+
+
+    template <class Tag>
+    template <class E1, class E2, typename detail::enable_if_has_fixed_shape_t<E1> *>
+    inline void xexpression_assigner<Tag>::computed_assign(xexpression<E1>& e1, const xexpression<E2>& e2)
+    {
+        using shape_type = typename E1::shape_type;
+
+        E1& de1 = e1.derived_cast();
+        const E2& de2 = e2.derived_cast();
+
+        if(de1.dimension() != de2.dimension())
+        {
+            // not sure if best error
+            throw_broadcast_error(de1.shape(), de2.shape());
+        }
+        else
+        {
+            auto && shape1 = de1.shape();
+            auto && shape2 = de2.shape();
+            if(std::equal(shape1.begin(), shape1.end(), shape2.begin()))
+            {
+                // the tests fail if I just set it to true for the case
+                // when creating e2 itself involved broadcasting
+                base_type::assign_data(e1, e2, false/*trivial_broadcast*/);
+            }
+            else
+            {
+                // not sure if best error
+                throw_broadcast_error(de1.shape(), de2.shape());
+            }
         }
     }
 

--- a/test/test_xassign.cpp
+++ b/test/test_xassign.cpp
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
+#include "xtensor/xfixed.hpp"
 
 #include "xtensor/xassign.hpp"
 #include "xtensor/xnoalias.hpp"
@@ -143,6 +144,98 @@ namespace xt
             EXPECT_EQ(a.shape(0), 2);
             EXPECT_EQ(a.shape(1), 3);
         }
+    }
 
+    TEST(xassign, fixed_shape)
+    {
+        // matching shape 1D
+        {
+            xt::xtensor_fixed<int, xt::xshape<2>> a = {2,3};
+            xt::xtensor_fixed<int, xt::xshape<2>> b = {3,4};
+
+            xt::noalias(a) += b;
+
+            EXPECT_EQ(a(0), 5);
+            EXPECT_EQ(a(1), 7);
+        }
+        //matching shape 2D
+        {
+            xt::xtensor_fixed<int, xt::xshape<2,2>> aa = {{1,2},{3,4}};
+            xt::xtensor_fixed<int, xt::xshape<2,2>> a(aa);
+            xt::xtensor_fixed<int, xt::xshape<2,2>> b = {{3,4},{5,6}};
+            xt::noalias(a) += b;
+
+            EXPECT_EQ(a(0,0),  aa(0,0) + b(0,0));
+            EXPECT_EQ(a(0,1),  aa(0,1) + b(0,1));
+            EXPECT_EQ(a(1,0),  aa(1,0) + b(1,0));
+            EXPECT_EQ(a(1,1),  aa(1,1) + b(1,1));
+        }
+        // b is broadcasted with matching dimension (first axis is singleton)
+        {
+            xt::xtensor_fixed<int, xt::xshape<2,2>> aa = {{1,2},{3,4}};
+            xt::xtensor_fixed<int, xt::xshape<2,2>> a(aa);
+            xt::xtensor_fixed<int, xt::xshape<2,1>> b = {{5,6}};
+            EXPECT_EQ(b.shape(0),2);
+            EXPECT_EQ(b.shape(1),1);
+            xt::noalias(a) += b;
+
+            EXPECT_EQ(a(0,0),  aa(0,0) + b.at(0,0));
+            EXPECT_EQ(a(0,1),  aa(0,1) + b.at(0,0));
+            EXPECT_EQ(a(1,0),  aa(1,0) + b.at(1,0));
+            EXPECT_EQ(a(1,1),  aa(1,1) + b.at(1,0));
+        }
+        // b is broadcasted with matching dimension (second axis is singleton)
+        {
+            xt::xtensor_fixed<int, xt::xshape<2,2>> aa = {{1,2},{3,4}};
+            xt::xtensor_fixed<int, xt::xshape<2,2>> a(aa);
+            xt::xtensor_fixed<int, xt::xshape<1,2>> b = {{3,4}};
+            EXPECT_EQ(b.shape(0),1);
+            EXPECT_EQ(b.shape(1),2);
+            xt::noalias(a) += b;
+
+            EXPECT_EQ(a(0,0),  aa(0,0) + b(0,0));
+            EXPECT_EQ(a(0,1),  aa(0,1) + b(0,1));
+            EXPECT_EQ(a(1,0),  aa(1,0) + b(0,0));
+            EXPECT_EQ(a(1,1),  aa(1,1) + b(0,1));
+        }
+        // broadcast with non matching dimensions
+        {
+            xt::xtensor_fixed<int, xt::xshape<2,2>> aa = {{1,2},{3,4}};
+            xt::xtensor_fixed<int, xt::xshape<2,2>> a(aa);
+            xt::xtensor_fixed<int, xt::xshape<2>> b = {3,4};
+
+            xt::noalias(a) += b;
+
+            EXPECT_EQ(a(0,0),  aa(0,0) + b(0));
+            EXPECT_EQ(a(0,1),  aa(0,1) + b(1));
+            EXPECT_EQ(a(1,0),  aa(1,0) + b(0));
+            EXPECT_EQ(a(1,1),  aa(1,1) + b(1));
+        }
+    }
+    TEST(xassign, fixed_raises)
+    {
+        // cannot broadcast a  itself on assignment
+        {
+            xt::xtensor_fixed<int, xt::xshape<2>> a = {2,3};
+            xt::xtensor_fixed<int, xt::xshape<2,2>> b = {{3,4},{3,4}};
+
+            EXPECT_THROW(xt::noalias(a) += b, xt::broadcast_error);
+        }
+
+        // cannot broadcast a  itself on assignment
+        {
+            xt::xtensor_fixed<int, xt::xshape<1,2>> a = {{3,4}};
+            xt::xtensor_fixed<int, xt::xshape<2,2>> b = {{3,4},{3,4}};
+
+            EXPECT_THROW(xt::noalias(a) += b, xt::broadcast_error);
+        }
+
+        // cannot broadcast a  itself on assignment
+        {
+            xt::xtensor_fixed<int, xt::xshape<2,1>> a = {{3},{4}};
+            xt::xtensor_fixed<int, xt::xshape<2,2>> b = {{3,4},{3,4}};
+
+            EXPECT_THROW(xt::noalias(a) += b, xt::broadcast_error);
+        }
     }
 }


### PR DESCRIPTION
Initial draft for a specialized computed_assign for xfixed:
 * added overload for fixed/nonfixed shape via enable_if
 * added tests

Any broadcasting which would require a reshaping of the tensor we assign to will lead to an broadcast error.
But there is one thing where I do not know how to solve it:

Lets say a has a shape of (2,2) and b a shape of (1,2)
```c++
  xt::xtensor_fixed<int, xt::xshape<2,2>> a = {{1,2},{3,4}};
  xt::xarray<int> b = {{5,6}};
```

and I do 
```c++
xt::noalias(a) += b;
```
For such expressions, where broadcasting is involved to bring b to the correct shape, test suite only passes if I, within my implementation for `computed_assign` do this:

```c++
...
base_type::assign_data(e1, e2, false/*trivial_broadcast*/);
...
```
If I set this to true, the test suite only passes for expression where no broadcasting is involved.


I am unsure how to figure out in a proper way from within `computed_assign` since the shape and dim of the expressions `e1` and `e2` are matching.  