### PR TITLE
Chane CMakeLists.txt to allow for cmake to run on Ubuntu 20.04 and cmake 3.16.3

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,16 +10,17 @@
 cmake_minimum_required(VERSION 3.1)
 
 find_package(doctest            REQUIRED)
-find_package(Threads)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-    project(xtensor-test)
+    project(xtensor-test C CXX)
 
     enable_testing()
 
     find_package(xtensor REQUIRED CONFIG)
     set(XTENSOR_INCLUDE_DIR ${xtensor_INCLUDE_DIRS})
 endif ()
+
+find_package(Threads)
 
 if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "Setting tests build type to Release")


### PR DESCRIPTION
This change is required for my system to run cmake. I run Ubuntu 20.04.2 LTS and cmake version 3.16.3.

# Checklist

- [ ] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
