### PR TITLE
has_trivial_default_constructor has been removed from libstdc++ since version 7.

### DIFF
--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -637,9 +637,14 @@ namespace xt
      * xtrivial_default_construct implemenation *
      ********************************************/
 
+#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 7
+// has_trivial_default_constructor has not been available since libstdc++-7.
+#define XTENSOR_GLIBCXX_USE_CXX11_ABI 1
+#else
 #if defined(_GLIBCXX_USE_CXX11_ABI)
 #if _GLIBCXX_USE_CXX11_ABI || (defined(_GLIBCXX_USE_DUAL_ABI) && !_GLIBCXX_USE_DUAL_ABI)
 #define XTENSOR_GLIBCXX_USE_CXX11_ABI 1
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

- clang : 13.0.0
- libstdc++ : 112.1
- xtensor : 0.24.0

When I use xtensor with libstdc++ version 11 with _GLIBCXX_USE_CXX11_ABI = 0, there are compilation error as following:

```
xxx/include/xtensor/xutils.hpp:654:51: error: no template named 'has_trivial_default_constructor' in namespace 'std'; did you mean 'is_trivially_default_constructible'?
    using xtrivially_default_constructible = std::has_trivial_default_constructor<T>;
                                             ~~~~~^
/usr/bin/../lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/type_traits:1151:12: note: 'is_trivially_default_constructible' declared here
    struct is_trivially_default_constructible
           ^
1 error generated.
```

I found `has_trivial_default_constructor` had been removed since libstdc++ 7.
Please refer https://gcc.gnu.org/onlinedocs/libstdc++/manual/api.html#api.rel_71.

I think `is_trivially_default_constructible` should be used  regardless of the value of _GLIBCXX_USE_CXX11_ABI with libstdc++ >= 7.

While I know there are a lot of issue about `has_trivial_default_constructor`,
I hope my PR is matched.

