### PR TITLE
Adding `xt::missing` to `operator()`

### DIFF
--- a/docs/source/indices.rst
+++ b/docs/source/indices.rst
@@ -52,11 +52,15 @@ To this end the following operators are at your disposal:
 Returns a (constant) reference to the element,
 specified by an *array index* given by a number of unsigned integers.
 
-.. note::
-
-    If the number of indices is less that the dimension of the array,
+*   If the number of indices is less that the dimension of the array,
     the indices are pre-padded with zeros until the dimension is matched
     (example: ``a(2) == a(0, 2) == 2``).
+
+*   If the number of indices is greater than the dimension of the array,
+    the first ``#indices - dimension`` indices are ignored.
+
+*   To post-pad an arbitrary number of zeros use ``xt::missing``
+    (example ``a(2, xt::missing) == a(2, 0) == 8``.
 
 ``at(args...)``
 ^^^^^^^^^^^^^^^

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -438,7 +438,7 @@ namespace xt
     {
         XTENSOR_TRY(check_index(shape(), args...));
         XTENSOR_CHECK_DIMENSION(shape(), args...);
-        size_type index = xt::data_offset<size_type>(strides(), static_cast<std::ptrdiff_t>(args)...);
+        size_type index = xt::data_offset<size_type>(strides(), args...);
         return storage()[index];
     }
 
@@ -454,7 +454,7 @@ namespace xt
     {
         XTENSOR_TRY(check_index(shape(), args...));
         XTENSOR_CHECK_DIMENSION(shape(), args...);
-        size_type index = xt::data_offset<size_type>(strides(), static_cast<std::ptrdiff_t>(args)...);
+        size_type index = xt::data_offset<size_type>(strides(), args...);
         return storage()[index];
     }
 

--- a/test/test_xtensor.cpp
+++ b/test/test_xtensor.cpp
@@ -167,6 +167,43 @@ namespace xt
         }
     }
 
+    TEST(xtensor, missign)
+    {
+        xt::xtensor<int, 2> a
+           {{0, 1, 2},
+            {3, 4, 5},
+            {6, 7, 8}};
+
+        EXPECT_EQ(a(0), 0);
+        EXPECT_EQ(a(1), 1);
+        EXPECT_EQ(a(2), 2);
+        EXPECT_EQ(a(0, 0), 0);
+        EXPECT_EQ(a(1, 0), 3);
+        EXPECT_EQ(a(2, 0), 6);
+        EXPECT_EQ(a(xt::missing), 0);
+        EXPECT_EQ(a(0, xt::missing), 0);
+        EXPECT_EQ(a(1, xt::missing), 3);
+        EXPECT_EQ(a(2, xt::missing), 6);
+        EXPECT_EQ(a(0, 0), 0);
+        EXPECT_EQ(a(0, 1), 1);
+        EXPECT_EQ(a(0, 2), 2);
+        EXPECT_EQ(a(1, 0), 3);
+        EXPECT_EQ(a(1, 1), 4);
+        EXPECT_EQ(a(1, 2), 5);
+        EXPECT_EQ(a(2, 0), 6);
+        EXPECT_EQ(a(2, 1), 7);
+        EXPECT_EQ(a(2, 2), 8);
+        EXPECT_EQ(a(9, 9, 9, 0, 0), 0);
+        EXPECT_EQ(a(9, 9, 9, 0, 1), 1);
+        EXPECT_EQ(a(9, 9, 9, 0, 2), 2);
+        EXPECT_EQ(a(9, 9, 9, 1, 0), 3);
+        EXPECT_EQ(a(9, 9, 9, 1, 1), 4);
+        EXPECT_EQ(a(9, 9, 9, 1, 2), 5);
+        EXPECT_EQ(a(9, 9, 9, 2, 0), 6);
+        EXPECT_EQ(a(9, 9, 9, 2, 1), 7);
+        EXPECT_EQ(a(9, 9, 9, 2, 2), 8);
+    }
+
     TEST(xtensor, resize)
     {
         xtensor_dynamic a;


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->

I had to move the `static_cast<std::ptrdiff_t>(...)`. If forgot why it is there in the first place, so I don't know if this changes anything

Fixes https://github.com/xtensor-stack/xtensor/issues/2486