### PR TITLE
Adding `xt::missing` functionality to `.periodic(...)`, `.at(...)`, and `.in_bounds(...)`

### DIFF
--- a/include/xtensor/xaccessible.hpp
+++ b/include/xtensor/xaccessible.hpp
@@ -174,7 +174,7 @@ namespace xt
     template <class... Args>
     inline auto xconst_accessible<D>::at(Args... args) const -> const_reference
     {
-        check_access(derived_cast().shape(), static_cast<size_type>(args)...);
+        check_access(derived_cast().shape(), args...);
         return derived_cast().operator()(args...);
     }
 
@@ -273,7 +273,7 @@ namespace xt
     template <class... Args>
     inline auto xaccessible<D>::at(Args... args) -> reference
     {
-        check_access(derived_cast().shape(), static_cast<size_type>(args)...);
+        check_access(derived_cast().shape(), args...);
         return derived_cast().operator()(args...);
     }
 
@@ -316,7 +316,7 @@ namespace xt
     inline auto xaccessible<D>::periodic(Args... args) -> reference
     {
         normalize_periodic(derived_cast().shape(), args...);
-        return derived_cast()(static_cast<size_type>(args)...);
+        return derived_cast()(args...);
     }
 
     /**

--- a/include/xtensor/xstrides.hpp
+++ b/include/xtensor/xstrides.hpp
@@ -642,6 +642,12 @@ namespace xt
             return true;
         }
 
+        template <class S, std::size_t dim>
+        inline bool check_in_bounds_impl(const S&, missing_type)
+        {
+            return true;
+        }
+
         template <class S, std::size_t dim, class T, class... Args>
         inline bool check_in_bounds_impl(const S& shape, T& arg, Args&... args)
         {
@@ -666,6 +672,11 @@ namespace xt
     {
         template <class S, std::size_t dim>
         inline void normalize_periodic_impl(const S&)
+        {
+        }
+
+        template <class S, std::size_t dim>
+        inline void normalize_periodic_impl(const S&, missing_type)
         {
         }
 

--- a/test/test_xtensor.cpp
+++ b/test/test_xtensor.cpp
@@ -167,7 +167,7 @@ namespace xt
         }
     }
 
-    TEST(xtensor, missign)
+    TEST(xtensor, missing)
     {
         xt::xtensor<int, 2> a
            {{0, 1, 2},
@@ -202,6 +202,19 @@ namespace xt
         EXPECT_EQ(a(9, 9, 9, 2, 0), 6);
         EXPECT_EQ(a(9, 9, 9, 2, 1), 7);
         EXPECT_EQ(a(9, 9, 9, 2, 2), 8);
+
+        EXPECT_EQ(a.periodic(-1, xt::missing), a(2, xt::missing));
+        EXPECT_EQ(a.periodic(-2, xt::missing), a(1, xt::missing));
+        EXPECT_EQ(a.periodic(-3, xt::missing), a(0, xt::missing));
+
+        EXPECT_EQ(a.at(0, xt::missing), a.at(0, 0));
+        EXPECT_EQ(a.at(1, xt::missing), a.at(1, 0));
+        EXPECT_EQ(a.at(2, xt::missing), a.at(2, 0));
+
+        EXPECT_TRUE(a.in_bounds(0, xt::missing));
+        EXPECT_TRUE(a.in_bounds(1, xt::missing));
+        EXPECT_TRUE(a.in_bounds(2, xt::missing));
+        EXPECT_FALSE(a.in_bounds(3, xt::missing));
     }
 
     TEST(xtensor, resize)


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->

This was missing. I think this covers all operators now.