### PR TITLE
Updated C++20 option for visual studio builds C++2a no longer a valid…

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,7 @@ elseif(CPP20)
   set_compiler_flag(
     _cxx_std_flag CXX
     "-std=c++2a"  # this should work with GNU, Intel, PGI
-    "/std:c++2a"  # this should work with MSVC
+    "/std:c++20"  # this should work with MSVC
   )
   if(_cxx_std_flag)
     message(STATUS "Building with C++20")


### PR DESCRIPTION
… std option.

# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [N/A] Tests have been added for new features or bug fixes.
- [ N/A] API of new functions and classes are documented.

# Description
Updated the language flag for C++20 since finalization of C++20 in MSVC

