### PR TITLE
Fixed build error in MSVC 2019 by decaying decltype to base type

### DIFF
--- a/test/test_extended_xsort.cpp
+++ b/test/test_extended_xsort.cpp
@@ -107,7 +107,7 @@ namespace xt
 
         // py_median = np.median(a)
         double py_median = 300.0;
-        EXPECT_EQ(static_cast<decltype(py_a)::value_type>(py_median), xt::median(py_a));
+        EXPECT_EQ(static_cast<std::decay<decltype(py_a)>::type::value_type>(py_median), xt::median(py_a));
     }
 
     /*py


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description
Build error induced by taking the value_type of a T& instead of T accomplished though std::decay of T&

closes #2505
