### PR TITLE
Adding cast to deal with xtensor-python's signedness of shape

### DIFF
--- a/include/xtensor/xsort.hpp
+++ b/include/xtensor/xsort.hpp
@@ -152,7 +152,7 @@ namespace xt
         {
             const auto& de = e.derived_cast();
             R ev;
-            ev.resize({de.size()});
+            ev.resize({static_cast<typename R::shape_type::value_type>(de.size())});
 
             std::copy(de.cbegin(), de.cend(), ev.begin());
             std::sort(ev.begin(), ev.end());


### PR DESCRIPTION
Fix confirmed in https://github.com/tdegeus/FrictionQPotSpringBlock/pull/46 , so ready from my side!

# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
