### PR TITLE
Adding missing `rank` to `xtensor_adaptor`

### DIFF
--- a/include/xtensor/xarray.hpp
+++ b/include/xtensor/xarray.hpp
@@ -230,6 +230,7 @@ namespace xt
         using backstrides_type = typename base_type::backstrides_type;
         using temporary_type = typename semantic_base::temporary_type;
         using expression_tag = Tag;
+        constexpr static std::size_t rank = SIZE_MAX;
 
         xarray_adaptor(storage_type&& storage);
         xarray_adaptor(const storage_type& storage);

--- a/include/xtensor/xtensor.hpp
+++ b/include/xtensor/xtensor.hpp
@@ -225,6 +225,7 @@ namespace xt
         using backstrides_type = typename base_type::backstrides_type;
         using temporary_type = typename semantic_base::temporary_type;
         using expression_tag = Tag;
+        constexpr static std::size_t rank = N;
 
         xtensor_adaptor(storage_type&& storage);
         xtensor_adaptor(const storage_type& storage);

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -875,7 +875,7 @@ namespace xt
     template <class E>
     struct get_rank<E, decltype((void)E::rank, void())>
     {
-        constexpr static std::size_t value= E::rank;
+        constexpr static std::size_t value = E::rank;
     };
 
     /******************


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

See title