### PR TITLE
Adding `reset_data` to `xbuffer_adaptor` and `reset_buffer` to `*adaptor` to replace the pointer without any reallocation.

### DIFF
--- a/docs/source/external-structures.rst
+++ b/docs/source/external-structures.rst
@@ -43,6 +43,34 @@ A requirement for the user-specified containers is to provide a minimal ``std::v
 provides the aforementioned interface. In fact, the container could even be backed by a
 file on the disk, a database or a binary message.
 
+Adapting a pointer
+------------------
+
+Suppose that you want to use the *xtensor* machinery on a small contiguous subset of a large tensor.
+You can, of course, use :ref:`Views`, but for efficiency you can also use pointers to the right bit of memory.
+Consider an example of an ``[M, 2, 2]`` tensor ``A``,
+for which you want to operate on ``A[i, :, :]`` for different ``i``.
+In this case the most efficient *xtensor* has to offer is:
+
+.. code-block:: cpp
+
+    int main()
+    {
+        size_t M = 3;
+        size_t nd = 2;
+        size_t size = nd * nd;
+        xt::xarray<int> A = xt::arange<int>(M * size).reshape({M, nd, nd});
+        auto b = xt::adapt(&A.flat(0), std::array<size_t, 2>{nd, nd});
+
+        for (size_t i = 0; i < M; ++i) {
+            b.reset_buffer(&A.flat(i * size), size);
+        }
+        return 0;
+    }
+
+where ``xt::adapt`` first creates an ``xt::xtensor_adaptor`` on the memory of ``A[0, :, :]``.
+Then, inside the loop, we only replace the pointer to the relevant ``A[i, 0, 0]``.
+
 Structures that embed shape and strides
 ---------------------------------------
 

--- a/include/xtensor/xarray.hpp
+++ b/include/xtensor/xarray.hpp
@@ -252,6 +252,9 @@ namespace xt
         template <class E>
         xarray_adaptor& operator=(const xexpression<E>& e);
 
+        template <class P, class S>
+        void reset_buffer(P&& pointer, S&& size);
+
     private:
 
         container_closure_type m_storage;
@@ -615,6 +618,13 @@ namespace xt
     inline auto xarray_adaptor<EC, L, SC, Tag>::storage_impl() const noexcept -> const storage_type&
     {
         return m_storage;
+    }
+
+    template <class EC, layout_type L, class SC, class Tag>
+    template <class P, class S>
+    inline void xarray_adaptor<EC, L, SC, Tag>::reset_buffer(P&& pointer, S&& size)
+    {
+        return m_storage.reset_data(std::forward<P>(pointer), std::forward<S>(size));
     }
 }
 

--- a/include/xtensor/xtensor.hpp
+++ b/include/xtensor/xtensor.hpp
@@ -247,6 +247,9 @@ namespace xt
         template <class E>
         xtensor_adaptor& operator=(const xexpression<E>& e);
 
+        template <class P, class S>
+        void reset_buffer(P&& pointer, S&& size);
+
     private:
 
         container_closure_type m_storage;
@@ -683,6 +686,13 @@ namespace xt
     inline auto xtensor_adaptor<EC, N, L, Tag>::storage_impl() const noexcept -> const storage_type&
     {
         return m_storage;
+    }
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    template <class P, class S>
+    inline void xtensor_adaptor<EC, N, L, Tag>::reset_buffer(P&& pointer, S&& size)
+    {
+        return m_storage.reset_data(std::forward<P>(pointer), std::forward<S>(size));
     }
 
     /*******************************

--- a/test/test_xadapt.cpp
+++ b/test/test_xadapt.cpp
@@ -61,6 +61,23 @@ namespace xt
         delete[] data;
     }
 
+    TEST(xarray_adaptor, pointer_no_ownership_replace)
+    {
+        size_t size = 4;
+        int* data = new int[3 * size];
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s({2, 2});
+
+        auto a1 = adapt(data, size, no_ownership(), s);
+        size_t st = static_cast<size_t>(a1.strides()[0]);
+
+        for (size_t i = 0; i < 3; ++i) {
+            a1.reset_buffer(&data[i * size], size);
+            a1(1, 0) = static_cast<int>(i);
+            EXPECT_EQ(i, data[i * size + st]);
+        }
+    }
+
     TEST(xarray_adaptor, pointer_acquire_ownership)
     {
         size_t size = 4;
@@ -209,6 +226,22 @@ namespace xt
         EXPECT_EQ(1, data[2]);
 
         delete[] data;
+    }
+
+    TEST(xtensor_adaptor, pointer_no_ownership_replace)
+    {
+        size_t size = 4;
+        int* data = new int[3 * size];
+        std::array<size_t, 2> shape = {2, 2};
+
+        auto a1 = adapt(data, size, no_ownership(), shape);
+        size_t st = static_cast<size_t>(a1.strides()[0]);
+
+        for (size_t i = 0; i < 3; ++i) {
+            a1.reset_buffer(&data[i * size], size);
+            a1(1, 0) = static_cast<int>(i);
+            EXPECT_EQ(i, data[i * size + st]);
+        }
     }
 
     TEST(xtensor_adaptor, pointer_const_no_ownership)


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Fixes https://github.com/xtensor-stack/xtensor/issues/2519