### PR TITLE
Enabling reference value types for xfunction.

### DIFF
--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -142,9 +142,10 @@ namespace xt
     struct xcontainer_inner_types<xfunction<F, CT...>>
     {
         // Added indirection for MSVC 2017 bug with the operator value_type()
-        using value_type = typename meta_identity<decltype(std::declval<F>()(std::declval<xvalue_type_t<std::decay_t<CT>>>()...))>::type;
-        using reference = value_type;
-        using const_reference = value_type;
+        using func_return_type = typename meta_identity<decltype(std::declval<F>()(std::declval<xvalue_type_t<std::decay_t<CT>>>()...))>::type;
+        using value_type = std::decay_t<func_return_type>;
+        using reference = func_return_type;
+        using const_reference = reference;
         using size_type = common_size_type_t<std::decay_t<CT>...>;
     };
 
@@ -439,7 +440,7 @@ namespace xt
         using xfunction_type = xfunction<F, CT...>;
 
         using value_type = typename xfunction_type::value_type;
-        using reference = typename xfunction_type::value_type;
+        using reference = typename xfunction_type::reference;
         using pointer = typename xfunction_type::const_pointer;
         using size_type = typename xfunction_type::size_type;
         using difference_type = typename xfunction_type::difference_type;


### PR DESCRIPTION
This pr adds the ability to have `xfunction` with values that are references.

For example:
```cpp
const int v = 5;
auto replace = [&v](int a) -> int& { return v; };  // before only `-> int` was possible
auto replace_vectorized = xt::vectorize(replace);
```

This is nice if we don't want to create temporary values for some complex types.
For example one of our use cases was to apply color lookup table to grayscale image:
```cpp
xtensor<uint8_t, 2> grayscale({100, 100});

LookupTable lookup_table; // this holds inside std::vector<Color> for ARGB colors lookup

auto colorise = [&lookup_table](uint8_t gray) -> Color& { return lookup_table.getMappedValue(gray); };
auto colorised = xt::vectorize(colorise)(grayscale);

for (Color& color : colorised) {
    // now we can iterate colorised image without creating unnecessary copies.
}

// These work too:
xt::xtensor<Color, 2> colorised_copy_1 = colorised;
auto colorised_copy_2 = xt::eval(colorised);
```