### PR TITLE
changing static layout in xtsrided_view temporary_type to container's…

### DIFF
--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -81,7 +81,7 @@ namespace xt
         using undecay_shape = S;
         using storage_getter = FST;
         using inner_storage_type = typename storage_getter::type;
-        using temporary_type = typename detail::xtype_for_shape<S>::template type<typename xexpression_type::value_type, L>;
+        using temporary_type = typename detail::xtype_for_shape<S>::template type<typename xexpression_type::value_type, xexpression_type::static_layout>;
         using storage_type = std::remove_reference_t<inner_storage_type>;
         static constexpr layout_type layout = L;
     };


### PR DESCRIPTION
This pull request is a minor fix for the static layout type in the temporary container for `xstrided_view`. Currently, even if the original container was of `layout_type::row_major`, `xstrided_view` just forwards its own layout type (which is `dynamic` by default) to the `temporary_type`, while the temporary type should also have `row_major` static layout. This behaviour is also inconsistent with `xview`, which behaves correctly.

Example:
```cpp
xt::xarray<float> array({ 5 });

using view_t = decltype(xt::view(array, xt::range(1, 5, 2)));            // xview         layout_type::dynamic
using strided_view_t = decltype(xt::strided_view(array, { xt::all() })); // xstrided_view layout_type::dynamic

// Correct
xt::temporary_type_t<view_t>::static_layout;         // xarray layout_type::row_major
// Incorrect
xt::temporary_type_t<strided_view_t>::static_layout; // xarray layout_type::dynamic
```