### PR TITLE
Fixing some iterator issues

### DIFF
--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -1163,8 +1163,8 @@ namespace xt
     template <layout_type L>
     inline auto xfunctor_applier_base<D>::crbegin() const noexcept
     {
-        return xfunctor_iterator<const functor_type, decltype(m_e.template rbegin<L>())>(
-            m_e.template rbegin<L>(),
+        return xfunctor_iterator<const functor_type, decltype(m_e.template crbegin<L>())>(
+            m_e.template crbegin<L>(),
             &m_functor
         );
     }
@@ -1178,8 +1178,8 @@ namespace xt
     template <layout_type L>
     inline auto xfunctor_applier_base<D>::crend() const noexcept
     {
-        return xfunctor_iterator<const functor_type, decltype(m_e.template rend<L>())>(
-            m_e.template rend<L>(),
+        return xfunctor_iterator<const functor_type, decltype(m_e.template crend<L>())>(
+            m_e.template crend<L>(),
             &m_functor
         );
     }

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -604,7 +604,8 @@ namespace xt
     void stepper_tools<layout_type::row_major>::increment_stepper(S& stepper, IT& index, const ST& shape)
     {
         using size_type = typename S::size_type;
-        size_type i = index.size();
+        const size_type size = index.size();
+        size_type i = size;
         while (i != 0)
         {
             --i;
@@ -625,7 +626,19 @@ namespace xt
         }
         if (i == 0)
         {
-            std::copy(shape.cbegin(), shape.cend(), index.begin());
+            if (size != size_type(0))
+            {
+                std::transform(
+                    shape.cbegin(),
+                    shape.cend() - 1,
+                    index.begin(),
+                    [](const auto& v)
+                    {
+                        return v - 1;
+                    }
+                );
+                index[size - 1] = shape[size - 1];
+            }
             stepper.to_end(layout_type::row_major);
         }
     }
@@ -640,8 +653,9 @@ namespace xt
     )
     {
         using size_type = typename S::size_type;
-        size_type i = index.size();
-        size_type leading_i = index.size() - 1;
+        const size_type size = index.size();
+        const size_type leading_i = size - 1;
+        size_type i = size;
         while (i != 0 && n != 0)
         {
             --i;
@@ -673,7 +687,19 @@ namespace xt
         }
         if (i == 0 && n != 0)
         {
-            std::copy(shape.cbegin(), shape.cend(), index.begin());
+            if (size != size_type(0))
+            {
+                std::transform(
+                    shape.cbegin(),
+                    shape.cend() - 1,
+                    index.begin(),
+                    [](const auto& v)
+                    {
+                        return v - 1;
+                    }
+                );
+                index[leading_i] = shape[leading_i];
+            }
             stepper.to_end(layout_type::row_major);
         }
     }
@@ -760,7 +786,7 @@ namespace xt
     void stepper_tools<layout_type::column_major>::increment_stepper(S& stepper, IT& index, const ST& shape)
     {
         using size_type = typename S::size_type;
-        size_type size = index.size();
+        const size_type size = index.size();
         size_type i = 0;
         while (i != size)
         {
@@ -782,7 +808,19 @@ namespace xt
         }
         if (i == size)
         {
-            std::copy(shape.cbegin(), shape.cend(), index.begin());
+            if (size != size_type(0))
+            {
+                std::transform(
+                    shape.cbegin() + 1,
+                    shape.cend(),
+                    index.begin() + 1,
+                    [](const auto& v)
+                    {
+                        return v - 1;
+                    }
+                );
+                index[0] = shape[0];
+            }
             stepper.to_end(layout_type::column_major);
         }
     }
@@ -797,9 +835,9 @@ namespace xt
     )
     {
         using size_type = typename S::size_type;
-        size_type size = index.size();
+        const size_type size = index.size();
+        const size_type leading_i = 0;
         size_type i = 0;
-        size_type leading_i = 0;
         while (i != size && n != 0)
         {
             size_type inc = (i == leading_i) ? n : 1;
@@ -808,7 +846,7 @@ namespace xt
                 index[i] += inc;
                 stepper.step(i, inc);
                 n -= inc;
-                if (i != leading_i || index.size() == 1)
+                if (i != leading_i || size == 1)
                 {
                     i = 0;
                     continue;
@@ -832,7 +870,19 @@ namespace xt
         }
         if (i == size && n != 0)
         {
-            std::copy(shape.cbegin(), shape.cend(), index.begin());
+            if (size != size_type(0))
+            {
+                std::transform(
+                    shape.cbegin() + 1,
+                    shape.cend(),
+                    index.begin() + 1,
+                    [](const auto& v)
+                    {
+                        return v - 1;
+                    }
+                );
+                index[leading_i] = shape[leading_i];
+            }
             stepper.to_end(layout_type::column_major);
         }
     }

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -155,6 +155,8 @@ namespace xt
         using storage_type = typename base_type::storage_type;
         using linear_iterator = typename storage_type::iterator;
         using const_linear_iterator = typename storage_type::const_iterator;
+        using reverse_linear_iterator = std::reverse_iterator<linear_iterator>;
+        using const_reverse_linear_iterator = std::reverse_iterator<const_linear_iterator>;
 
         using iterable_base = select_iterable_base_t<L, xexpression_type::static_layout, self_type>;
         using inner_shape_type = typename base_type::inner_shape_type;
@@ -217,8 +219,17 @@ namespace xt
 
         linear_iterator linear_begin();
         linear_iterator linear_end();
+        const_linear_iterator linear_begin() const;
+        const_linear_iterator linear_end() const;
         const_linear_iterator linear_cbegin() const;
         const_linear_iterator linear_cend() const;
+
+        reverse_linear_iterator linear_rbegin();
+        reverse_linear_iterator linear_rend();
+        const_reverse_linear_iterator linear_rbegin() const;
+        const_reverse_linear_iterator linear_rend() const;
+        const_reverse_linear_iterator linear_crbegin() const;
+        const_reverse_linear_iterator linear_crend() const;
 
         template <class ST, class STEP = stepper>
         disable_indexed_stepper_t<STEP> stepper_begin(const ST& shape);
@@ -486,6 +497,18 @@ namespace xt
     }
 
     template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::linear_begin() const -> const_linear_iterator
+    {
+        return this->linear_cbegin();
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::linear_end() const -> const_linear_iterator
+    {
+        return this->linear_cend();
+    }
+
+    template <class CT, class S, layout_type L, class FST>
     inline auto xstrided_view<CT, S, L, FST>::linear_cbegin() const -> const_linear_iterator
     {
         return this->storage().cbegin() + static_cast<std::ptrdiff_t>(data_offset());
@@ -495,6 +518,42 @@ namespace xt
     inline auto xstrided_view<CT, S, L, FST>::linear_cend() const -> const_linear_iterator
     {
         return this->storage().cbegin() + static_cast<std::ptrdiff_t>(data_offset() + size());
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::linear_rbegin() -> reverse_linear_iterator
+    {
+        return reverse_linear_iterator(this->linear_begin());
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::linear_rend() -> reverse_linear_iterator
+    {
+        return reverse_linear_iterator(this->linear_end());
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::linear_rbegin() const -> const_reverse_linear_iterator
+    {
+        return this->linear_crbegin();
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::linear_rend() const -> const_reverse_linear_iterator
+    {
+        return this->linear_crend();
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::linear_crbegin() const -> const_reverse_linear_iterator
+    {
+        return const_reverse_linear_iterator(this->linear_cbegin());
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::linear_crend() const -> const_reverse_linear_iterator
+    {
+        return const_reverse_linear_iterator(this->linear_cend());
     }
 
     /***************


### PR DESCRIPTION
This merge request fixes some issues with iterators.

- [x] `xfunctor_view::crbegin` was returning non const iterator
- [x] `xiterator_adaptor::data` was returning iterator, not a pointer
- [x] `xt::reshape_view().rbegin()` didn't compile

### Fixing multidimensional index of end `xiterator`
- [x] multidimensional index of `xiterator` for `end()` iterator would be always set to `shape()`, which made `*rbegin()` be out of bounds access. I changed the index of `end()` to be `shape[i] - 1` for all dimensions, except the last one in row-major case, and except the first one in column-major case

```cpp
xarray<int> a = { {{0, 1, 2, 3},
                   {4, 5, 6, 7},
                   {8, 9, 10, 11}},
                  {{12, 13, 14, 15},
                   {16, 17, 18, 19},
                   {20, 21, 22, 23}} };

auto view = dynamic_view(a, { 1, keep(0, 2), range(1, 4) });
// shape: {1, 2, 3}

// old version
view.end(); // index {1, 2, 3}
std::prev(view.end()); // index {1, 2, 2}
// out of bounds access
*view.rbegin(); // index {1, 2, 2}

// new version
view.end(); // index {0, 1, 3}
std::prev(view.end()); // index {0, 1, 2}
// correct access
*view.rbegin(); // index {0, 1, 2}
```