### PR TITLE
Average: debugging bug

### DIFF
--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -1975,21 +1975,13 @@ namespace detail {
         auto ax = normalize_axis(e, axes);
         if (weights.dimension() == 1)
         {
-            if (weights.size() != e.shape()[ax[0]])
-            {
-                XTENSOR_THROW(std::runtime_error, "Weights need to have the same shape as expression at axes.");
-            }
-
+            XTENSOR_ASSERT_MSG(weights.size() == e.shape()[ax[0]], "Weights need to have the same shape as expression at axes.");
             std::fill(broadcast_shape.begin(), broadcast_shape.end(), std::size_t(1));
             broadcast_shape[ax[0]] = weights.size();
         }
         else
         {
-            if (!same_shape(e.shape(), weights.shape()))
-            {
-                XTENSOR_THROW(std::runtime_error, "Weights with dim > 1 need to have the same shape as expression.");
-            }
-
+            XTENSOR_ASSERT_MSG(same_shape(e.shape(), weights.shape()), "Weights with dim > 1 need to have the same shape as expression.");
             std::copy(e.shape().begin(), e.shape().end(), broadcast_shape.begin());
         }
 

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -889,6 +889,27 @@ namespace xt
         EXPECT_EQ(xt::average(v, w, {0, 1})(), m);
     }
 
+    TEST(xmath, average_random)
+    {
+        xt::xtensor<double,4> v = xt::random::rand<double>({4, 5, 6, 7});
+        xt::xtensor<double,4> w = xt::random::rand<double>({4, 5, 6, 7}) + 1.0;
+        xt::xtensor<double,2> r = xt::zeros<double>({6, 7});
+        xt::xtensor<double,2> n = xt::zeros<double>({6, 7});
+
+        for (size_t i = 0; i < v.shape(0); ++i) {
+            for (size_t j = 0; j < v.shape(1); ++j) {
+                for (size_t k = 0; k < v.shape(2); ++k) {
+                    for (size_t l = 0; l < v.shape(3); ++l) {
+                        r(k, l) += v(i, j, k, l) * w(i, j, k, l);
+                        n(k, l) += w(i, j, k, l);
+                    }
+                }
+            }
+        }
+
+        EXPECT_TRUE(xt::allclose(xt::average(v, w, {0, 1}), xt::eval(r / n)));
+    }
+
     /************************
      * Linear interpolation *
      ************************/


### PR DESCRIPTION
In my code `average` gives the **incorrect result!!**. This is a start to debug

**Edit** the bug seems to happen only with xtensor-python