### PR TITLE
fix doc typo: "hastack" to "hstack"

### DIFF
--- a/docs/source/quickref/builder.rst
+++ b/docs/source/quickref/builder.rst
@@ -198,7 +198,7 @@ HStack
 
     xt::xarray<double> a1 = {1, 2, 3};
     xt::xarray<double> b1 = {2, 3 ,4};
-    auto c1 = xt::hastack(xt::xtuple(a1, b1));
+    auto c1 = xt::hstack(xt::xtuple(a1, b1));
     std::cout << c1 << std::endl;
     // Outputs {1, 2, 3, 2, 3, 4}
 


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.


# Description

the commit fixes a typo in builders documentation, in `hstack`, the second example uses `hastack` (mind the extra "a").
<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
