### PR TITLE
find external packages (threads) after defining project

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,9 +9,6 @@
 
 cmake_minimum_required(VERSION 3.1)
 
-find_package(doctest            REQUIRED)
-find_package(Threads)
-
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtensor-test CXX)
 
@@ -20,6 +17,9 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     find_package(xtensor REQUIRED CONFIG)
     set(XTENSOR_INCLUDE_DIR ${xtensor_INCLUDE_DIRS})
 endif ()
+
+find_package(doctest            REQUIRED)
+find_package(Threads)
 
 if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "Setting tests build type to Release")


### PR DESCRIPTION
xtensor finds the threads package. But `find(Threads)` fails with the error message:
```
  FindThreads only works if either C or CXX language is enabled
```
The project needs to be defined first (enabling CXX language)

Fixed by debian patch
https://salsa.debian.org/science-team/xtensor/-/blob/master/debian/patches/test_findpackage_after_project.patch

Fixes #2498 