### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ cmake -DCMAKE_INSTALL_PREFIX=your_install_prefix
 make install
 ```
 
+### Installing xtensor using vcpkg
+
+You can download and install xtensor using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install xtensor
+```
+
+The xtensor port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Trying it online
 
 You can play with `xtensor` interactively in a Jupyter notebook right now! Just click on the binder link below:


### PR DESCRIPTION
`xtensor `is available as a port in vcpkg, a C++ library manager that simplifies installation for `xtensor `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build xtensor, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/xtensor/portfile.cmake). We try to keep the library maintained as close as possible to the original library.