### PR TITLE
`sep` and `head` arguments in the 

### DIFF
--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -190,6 +190,12 @@ namespace xt
         return tensor_type(std::move(data), std::move(shape), std::move(strides));
     }
 
+    /**
+     * @brief Dump tensor to CSV. (see declaration for more details)
+     *
+     * @param stream the output stream to write the CSV encoded values
+     * @param e the tensor expression to serialize
+     */
     template <class E>
     void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep, const std::string& head)
     {

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -34,15 +34,6 @@ namespace xt
     template <class T, class A = std::allocator<T>>
     xcsv_tensor<T, A> load_csv(std::istream& stream, const char delimiter = ',', const std::size_t skip_rows = 0, const std::ptrdiff_t max_rows = -1, const std::string comments = "#");
 
-    /**
-     * @brief exporting xexpression object to a std::ostream
-     * 
-     * @tparam expression type
-     * @param stream putput stream (e.g. std::cout)
-     * @param e E expression (e.g. xt::xarray<double>) 
-     * @param sep separator
-     * @param head header
-     */
     template <class E>
     void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep=",", const std::string& head="");
 

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -1,11 +1,11 @@
 /***************************************************************************
- * Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
- * Copyright (c) QuantStack                                                 *
- *                                                                          *
- * Distributed under the terms of the BSD 3-Clause License.                 *
- *                                                                          *
- * The full license is in the file LICENSE, distributed with this software. *
- ****************************************************************************/
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
 
 #ifndef XTENSOR_CSV_HPP
 #define XTENSOR_CSV_HPP
@@ -32,7 +32,7 @@ namespace xt
     using xcsv_tensor = xtensor_container<std::vector<T, A>, 2, layout_type::row_major>;
 
     template <class T, class A = std::allocator<T>>
-    xcsv_tensor<T, A> load_csv(std::istream &stream, const char delimiter = ',', const std::size_t skip_rows = 0, const std::ptrdiff_t max_rows = -1, const std::string comments = "#");
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const char delimiter = ',', const std::size_t skip_rows = 0, const std::ptrdiff_t max_rows = -1, const std::string comments = "#");
 
     /**
      * @brief dump xexpression to std::ostream (usually csv file)
@@ -71,7 +71,7 @@ namespace xt
     namespace detail
     {
         template <class T>
-        inline T lexical_cast(const std::string &cell)
+        inline T lexical_cast(const std::string& cell)
         {
             T res;
             std::istringstream iss(cell);
@@ -80,45 +80,45 @@ namespace xt
         }
 
         template <>
-        inline std::string lexical_cast(const std::string &cell)
+        inline std::string lexical_cast(const std::string& cell)
         {
             size_t first = cell.find_first_not_of(' ');
             if (first == std::string::npos)
                 return cell;
 
             size_t last = cell.find_last_not_of(' ');
-            return cell.substr(first, last == std::string::npos ? cell.size() : last + 1);
+            return cell.substr(first, last==std::string::npos?cell.size():last+1);
         }
 
         template <>
-        inline float lexical_cast<float>(const std::string &cell) { return std::stof(cell); }
+        inline float lexical_cast<float>(const std::string& cell) { return std::stof(cell); }
 
         template <>
-        inline double lexical_cast<double>(const std::string &cell) { return std::stod(cell); }
+        inline double lexical_cast<double>(const std::string& cell) { return std::stod(cell); }
 
         template <>
-        inline long double lexical_cast<long double>(const std::string &cell) { return std::stold(cell); }
+        inline long double lexical_cast<long double>(const std::string& cell) { return std::stold(cell); }
 
         template <>
-        inline int lexical_cast<int>(const std::string &cell) { return std::stoi(cell); }
+        inline int lexical_cast<int>(const std::string& cell) { return std::stoi(cell); }
 
         template <>
-        inline long lexical_cast<long>(const std::string &cell) { return std::stol(cell); }
+        inline long lexical_cast<long>(const std::string& cell) { return std::stol(cell); }
 
         template <>
-        inline long long lexical_cast<long long>(const std::string &cell) { return std::stoll(cell); }
+        inline long long lexical_cast<long long>(const std::string& cell) { return std::stoll(cell); }
 
         template <>
-        inline unsigned int lexical_cast<unsigned int>(const std::string &cell) { return static_cast<unsigned int>(std::stoul(cell)); }
+        inline unsigned int lexical_cast<unsigned int>(const std::string& cell) { return static_cast<unsigned int>(std::stoul(cell)); }
 
         template <>
-        inline unsigned long lexical_cast<unsigned long>(const std::string &cell) { return std::stoul(cell); }
+        inline unsigned long lexical_cast<unsigned long>(const std::string& cell) { return std::stoul(cell); }
 
         template <>
-        inline unsigned long long lexical_cast<unsigned long long>(const std::string &cell) { return std::stoull(cell); }
+        inline unsigned long long lexical_cast<unsigned long long>(const std::string& cell) { return std::stoull(cell); }
 
         template <class ST, class T, class OI>
-        ST load_csv_row(std::istream &row_stream, OI output, std::string cell, const char delimiter = ',')
+        ST load_csv_row(std::istream& row_stream, OI output, std::string cell, const char delimiter = ',')
         {
             ST length = 0;
             while (std::getline(row_stream, cell, delimiter))
@@ -132,7 +132,7 @@ namespace xt
 
     /**
      * @brief Load tensor from CSV.
-     *
+     * 
      * Returns an \ref xexpression for the parsed CSV
      * @param stream the input stream containing the CSV encoded values
      * @param delimiter the character used to separate values. [default: ',']
@@ -141,7 +141,7 @@ namespace xt
      * @param comments the string used to indicate the start of a comment. [default: "#"]
      */
     template <class T, class A>
-    xcsv_tensor<T, A> load_csv(std::istream &stream,
+    xcsv_tensor<T, A> load_csv(std::istream& stream,
                                const char delimiter,
                                const std::size_t skip_rows,
                                const std::ptrdiff_t max_rows,
@@ -161,7 +161,7 @@ namespace xt
             std::string row, cell;
             while (std::getline(stream, row))
             {
-                if (nhead < skip_rows)
+                if (nhead < skip_rows) 
                 {
                     ++nhead;
                     continue;
@@ -180,7 +180,7 @@ namespace xt
             }
         }
         inner_shape_type shape = {nbrow, nbcol};
-        inner_strides_type strides; // no need for initializer list for stack-allocated strides_type
+        inner_strides_type strides;  // no need for initializer list for stack-allocated strides_type
         size_type data_size = compute_strides(shape, layout_type::row_major, strides);
         // Sanity check for data size.
         if (data.size() != data_size)
@@ -191,22 +191,19 @@ namespace xt
     }
 
     template <class E>
-    void dump_csv(std::ostream &stream, const xexpression<E> &e, const std::string &sep, const std::string &head)
+    void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep, const std::string& head)
     {
         using size_type = typename E::size_type;
-        const E &ex = e.derived_cast();
+        const E& ex = e.derived_cast();
         if (ex.dimension() != 2)
         {
             XTENSOR_THROW(std::runtime_error, "Only 2-D expressions can be serialized to CSV");
         }
         size_type nbrows = ex.shape()[0], nbcols = ex.shape()[1];
         auto st = ex.stepper_begin(ex.shape());
-
-        if (head != "")
-        {
-            stream << head << std::endl;
-        }
-
+        
+        if (head != ""){ stream << head << std::endl; }
+        
         for (size_type r = 0; r != nbrows; ++r)
         {
             for (size_type c = 0; c != nbcols; ++c)
@@ -251,19 +248,22 @@ namespace xt
         std::string comments;
 
         xcsv_config()
-            : delimiter(','), skip_rows(0), max_rows(-1), comments("#")
+            : delimiter(',')
+            , skip_rows(0)
+            , max_rows(-1)
+            , comments("#")
         {
         }
     };
 
     template <class E>
-    void load_file(std::istream &stream, xexpression<E> &e, const xcsv_config &config)
+    void load_file(std::istream& stream, xexpression<E>& e, const xcsv_config& config)
     {
         e.derived_cast() = load_csv<typename E::value_type>(stream, config.delimiter, config.skip_rows, config.max_rows, config.comments);
     }
 
     template <class E>
-    void dump_file(std::ostream &stream, const xexpression<E> &e, const xcsv_config &)
+    void dump_file(std::ostream& stream, const xexpression<E> &e, const xcsv_config&)
     {
         dump_csv(stream, e);
     }

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -34,8 +34,35 @@ namespace xt
     template <class T, class A = std::allocator<T>>
     xcsv_tensor<T, A> load_csv(std::istream& stream, const char delimiter = ',', const std::size_t skip_rows = 0, const std::ptrdiff_t max_rows = -1, const std::string comments = "#");
 
+    /**
+     * @brief dump xexpression to std::ostream (usually csv file)
+     *
+     * Example output with sep="@" and `head="xANDy"`:
+     *
+     * ```
+     * xANDy
+     * -1.45@-2.18
+     * -1.05@6.91
+     * -2.10@1.61
+     * ```
+     *
+     * @tparam E xexpression type
+     * @param stream reference to std::ostream where the expression is dumped to
+     * @param e xpression<E>
+     * @param sep column separator
+     * @param head header std::string
+     */
     template <class E>
-    void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep=",", const std::string& head="");
+    void dump_csv(std::ostream &stream, const xexpression<E> &e, const std::string &sep = ",", const std::string &head = "");
+
+    /**
+     * @brief dump_csv() overloading: dumping with header equal to column names
+     *
+     * the header std::string is the concatenation of the elements of `col_names`, separated by `sep`
+     *
+     */
+    template <class E>
+    void dump_csv(std::ostream &stream, const xexpression<E> &e, const std::string &sep = ",", const std::vector<std::string> &col_names = {""});
 
     /*****************************************
      * load_csv and dump_csv implementations *
@@ -163,12 +190,6 @@ namespace xt
         return tensor_type(std::move(data), std::move(shape), std::move(strides));
     }
 
-    /**
-     * @brief Dump tensor to CSV.
-     * 
-     * @param stream the output stream to write the CSV encoded values
-     * @param e the tensor expression to serialize
-     */
     template <class E>
     void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep, const std::string& head)
     {
@@ -201,6 +222,22 @@ namespace xt
                 }
             }
         }
+    }
+
+    template <class E>
+    void dump_csv(std::ostream &stream, const xexpression<E> &e, const std::string &sep, const std::vector<std::string> &col_names)
+    {
+        std::string head = "";
+        const size_t nc = col_names.size();
+        for (size_t i = 0; i <= nc - 2; i++)
+        {
+            head += col_names[i] + sep
+        }
+        if (nc > 0)
+        {
+            head += col_names[nc - 1];
+        }
+        dump_csv(stream, e, sep, head);
     }
 
     struct xcsv_config

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -44,7 +44,7 @@ namespace xt
      * @param head header
      */
     template <class E>
-    void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep=" ", const std::string& head="");
+    void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep=",", const std::string& head="");
 
     /*****************************************
      * load_csv and dump_csv implementations *

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -62,7 +62,7 @@ namespace xt
      *
      */
     template <class E>
-    void dump_csv(std::ostream &stream, const xexpression<E> &e, const std::string &sep = ",", const std::vector<std::string> &col_names = {""});
+    void dump_csv(std::ostream &stream, const xexpression<E> &e, const std::string &sep, const std::vector<std::string> &col_names);
 
     /*****************************************
      * load_csv and dump_csv implementations *

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -191,7 +191,7 @@ namespace xt
     }
 
     /**
-     * @brief Dump tensor to CSV. (see declaration for more details)
+     * @brief Dump tensor to CSV.
      *
      * @param stream the output stream to write the CSV encoded values
      * @param e the tensor expression to serialize

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -11,6 +11,7 @@
 #define XTENSOR_CSV_HPP
 
 #include <exception>
+#include <iostream>
 #include <istream>
 #include <iterator>
 #include <sstream>
@@ -33,8 +34,17 @@ namespace xt
     template <class T, class A = std::allocator<T>>
     xcsv_tensor<T, A> load_csv(std::istream& stream, const char delimiter = ',', const std::size_t skip_rows = 0, const std::ptrdiff_t max_rows = -1, const std::string comments = "#");
 
+    /**
+     * @brief exporting xexpression object to a std::ostream
+     * 
+     * @tparam expression type
+     * @param stream putput stream (e.g. std::cout)
+     * @param e E expression (e.g. xt::xarray<double>) 
+     * @param sep separator
+     * @param head header
+     */
     template <class E>
-    void dump_csv(std::ostream& stream, const xexpression<E>& e);
+    void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep=" ", const std::string& head="");
 
     /*****************************************
      * load_csv and dump_csv implementations *
@@ -169,7 +179,7 @@ namespace xt
      * @param e the tensor expression to serialize
      */
     template <class E>
-    void dump_csv(std::ostream& stream, const xexpression<E>& e)
+    void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep, const std:string& head)
     {
         using size_type = typename E::size_type;
         const E& ex = e.derived_cast();
@@ -179,6 +189,9 @@ namespace xt
         }
         size_type nbrows = ex.shape()[0], nbcols = ex.shape()[1];
         auto st = ex.stepper_begin(ex.shape());
+        
+        if (head != ""){ stream << head << std::endl; }
+        
         for (size_type r = 0; r != nbrows; ++r)
         {
             for (size_type c = 0; c != nbcols; ++c)
@@ -187,7 +200,7 @@ namespace xt
                 if (c != nbcols - 1)
                 {
                     st.step(1);
-                    stream << ',';
+                    stream << sep;
                 }
                 else
                 {

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -179,7 +179,7 @@ namespace xt
      * @param e the tensor expression to serialize
      */
     template <class E>
-    void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep, const std:string& head)
+    void dump_csv(std::ostream& stream, const xexpression<E>& e, const std::string& sep, const std::string& head)
     {
         using size_type = typename E::size_type;
         const E& ex = e.derived_cast();


### PR DESCRIPTION
I've added 2 functionalities to the `dump_csv()` function. The user can now specify the separator and header as `std::string`.

Example output with `sep="@"` and `head="x@y":

```
x@y
-1.45@-2.18
-1.05@6.91
-2.10@1.61

```