### PR TITLE
fix a tiny typo in concepts.rst

### DIFF
--- a/docs/source/developer/concepts.rst
+++ b/docs/source/developer/concepts.rst
@@ -46,7 +46,7 @@ object to the most inheriting type, depending on the nature of the object (*lval
 .. code::
 
     derived_type& derived_cast() & noexcept;
-    const derived_type& derived_cast() & noexcept;
+    const derived_type& derived_cast() const & noexcept;
     derived_type derived_cast() && noexcept;
 
 .. _xiterable-concept-label:


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description
Fix a small typo in line 49, concepts.rst. As is shown in the real code, the correct function prototype is `const derived_type& derived_cast() const & noexcept;` while the original one in the doc is `const derived_type& derived_cast() & noexcept;`, which is obviously wrong since it's not a valid function overload.
<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
