### PR TITLE
fix npy_file move assignment

### DIFF
--- a/include/xtensor/xnpy.hpp
+++ b/include/xtensor/xnpy.hpp
@@ -495,7 +495,7 @@ namespace xt
 
             // delete copy constructor
             npy_file(const npy_file&) = delete;
-            npy_file& operator=(npy_file) = delete;
+            npy_file& operator=(const npy_file&) = delete;
 
             // implement move constructor and assignment
             npy_file(npy_file&& rhs)

--- a/test/test_xnpy.cpp
+++ b/test/test_xnpy.cpp
@@ -83,6 +83,29 @@ namespace xt
         EXPECT_TRUE(all(equal(iarr1d, iarr1d_loaded)));
     }
 
+    TEST(xnpy, npy_file_move)
+    {
+        xarray<bool> barr = {{{ 0, 0, 1},
+                              { 1, 1, 0},
+                              { 1, 0, 1}},
+                             {{ 1, 1, 0},
+                              { 0, 1, 0},
+                              { 0, 1, 0}},
+                             {{ 0, 0, 1},
+                              { 1, 1, 1},
+                              { 0, 0, 0}}};
+
+        std::ifstream bstream(get_load_filename("files/xnpy_files/bool"));
+        detail::npy_file npy = detail::load_npy_file(bstream);
+        auto barr_cast = npy.cast<bool>(true);
+        EXPECT_TRUE(all(equal(barr, barr_cast)));
+
+        detail::npy_file npy_move;
+        npy_move = std::move(npy);
+        auto barr_cast_move = npy_move.cast<bool>(true);
+        EXPECT_TRUE(all(equal(barr, barr_cast_move)));
+    }
+
     bool compare_binary_files(std::string fn1, std::string fn2)
     {
         std::ifstream stream1(fn1, std::ios::in | std::ios::binary);


### PR DESCRIPTION
# Description

* fix `struct npy_file`'s Move Assignment.
* fix memory leak when moving to a npy_file with buffer.

<!---
Give any relevant description here. 
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
