### PR TITLE
Explicitly declare test_xtensor_core_lib as STATIC

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -306,7 +306,7 @@ add_test(NAME xtest COMMAND test_xtensor_lib)
 # Some files will be compiled twice, however compiling common files in a static
 # library and linking test_xtensor_lib with it removes half of the tests at
 # runtime.
-add_library(test_xtensor_core_lib ${COMMON_BASE} ${TEST_HEADERS} ${XTENSOR_HEADERS})
+add_library(test_xtensor_core_lib STATIC ${COMMON_BASE} ${TEST_HEADERS} ${XTENSOR_HEADERS})
 target_include_directories(test_xtensor_core_lib PRIVATE ${XTENSOR_INCLUDE_DIR})
 
 target_link_libraries(test_xtensor_core_lib PRIVATE xtensor doctest::doctest ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

When `STATIC` keyword is missed from `add_library()` arguments, the library type (static/shared) can still be controlled via `-DBUILD_SHARED_LIBS` command line option.

While `-DBUILD_SHARED_LIBS=OFF` is the default value, it is common practice to set this `ON` while building packages for major Linux distributions. In order to specify that the library is meant to be static unconditionally, use `STATIC` keyword here.
