### PR TITLE
Specialize get_strides_type for xbuffer_adaptor

### DIFF
--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -22,6 +22,7 @@
 
 #include <xtl/xcomplex.hpp>
 #include <xtl/xtype_traits.hpp>
+#include <xtl/xsequence.hpp>
 
 #include "xaccumulator.hpp"
 #include "xeval.hpp"
@@ -2108,7 +2109,13 @@ namespace detail {
         auto inner_mean = eval(mean<T>(sc, std::move(axes_copy), evaluation_strategy::immediate));
 
         // fake keep_dims = 1
-        auto keep_dim_shape = e.shape();
+        // Since the inner_shape might have a reference semantic (e.g. xbuffer_adaptor in bindings)
+        // We need to map it to another type before modifying it.
+        // We pragmatically abuse `get_strides_t`
+        using tmp_shape_t = get_strides_t<typename std::decay_t<E>::shape_type>;
+        tmp_shape_t keep_dim_shape = xtl::forward_sequence<tmp_shape_t, decltype(e.shape())>(
+            e.shape()
+        );
         for (const auto& el : axes)
         {
             keep_dim_shape[el] = 1u;
@@ -2712,7 +2719,13 @@ namespace detail {
         auto inner_mean = nanmean<result_type>(sc, std::move(axes_copy));
 
         // fake keep_dims = 1
-        auto keep_dim_shape = e.shape();
+        // Since the inner_shape might have a reference semantic (e.g. xbuffer_adaptor in bindings)
+        // We need to map it to another type before modifying it.
+        // We pragmatically abuse `get_strides_t`
+        using tmp_shape_t = get_strides_t<typename std::decay_t<E>::shape_type>;
+        tmp_shape_t keep_dim_shape = xtl::forward_sequence<tmp_shape_t, decltype(e.shape())>(
+            e.shape()
+        );
         for (const auto& el : axes)
         {
             keep_dim_shape[el] = 1;

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -858,6 +858,22 @@ namespace xt
         using type = std::array<std::ptrdiff_t, sizeof...(I)>;
     };
 
+    template <class CP, class O, class A>
+    class xbuffer_adaptor;
+
+    template <class CP, class O, class A>
+    struct get_strides_type<xbuffer_adaptor<CP, O, A>>
+    {
+        // In bindings this mapping is called by reshape_view with an inner shape of type
+        // xbuffer_adaptor.
+        // Since we cannot create a buffer adaptor holding data, we map it to an std::vector.
+        using type = std::vector<
+            typename xbuffer_adaptor<CP, O, A>::value_type,
+            typename xbuffer_adaptor<CP, O, A>::allocator_type
+         >;
+    };
+
+
     template <class C>
     using get_strides_t = typename get_strides_type<C>::type;
 


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

Fix https://github.com/xtensor-stack/xtensor-r/issues/85
Solution discussed with @JohanMabille 