### PR TITLE
Fix for C++ 20 for which pointer and reference have been removed.

### DIFF
--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -619,10 +619,12 @@ namespace xt
         using allocator_type = A;
         using size_type = typename std::allocator_traits<A>::size_type;
         using value_type = typename std::allocator_traits<A>::value_type;
+#if __cplusplus <= 201703L
         using pointer = typename std::allocator_traits<A>::pointer;
         using const_pointer = typename std::allocator_traits<A>::const_pointer;
         using reference = value_type&;
         using const_reference = const value_type&;
+#endif
         using difference_type = typename std::allocator_traits<A>::difference_type;
 
         using iterator = pointer;


### PR DESCRIPTION
# Checklist

- X The title and commit message(s) are descriptive.
- X Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

I have not opened an issue, given that the problem and its solution are obvious.
C++ 20 has suppressed pointer, reference and their const versions from allocator, thus xtensor should follow....

https://en.cppreference.com/w/cpp/memory/allocator
