### PR TITLE
Fix missing namespace in doxygengroup

### DIFF
--- a/docs/source/api/xshape.rst
+++ b/docs/source/api/xshape.rst
@@ -9,4 +9,8 @@ xshape
 
 Defined in ``xtensor/xshape.hpp``
 
+.. cpp:namespace-push:: xt
+
 .. doxygengroup:: xt_xshape
+
+.. cpp:namespace-pop::

--- a/docs/source/api/xsort.rst
+++ b/docs/source/api/xsort.rst
@@ -9,4 +9,8 @@ xsort
 
 Defined in ``xtensor/xsort.hpp``
 
+.. cpp:namespace-push:: xt
+
 .. doxygengroup:: xt_xsort
+
+.. cpp:namespace-pop::


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] ~~Tests have been added for new features or bug fixes.~~
- [x] API of new functions and classes are documented.

# Description

Current use of `.. doxygengroup` breaks links for reference of style ``:cpp:func:`xt::func` ``.
With this fix, we can restore the links without changing all references.

@tdegeus 