### PR TITLE
Change xindex_view reference type to handle const data

### DIFF
--- a/include/xtensor/xindex_view.hpp
+++ b/include/xtensor/xindex_view.hpp
@@ -102,7 +102,7 @@ namespace xt
         using expression_tag = typename extension_base::expression_tag;
 
         using value_type = typename xexpression_type::value_type;
-        using reference = typename xexpression_type::reference;
+        using reference = inner_reference_t<CT>;
         using const_reference = typename xexpression_type::const_reference;
         using pointer = typename xexpression_type::pointer;
         using const_pointer = typename xexpression_type::const_pointer;

--- a/test/test_xindex_view.cpp
+++ b/test/test_xindex_view.cpp
@@ -55,6 +55,15 @@ namespace xt
         EXPECT_EQ(3, e(2, 2));
     }
 
+    TEST(xindex_view, indices_const)
+    {
+        xarray<double> const e = xt::random::rand<double>({3, 3});
+        auto v = index_view(e, {{1ul, 1ul}, {1ul, 2ul}, {2ul, 2ul}});
+        EXPECT_EQ(e(1, 1), v(0));
+        auto const vc = index_view(e, {{1ul, 1ul}, {1ul, 2ul}, {2ul, 2ul}});
+        EXPECT_EQ(vc(0), v(0));
+    }
+
     TEST(xindex_view, boolean)
     {
         xarray<double> e = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] ~~API of new functions and classes are documented.~~

# Description

Close #2621
