### PR TITLE
Adding missing `defgroup` `xt_xshape`

### DIFF
--- a/include/xtensor/xshape.hpp
+++ b/include/xtensor/xshape.hpp
@@ -92,6 +92,10 @@ namespace xtl
 
 namespace xt
 {
+    /**
+     * @defgroup xt_xshape Support functions to get/check a shape array.
+     */
+
     /**************
      * same_shape *
      **************/


### PR DESCRIPTION
Fixes https://github.com/xtensor-stack/xtensor/issues/2559