### PR TITLE
fixes #2568. MSVC optimizations causing segmentation faults in optimized builds.

### DIFF
--- a/docs/source/compilers.rst
+++ b/docs/source/compilers.rst
@@ -50,6 +50,15 @@ In ``xfixed.hpp`` we add a level of indirection to expand one parameter pack bef
 Not doing this results in VS2017 complaining about a parameter pack that needs to be expanded in this
 context while it actually is.
 
+Visual Studio 2022 (19.31+) workaround inline compiler optimization bug
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In `xstrides.hpp`, added an early return inside `compute_strides` when ``shape.size() == 0`` to
+prevent a run time crash from occuring. Without this guard statement, instructions from inside the
+for loop were somehow being reached, despite being logically unreachable.
+Original issue  `here. <https://github.com/xtensor-stack/xtensor/issues/2568>`_
+Upstream issue `here. <https://developercommunity.visualstudio.com/t/Runtime-Crash-msvc--1931-with-optimiz/10134617>`_
+
 GCC-4.9 and Clang < 3.8 and constexpr ``std::min`` and ``std::max``
 -------------------------------------------------------------------
 

--- a/docs/source/compilers.rst
+++ b/docs/source/compilers.rst
@@ -53,7 +53,7 @@ context while it actually is.
 Visual Studio 2022 (19.31+) workaround inline compiler optimization bug
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In `xstrides.hpp`, added an early return inside `compute_strides` when ``shape.size() == 0`` to
+In ``xstrides.hpp``, added an early return inside ``compute_strides`` when ``shape.size() == 0`` to
 prevent a run time crash from occuring. Without this guard statement, instructions from inside the
 for loop were somehow being reached, despite being logically unreachable.
 Original issue  `here. <https://github.com/xtensor-stack/xtensor/issues/2568>`_

--- a/include/xtensor/xstrides.hpp
+++ b/include/xtensor/xstrides.hpp
@@ -456,6 +456,14 @@ namespace xt
         {
             using strides_value_type = typename std::decay_t<strides_type>::value_type;
             strides_value_type data_size = 1;
+
+        #if defined(_MSC_VER) && (1931 <= _MSC_VER)
+            // Workaround MSVC compiler optimization bug, xtensor#2568
+            if (0 == shape.size()) {
+                return static_cast<std::size_t>(data_size);
+            }
+        #endif
+
             if (L == layout_type::row_major || l == layout_type::row_major)
             {
                 for (std::size_t i = shape.size(); i != 0; --i)

--- a/test/test_xsort.cpp
+++ b/test/test_xsort.cpp
@@ -218,6 +218,12 @@ namespace xt
 
         xtensor<std::size_t, 2> ex_6 = {{0, 0, 0, 0}, {0, 0, 0, 0}};
         EXPECT_EQ(ex_6, argmax(c, 1));
+
+        // xtensor#2568
+        xarray<double> d = {0, 1, 0};
+        xtensor<size_t, 0> d_ex_1 = { 1 };
+        EXPECT_EQ(d_ex_1, argmax(d));
+        EXPECT_EQ(1, argmax(d)(0));
     }
 
     TEST(xsort, sort_large_prob)


### PR DESCRIPTION
Works around an msvc optimizer bug which occurs when shape.size() == 0. 

Surrounding the problematic region to prevent illegal access that occurs on windows MSVC optimized builds (/O1, /O2).

- allows construction of 0-sized xarray and xtensors (e.g. xt::xtensor<size_t, 0>)
- also fixes xt::argmax() crashing 

# Checklist

- [ ] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

Fixes #2551 
Fixes #2568 
Fixes #2596 
