### PR TITLE
Fix a bug where .fill doesn't work for a xcontainer that is non-contiguous

### DIFF
--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -422,7 +422,14 @@ namespace xt
     template <class T>
     inline void xcontainer<D>::fill(const T& value)
     {
-        std::fill(linear_begin(), linear_end(), value);
+        if (contiguous_layout)
+        {
+            std::fill(this->linear_begin(), this->linear_end(), value);
+        }
+        else
+        {
+            std::fill(this->begin(), this->end(), value);
+        }
     }
 
     /**

--- a/test/test_xadapt.cpp
+++ b/test/test_xadapt.cpp
@@ -505,6 +505,23 @@ namespace xt
         }
     }
 
+    TEST(xtensor_adaptor, pointer_strided_fill)
+    {
+        auto data = std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8};
+        auto adapter = xt::adapt(
+            data.data(),
+            4,
+            xt::no_ownership(),
+            std::vector<size_t>{4, 1},
+            std::vector<size_t>{2, 1}
+        );
+        adapter.fill(0);
+        EXPECT_EQ(data[0], 0);
+        EXPECT_EQ(data[3], 4);
+        EXPECT_EQ(data[4], 0);
+        EXPECT_EQ(data[5], 6);
+    }
+
     TEST(xtensor_adaptor, smart_ptr)
     {
         auto data = std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8};


### PR DESCRIPTION
The .fill() method of xcontainer doesn't check if the container is actually contiguous, and therefore makes mistakes for noncontiguous containers. This is a quick fix for that.

For instance, the following fills the first four values of `data` with zeros, instead of the ones that correspond to the first column.
```
auto data = std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8};
auto adapter = xt::adapt(data.data(), 4, xt::no_ownership(), std::vector<size_t>{4, 1}, std::vector<size_t>{2, 1});
adapter.fill(0)
```
