### PR TITLE
Removing duplicates from documentation

### DIFF
--- a/docs/source/api/xarray_adaptor.rst
+++ b/docs/source/api/xarray_adaptor.rst
@@ -11,34 +11,3 @@ Defined in ``xtensor/xarray.hpp``
 
 .. doxygenclass:: xt::xarray_adaptor
    :members:
-
-adapt
-=====
-
-Defined in ``xtensor/xadapt.hpp``
-
-.. doxygenfunction:: xt::adapt(C&&, const SC&, layout_type)
-
-.. doxygenfunction:: xt::adapt(C&&, SC&&, SS&&)
-
-.. doxygenfunction:: xt::adapt(P&&, typename A::size_type, O, const SC&, layout_type, const A&)
-
-.. doxygenfunction:: xt::adapt(P&&, typename A::size_type, O, SC&&, SS&&, const A&)
-
-.. doxygenfunction:: xt::adapt(T (&)[N], const SC&, layout_type)
-
-.. doxygenfunction:: xt::adapt(T (&)[N], SC&&, SS&&)
-
-.. doxygenfunction:: xt::adapt(C&& pointer, const fixed_shape<X...>&);
-
-.. doxygenfunction:: xt::adapt(C&&, layout_type)
-
-.. doxygenfunction:: xt::adapt(P&&, typename A::size_type, O, layout_type, const A&)
-
-.. doxygenfunction:: xt::adapt_smart_ptr(P&&, const SC&, layout_type)
-
-.. doxygenfunction:: xt::adapt_smart_ptr(P&&, const SC&, D&&, layout_type)
-
-.. doxygenfunction:: xt::adapt_smart_ptr(P&&, const I (&)[N], layout_type)
-
-.. doxygenfunction:: xt::adapt_smart_ptr(P&&, const I (&)[N], D&&, layout_type)


### PR DESCRIPTION
It seems that I introduced some duplicates in https://github.com/xtensor-stack/xtensor/pull/2665