### PR TITLE
Support external linkage for "recurser_run"

### DIFF
--- a/include/xtensor/xio.hpp
+++ b/include/xtensor/xio.hpp
@@ -254,7 +254,7 @@ namespace xt
         }
 
         template <class F, class E>
-        static void recurser_run(F& fn, const E& e, xstrided_slice_vector& slices, std::size_t lim = 0)
+        void recurser_run(F& fn, const E& e, xstrided_slice_vector& slices, std::size_t lim = 0)
         {
             using size_type = typename E::size_type;
             const auto view = strided_view(e, slices);


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Static functions (different to static class/struct methods) are a language feature for prevent external linkage and avoid polluting the global namespace similar to using an anonymous namespace. For a C++20 module to wrap xtensor it is fine for a normal exported function to call a function with internal linkage, but not if it shares a template parameter with it ([see p1815r2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1815r2.html)).

In order to export the useful API definitions `pretty_print` and `operator<<` from `xtensor/xio.hpp`, `recurser_run` needs to support external linkage.