### PR TITLE
fix memory leak of npy_file's move assignment

### DIFF
--- a/include/xtensor/xnpy.hpp
+++ b/include/xtensor/xnpy.hpp
@@ -561,6 +561,10 @@ namespace xt
             {
                 if (this != &rhs)
                 {
+                    if (m_buffer != nullptr)
+                    {
+                        std::allocator<char>{}.deallocate(m_buffer, m_n_bytes);
+                    }
                     m_shape = std::move(rhs.m_shape);
                     m_fortran_order = std::move(rhs.m_fortran_order);
                     m_word_size = std::move(rhs.m_word_size);


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description
Fix memory leak when one npy_file move to another npy_file.
<!---
Give any relevant description here.
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
