### PR TITLE
Fix conversion warning in xrepeat

### DIFF
--- a/include/xtensor/xrepeat.hpp
+++ b/include/xtensor/xrepeat.hpp
@@ -263,7 +263,7 @@ namespace xt
         , m_shape(e.shape())
     {
         using shape_value_type = typename shape_type::value_type;
-        m_shape[axis] = static_cast<shape_value_type>(std::accumulate(m_repeats.begin(), m_repeats.end(), 0));
+        m_shape[axis] = static_cast<shape_value_type>(std::accumulate(m_repeats.begin(), m_repeats.end(), shape_value_type{}));
     }
 
     /**

--- a/include/xtensor/xrepeat.hpp
+++ b/include/xtensor/xrepeat.hpp
@@ -263,7 +263,7 @@ namespace xt
         , m_shape(e.shape())
     {
         using shape_value_type = typename shape_type::value_type;
-        m_shape[axis] = static_cast<shape_value_type>(std::accumulate(m_repeats.begin(), m_repeats.end(), shape_value_type{}));
+        m_shape[axis] = static_cast<shape_value_type>(std::accumulate(m_repeats.begin(), m_repeats.end(), shape_value_type(0)));
     }
 
     /**

--- a/include/xtensor/xrepeat.hpp
+++ b/include/xtensor/xrepeat.hpp
@@ -263,7 +263,9 @@ namespace xt
         , m_shape(e.shape())
     {
         using shape_value_type = typename shape_type::value_type;
-        m_shape[axis] = static_cast<shape_value_type>(std::accumulate(m_repeats.begin(), m_repeats.end(), shape_value_type(0)));
+        m_shape[axis] = static_cast<shape_value_type>(
+            std::accumulate(m_repeats.begin(), m_repeats.end(), shape_value_type(0))
+        );
     }
 
     /**


### PR DESCRIPTION
# Checklist

- [ ] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

The internal type of std::accumulate is determined by the init parameter.
Initializing with 0 (int) results in a "conversion from 'size_t' to 'type', possible loss of data" warning in MSVC.
Here is a [link](https://godbolt.org/z/8xaYsTjvj) showcasing the warning in Compiler Explorer.
