### PR TITLE
Update to use XTENSOR_DEFAULT_ALIGNMENT when using XSIMD

### DIFF
--- a/include/xtensor/xtensor_config.hpp
+++ b/include/xtensor/xtensor_config.hpp
@@ -79,7 +79,7 @@
 #else
 #ifdef XTENSOR_USE_XSIMD
 
-#define XTENSOR_DEFAULT_ALLOCATOR(T) xsimd::aligned_allocator<T, XSIMD_DEFAULT_ALIGNMENT>
+#define XTENSOR_DEFAULT_ALLOCATOR(T) xsimd::aligned_allocator<T, XTENSOR_DEFAULT_ALIGNMENT>
 #else
 #define XTENSOR_DEFAULT_ALLOCATOR(T) std::allocator<T>
 #endif


### PR DESCRIPTION
# Checklist

- [ x] The title and commit message(s) are descriptive.
- [ x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ x] Tests have been added for new features or bug fixes.
- [ x] API of new functions and classes are documented.

# Description
Updated to allow overriding of alignment when using XSIMD. If the user doesn't provide an overriding value then the default XSIMD value is used. This fixed linker issues when different default vectorization settings are used between libraries within the same project. The intel C++ compiler requests 16 alignment for AVX while MSVC defines it to 32 so it's nice to be able to pin the alignment at the higher of the two. 
