### PR TITLE
Fix xaxis_*_iterator shape and strides types

### DIFF
--- a/include/xtensor/xaxis_iterator.hpp
+++ b/include/xtensor/xaxis_iterator.hpp
@@ -39,7 +39,7 @@ namespace xt
         using xexpression_type = std::decay_t<CT>;
         using size_type = typename xexpression_type::size_type;
         using difference_type = typename xexpression_type::difference_type;
-        using shape_type = typename xexpression_type::shape_type;
+        using shape_type = std::vector<typename xexpression_type::shape_type::value_type>;
         using value_type = xstrided_view<CT, shape_type>;
         using reference = std::remove_reference_t<apply_cv_t<CT, value_type>>;
         using pointer = xtl::xclosure_pointer<std::remove_reference_t<apply_cv_t<CT, value_type>>>;
@@ -106,8 +106,8 @@ namespace xt
         )
         {
             using xexpression_type = std::decay_t<CT>;
-            using shape_type = typename xexpression_type::shape_type;
-            using strides_type = typename xexpression_type::strides_type;
+            using shape_type = std::vector<typename xexpression_type::shape_type::value_type>;
+            using strides_type = std::vector<typename xexpression_type::strides_type::value_type>;
 
             const auto& e_shape = e.shape();
             shape_type shape(e_shape.size() - 1);

--- a/include/xtensor/xaxis_slice_iterator.hpp
+++ b/include/xtensor/xaxis_slice_iterator.hpp
@@ -34,8 +34,8 @@ namespace xt
         using xexpression_type = std::decay_t<CT>;
         using size_type = typename xexpression_type::size_type;
         using difference_type = typename xexpression_type::difference_type;
-        using shape_type = typename xexpression_type::shape_type;
-        using strides_type = typename xexpression_type::strides_type;
+        using shape_type = std::array<typename xexpression_type::shape_type::value_type, 1>;
+        using strides_type = std::array<typename xexpression_type::strides_type::value_type, 1>;
         using value_type = xstrided_view<CT, shape_type>;
         using reference = std::remove_reference_t<apply_cv_t<CT, value_type>>;
         using pointer = xtl::xclosure_pointer<std::remove_reference_t<apply_cv_t<CT, value_type>>>;

--- a/test/test_xaxis_iterator.cpp
+++ b/test/test_xaxis_iterator.cpp
@@ -8,25 +8,38 @@
  ****************************************************************************/
 
 #include "xtensor/xarray.hpp"
+#include "xtensor/xtensor.hpp"
+#include "xtensor/xfixed.hpp"
 #include "xtensor/xaxis_iterator.hpp"
 
 #include "test_common_macros.hpp"
+
+#define ROW_TYPES \
+    xarray<int, layout_type::row_major>, \
+    xtensor<int, 3, layout_type::row_major>, \
+    xtensor_fixed<int, xt::xshape<2, 3, 4>, layout_type::row_major>
+#define COL_TYPES \
+    xarray<int, layout_type::column_major>, \
+    xtensor<int, 3, layout_type::column_major>, \
+    xtensor_fixed<int, xt::xshape<2, 3, 4>, layout_type::column_major>
+#define ALL_TYPES ROW_TYPES, COL_TYPES
 
 namespace xt
 {
     using std::size_t;
 
-    xarray<int> get_test_array()
+    template<typename T=xarray<int>>
+    T get_test_array()
     {
-        xarray<int> res = {
+        T res = {
             {{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}},
             {{13, 14, 15, 16}, {17, 18, 19, 20}, {21, 22, 23, 24}}};
         return res;
     }
 
-    TEST(xaxis_iterator, begin)
+    TEST_CASE_TEMPLATE("xaxis_iterator.begin", T, ALL_TYPES)
     {
-        xarray<int> a = get_test_array();
+        T a = get_test_array<T>();
         auto iter_begin = axis_begin(a);
         EXPECT_EQ(size_t(2), iter_begin->dimension());
         EXPECT_EQ(a.shape()[1], iter_begin->shape()[0]);
@@ -37,9 +50,9 @@ namespace xt
         EXPECT_EQ(a(0, 2, 3), (*iter_begin)(2, 3));
     }
 
-    TEST(xaxis_iterator, increment)
+    TEST_CASE_TEMPLATE("xaxis_iterator.increment", T, ROW_TYPES)
     {
-        xarray<int> a = get_test_array();
+        T a = get_test_array<T>();
         auto iter = axis_begin(a);
         ++iter;
 
@@ -52,9 +65,9 @@ namespace xt
         EXPECT_EQ(a(1, 2, 3), (*iter)(2, 3));
     }
 
-    TEST(xaxis_iterator, end)
+    TEST_CASE_TEMPLATE("xaxis_iterator.end", T, ALL_TYPES)
     {
-        xarray<int> a = get_test_array();
+        T a = get_test_array<T>();
         auto iter_begin = axis_begin(a, 1u);
         auto iter_end = axis_end(a, 1u);
         auto dist = std::distance(iter_begin, iter_end);
@@ -80,9 +93,9 @@ namespace xt
         EXPECT_EQ(iter_begin_row, iter_end_row);
     }
 
-    TEST(xaxis_iterator, nested)
+    TEST_CASE_TEMPLATE("xaxis_iterator.nested", T, ROW_TYPES)
     {
-        xarray<int> a = get_test_array();
+        T a = get_test_array<T>();
         auto iter = axis_begin(a);
         ++iter;
         auto niter = axis_begin(*iter);
@@ -95,9 +108,9 @@ namespace xt
         EXPECT_EQ(a(1, 1, 3), (*niter)(3));
     }
 
-    TEST(xaxis_iterator, const_array)
+    TEST_CASE_TEMPLATE("xaxis_iterator.const_array", T, ROW_TYPES)
     {
-        const xarray<int> a = get_test_array();
+        const T a = get_test_array<T>();
         auto iter = axis_begin(a);
         ++iter;
 
@@ -110,9 +123,9 @@ namespace xt
         EXPECT_EQ(a(1, 2, 3), (*iter)(2, 3));
     }
 
-    TEST(xaxis_iterator, axis_0)
+    TEST_CASE_TEMPLATE("xaxis_iterator.axis_0", T, ROW_TYPES)
     {
-        xarray<int> a = get_test_array();
+        T a = get_test_array<T>();
         auto iter = axis_begin(a, 0);
 
         EXPECT_EQ(a(0, 0, 0), (*iter)(0, 0));
@@ -142,9 +155,9 @@ namespace xt
         EXPECT_EQ(a(1, 2, 3), (*iter)(2, 3));
     }
 
-    TEST(xaxis_iterator, axis_1)
+    TEST_CASE_TEMPLATE("xaxis_iterator.axis_1", T, ROW_TYPES)
     {
-        xarray<int> a = get_test_array();
+        T a = get_test_array<T>();
         auto iter = axis_begin(a, 1u);
 
         EXPECT_EQ(a(0, 0, 0), (*iter)(0, 0));
@@ -175,9 +188,9 @@ namespace xt
         EXPECT_EQ(a(1, 2, 3), (*iter)(1, 3));
     }
 
-    TEST(xaxis_iterator, axis_2)
+    TEST_CASE_TEMPLATE("xaxis_iterator.axis_2", T, ROW_TYPES)
     {
-        xarray<int> a = get_test_array();
+        T a = get_test_array<T>();
         auto iter = axis_begin(a, 2u);
 
         EXPECT_EQ(a(0, 0, 0), (*iter)(0, 0));

--- a/test/test_xaxis_slice_iterator.cpp
+++ b/test/test_xaxis_slice_iterator.cpp
@@ -8,25 +8,39 @@
  ****************************************************************************/
 
 #include "xtensor/xarray.hpp"
+#include "xtensor/xfixed.hpp"
+#include "xtensor/xtensor.hpp"
 #include "xtensor/xaxis_slice_iterator.hpp"
 
 #include "test_common_macros.hpp"
 
+#define ROW_TYPES \
+    xarray<int, layout_type::row_major>, \
+    xtensor<int, 3, layout_type::row_major>, \
+    xtensor_fixed<int, xt::xshape<2, 3, 4>, layout_type::row_major>
+#define COL_TYPES \
+    xarray<int, layout_type::column_major>, \
+    xtensor<int, 3, layout_type::column_major>, \
+    xtensor_fixed<int, xt::xshape<2, 3, 4>, layout_type::column_major>
+#define ALL_TYPES ROW_TYPES, COL_TYPES
+
 namespace xt
 {
     using std::size_t;
+    constexpr auto _col = layout_type::column_major;
 
-    xarray<int> get_slice_test_array()
+    template<typename T=xarray<int>>
+    T get_slice_test_array()
     {
-        xarray<int> res = {
+        T res = {
             {{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}},
             {{13, 14, 15, 16}, {17, 18, 19, 20}, {21, 22, 23, 24}}};
         return res;
     }
 
-    TEST(xaxis_slice_iterator, begin)
+    TEST_CASE_TEMPLATE("xaxis_slice_iterator.begin", T, ALL_TYPES)
     {
-        xarray<int> a = get_slice_test_array();
+        T a = get_slice_test_array<T>();
         auto iter_begin = axis_slice_begin(a, 0);
         EXPECT_EQ(size_t(1), iter_begin->dimension());
         EXPECT_EQ(a.shape()[0], iter_begin->shape()[0]);
@@ -34,33 +48,23 @@ namespace xt
         EXPECT_EQ(a(1, 0, 0), (*iter_begin)(1));
     }
 
-    TEST(xaxis_slice_iterator, end)
+    TEST_CASE_TEMPLATE("xaxis_slice_iterator.end", T, ALL_TYPES)
     {
-        xarray<int> a = get_slice_test_array();
-        xarray<int, layout_type::column_major> a_col = get_slice_test_array();
+        T a = get_slice_test_array<T>();
 
         auto dist = std::distance(axis_slice_begin(a, 0), axis_slice_end(a, 0));
-        EXPECT_EQ(12, dist);
-
-        dist = std::distance(axis_slice_begin(a_col), axis_slice_end(a_col));
         EXPECT_EQ(12, dist);
 
         dist = std::distance(axis_slice_begin(a, 1), axis_slice_end(a, 1));
         EXPECT_EQ(8, dist);
 
-        dist = std::distance(axis_slice_begin(a_col, 1), axis_slice_end(a_col, 1));
-        EXPECT_EQ(8, dist);
-
         dist = std::distance(axis_slice_begin(a, 2), axis_slice_end(a, 2));
-        EXPECT_EQ(6, dist);
-
-        dist = std::distance(axis_slice_begin(a_col, 2), axis_slice_end(a_col, 2));
         EXPECT_EQ(6, dist);
     }
 
-    TEST(xaxis_slice_iterator, increment)
+    TEST_CASE_TEMPLATE("xaxis_slice_iterator.increment", T, ROW_TYPES)
     {
-        xarray<int, layout_type::row_major> a = get_slice_test_array();
+        T a = get_slice_test_array<T>();
         auto iter = axis_slice_begin(a, 0);
         ++iter;
 
@@ -71,9 +75,9 @@ namespace xt
         EXPECT_EQ(a(1, 0, 1), (*iter)(1));
     }
 
-    TEST(xaxis_slice_iterator, const_array)
+    TEST_CASE_TEMPLATE("xaxis_slice_iterator.const_array", T, ROW_TYPES)
     {
-        const xarray<int, layout_type::row_major> a = get_slice_test_array();
+        const T a = get_slice_test_array<T>();
         auto iter = axis_slice_begin(a, 2);
         ++iter;
 
@@ -86,9 +90,9 @@ namespace xt
         EXPECT_EQ(a(0, 1, 3), (*iter)(3));
     }
 
-    TEST(xaxis_slice_iterator, axis_0)
+    TEST_CASE_TEMPLATE("xaxis_slice_iterator.axis_0", T, ROW_TYPES)
     {
-        xarray<int, layout_type::row_major> a = get_slice_test_array();
+        T a = get_slice_test_array<T>();
         auto iter = axis_slice_begin(a, size_t(0));
 
         EXPECT_EQ(a(0, 0, 0), (*iter)(0));
@@ -128,9 +132,9 @@ namespace xt
         EXPECT_EQ(a(1, 2, 3), (*iter)(1));
     }
 
-    TEST(xaxis_slice_iterator, axis_0_col)
+    TEST_CASE_TEMPLATE("xaxis_slice_iterator.axis_0_col", T, COL_TYPES)
     {
-        xarray<int, layout_type::column_major> a = get_slice_test_array();
+       T a = get_slice_test_array<T>();
         auto iter = axis_slice_begin(a, size_t(0));
 
         EXPECT_EQ(a(0, 0, 0), (*iter)(0));
@@ -170,9 +174,9 @@ namespace xt
         EXPECT_EQ(a(1, 2, 3), (*iter)(1));
     }
 
-    TEST(xaxis_slice_iterator, axis_1)
+    TEST_CASE_TEMPLATE("xaxis_slice_iterator.axis_1", T, ROW_TYPES)
     {
-        xarray<int, layout_type::row_major> a = get_slice_test_array();
+        T a = get_slice_test_array<T>();
         auto iter = axis_slice_begin(a, size_t(1));
 
         EXPECT_EQ(a(0, 0, 0), (*iter)(0));
@@ -208,9 +212,9 @@ namespace xt
         EXPECT_EQ(a(1, 2, 3), (*iter)(2));
     }
 
-    TEST(xaxis_slice_iterator, axis_1_col)
+    TEST_CASE_TEMPLATE("xaxis_slice_iterator.axis_1_col", T, COL_TYPES)
     {
-        xarray<int, layout_type::column_major> a = get_slice_test_array();
+        T a = get_slice_test_array<T>();
         auto iter = axis_slice_begin(a, size_t(1));
 
         EXPECT_EQ(a(0, 0, 0), (*iter)(0));
@@ -246,9 +250,9 @@ namespace xt
         EXPECT_EQ(a(1, 2, 3), (*iter)(2));
     }
 
-    TEST(xaxis_slice_iterator, axis_2)
+    TEST_CASE_TEMPLATE("xaxis_slice_iterator.axis_2", T, ROW_TYPES)
     {
-        xarray<int, layout_type::row_major> a = get_slice_test_array();
+        T a = get_slice_test_array<T>();
         auto iter = axis_slice_begin(a, size_t(2));
 
         EXPECT_EQ(a(0, 0, 0), (*iter)(0));
@@ -282,9 +286,9 @@ namespace xt
         EXPECT_EQ(a(1, 2, 3), (*iter)(3));
     }
 
-    TEST(xaxis_slice_iterator, axis_2_col)
+    TEST_CASE_TEMPLATE("xaxis_slice_iterator.axis_2_col", T, COL_TYPES)
     {
-        xarray<int, layout_type::column_major> a = get_slice_test_array();
+        T a = get_slice_test_array<T>();
         auto iter = axis_slice_begin(a, size_t(2));
 
         EXPECT_EQ(a(0, 0, 0), (*iter)(0));


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Fixes #2116.

As described by @dchansen in #2723:
> This issue for both cases is that the strides_type and shape_type in axis_slice_iterator and axis_iterator are taken from the given xexpression, which is not correct for xtensor as the resulting strided_view should anyhow be dynamically sized.
> 
> The alternative would be to assign a dynamic strides and shape_type, but it was not clear to me what the correct replacement type should be.

So I changed the type of the shape and strides members in the returned views/iterators as follows:
- For `xaxis_iterator`: `std::vector<T>`, where `T` is the value type of the input expression's shape or strides type.
- For `xaxis_slice_iterator`: `std::array<T, 1>`, since the resulting view is always one-dimensional. Note that this is different from the currently returned shape and strides type in case of `xarray` input, so this breaks API/ABI for those cases. If that is not desired, this case should also use `std::vector<T>`.

For both iterators, this loses some compile-time information in certain cases. E.g.:
- For `xtensor_fixed` inputs, the resulting view could also have compile-time shape and strides, but some more metaprogramming magic would be required to correctly detect that situation and select the correct types. 
- For `xtensor` inputs, `xaxis_iterator`'s view could have fixed dimension of N-1. 

Someone else would have to look into that if that's desired. However, I think the above paragraph would be more of an optimization, and this fix at least makes the iterators on `xtensor` and `xtensor_fixed` functionally correct, in the sense that their views have the correct shape and contain the correct elements.

I also made the iterator test cases type parameterized, so the existing test cases check all of `xarray`, `xtensor`, and `xtensor_fixed` as input types.