### PR TITLE
Fixing bug in `argmin`/`argmax` called with `axis` on rank-1 container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
 
-
   linux:
 
     strategy:
@@ -85,7 +84,6 @@ jobs:
     - name: Run tests
       working-directory: build
       run: ctest -R ^xtest$ --output-on-failure
-
 
   macos:
 

--- a/include/xtensor/xsort.hpp
+++ b/include/xtensor/xsort.hpp
@@ -1173,8 +1173,16 @@ namespace xt
             {
                 auto begin = e.template begin<L>();
                 auto end = e.template end<L>();
-                std::size_t i = static_cast<std::size_t>(std::distance(begin, std::min_element(begin, end)));
-                return xtensor<size_t, 0>{i};
+                if (std::is_same<F, std::less<value_type>>::value)
+                {
+                    std::size_t i = static_cast<std::size_t>(std::distance(begin, std::min_element(begin, end)));
+                    return xtensor<size_t, 0>{i};
+                }
+                else
+                {
+                    std::size_t i = static_cast<std::size_t>(std::distance(begin, std::max_element(begin, end)));
+                    return xtensor<size_t, 0>{i};
+                }
             }
 
             result_shape_type alt_shape;

--- a/include/xtensor/xsort.hpp
+++ b/include/xtensor/xsort.hpp
@@ -1173,7 +1173,7 @@ namespace xt
             {
                 auto begin = e.template begin<L>();
                 auto end = e.template end<L>();
-                // todo C++17 : constexpr 
+                // todo C++17 : constexpr
                 if (std::is_same<F, std::less<value_type>>::value)
                 {
                     std::size_t i = static_cast<std::size_t>(std::distance(begin, std::min_element(begin, end)));

--- a/include/xtensor/xsort.hpp
+++ b/include/xtensor/xsort.hpp
@@ -1173,6 +1173,7 @@ namespace xt
             {
                 auto begin = e.template begin<L>();
                 auto end = e.template end<L>();
+                // todo C++17 : constexpr 
                 if (std::is_same<F, std::less<value_type>>::value)
                 {
                     std::size_t i = static_cast<std::size_t>(std::distance(begin, std::min_element(begin, end)));

--- a/test/test_xsort.cpp
+++ b/test/test_xsort.cpp
@@ -235,6 +235,10 @@ namespace xt
         EXPECT_EQ(ex, argmin(xa));
         EXPECT_EQ(ex_2, argmin(xa, 0));
         EXPECT_EQ(ex_3, argmin(xa, 1));
+
+        xtensor<double, 1> ya = {1, 0, 3, 2, 2};
+        EXPECT_EQ(1, argmin(ya)());
+        EXPECT_EQ(1, argmin(ya, 0)());
     }
 
     TEST(xsort, argmax)
@@ -262,6 +266,10 @@ namespace xt
 
         xtensor<std::size_t, 2> ex_6 = {{0, 0, 0, 0}, {0, 0, 0, 0}};
         EXPECT_EQ(ex_6, argmax(c, 1));
+
+        xtensor<double, 1> ya = {1, 0, 3, 2, 2};
+        EXPECT_EQ(2, argmax(ya)());
+        EXPECT_EQ(2, argmax(ya, 0)());
 
         // xtensor#2568
         xarray<double> d = {0, 1, 0};


### PR DESCRIPTION
Fixes https://github.com/xtensor-stack/xtensor/issues/2752

Todo: change to `constexpr` if C++17 support is enabled