### PR TITLE
Minor xindex_view to_array cleanup

### DIFF
--- a/include/xtensor/xindex_view.hpp
+++ b/include/xtensor/xindex_view.hpp
@@ -11,11 +11,11 @@
 #define XTENSOR_INDEX_VIEW_HPP
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
 #include <utility>
-#include <array>
 
 #include "xexpression.hpp"
 #include "xiterable.hpp"

--- a/include/xtensor/xindex_view.hpp
+++ b/include/xtensor/xindex_view.hpp
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <array>
 
 #include "xexpression.hpp"
 #include "xiterable.hpp"
@@ -791,7 +792,7 @@ namespace xt
     inline auto index_view(E&& e, const xindex (&indices)[L]) noexcept
     {
         using view_type = xindex_view<xclosure_t<E>, std::array<xindex, L>>;
-        return view_type(std::forward<E>(e), to_array(indices));
+        return view_type(std::forward<E>(e), xt::to_array(indices));
     }
 
     /**


### PR DESCRIPTION
`#include <array>` for std::array
Namespace qualify `to_array` as `xt::to_array` to avoid ambiguous overload from adl of `std::array`. Note: This could, perhaps, be `std::to_array` instead.

