### PR TITLE
Adding the ability to enable memory overlap check in assignment to avoid unneeded temporary memory allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ target_link_libraries(xtensor INTERFACE xtl)
 
 OPTION(XTENSOR_ENABLE_ASSERT "xtensor bound check" OFF)
 OPTION(XTENSOR_CHECK_DIMENSION "xtensor dimension check" OFF)
+OPTION(XTENSOR_FORCE_TEMPORARY_MEMORY_IN_ASSIGNMENTS "xtensor force the use of temporary memory when assigning instead of an automatic overlap check" ON)
 OPTION(BUILD_TESTS "xtensor test suite" OFF)
 OPTION(BUILD_BENCHMARK "xtensor benchmark" OFF)
 OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
@@ -217,6 +218,10 @@ endif()
 
 if(XTENSOR_CHECK_DIMENSION)
     add_definitions(-DXTENSOR_ENABLE_CHECK_DIMENSION)
+endif()
+
+if(XTENSOR_FORCE_TEMPORARY_MEMORY_IN_ASSIGNMENTS)
+    add_definitions(-DXTENSOR_FORCE_TEMPORARY_MEMORY_IN_ASSIGNMENTS)
 endif()
 
 if(DEFAULT_COLUMN_MAJOR)

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -118,6 +118,29 @@ namespace xt
         return linear_end(c.expression());
     }
 
+    /*************************************
+     * overlapping_memory_checker_traits *
+     *************************************/
+
+    template <class E>
+    struct overlapping_memory_checker_traits<
+        E,
+        std::enable_if_t<!has_memory_address<E>::value && is_specialization_of<xbroadcast, E>::value>>
+    {
+        static bool check_overlap(const E& expr, const memory_range& dst_range)
+        {
+            if (expr.size() == 0)
+            {
+                return false;
+            }
+            else
+            {
+                using ChildE = std::decay_t<decltype(expr.expression())>;
+                return overlapping_memory_checker_traits<ChildE>::check_overlap(expr.expression(), dst_range);
+            }
+        }
+    };
+
     /**
      * @class xbroadcast
      * @brief Broadcasted xexpression to a specified shape.

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -76,6 +76,21 @@ namespace xt
         using size_type = std::size_t;
     };
 
+    /*************************************
+     * overlapping_memory_checker_traits *
+     *************************************/
+
+    template <class E>
+    struct overlapping_memory_checker_traits<
+        E,
+        std::enable_if_t<!has_memory_address<E>::value && is_specialization_of<xgenerator, E>::value>>
+    {
+        static bool check_overlap(const E&, const memory_range&)
+        {
+            return false;
+        }
+    };
+
     /**
      * @class xgenerator
      * @brief Multidimensional function operating on indices.


### PR DESCRIPTION
Currently the default behaviour of `xsemantic_base<D>::operator=(const xexpression<E>& e)` is to create a temporary copy of `e` to avoid any problems with overlapping memory. However, if the user doesn't use some obscure strides for the containers, a check if the pointers from `begin` and `end` elements don't overlap is sufficient. Based on our benchmarks, depending on the size of the containers brings huge speedups for some use cases (up to `90%` in case of views). This is also achievable with `noalias`, but it's hard to enforce its usage and adding a compilation flag `XTENSOR_FORCE_TEMPORARY_MEMORY_IN_ASSIGNMENTS` that allows changing this behaviour is highly beneficial. 

I'm also attaching the benchmark results we obtained: 
[xtensor_assign_benchmark_results.ods](https://github.com/xtensor-stack/xtensor/files/13979881/xtensor_assign_benchmark_results.ods)


<details>
  <summary>Explanation behind benchmark names.</summary>
Benchmark was written as single templated function, so based on the template parameters in the benchmark name, the benchmarked operation looked as following, where both containers are 2d, with last number parameter being the size of single dimension:

```cpp
DstOperation(DstContainer) = SrcOperation(xtensor<..., 2>)
```
</details>