### PR TITLE
Add missing default xbuffer_adaptor

### DIFF
--- a/include/xtensor/xbuffer_adaptor.hpp
+++ b/include/xtensor/xbuffer_adaptor.hpp
@@ -111,7 +111,7 @@ namespace xt
             using size_type = typename allocator_traits::size_type;
             using difference_type = typename allocator_traits::difference_type;
 
-            xbuffer_smart_pointer();
+            xbuffer_smart_pointer() = default;
 
             template <class P, class DT>
             xbuffer_smart_pointer(P&& data_ptr, size_type size, DT&& destruct);

--- a/test/test_xbuffer_adaptor.cpp
+++ b/test/test_xbuffer_adaptor.cpp
@@ -7,6 +7,8 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
+#include <memory>
+
 #include "xtensor/xbuffer_adaptor.hpp"
 
 #include "test_common_macros.hpp"
@@ -215,5 +217,26 @@ namespace xt
         EXPECT_EQ(data[size - 1], 1.2);
 
         delete[] data;
+    }
+
+    TEST(xbuffer_adaptor, shared_owner)
+    {
+        using T = double;
+        using xbuf = xbuffer_adaptor<T, xt::smart_ownership, std::shared_ptr<T[]>>;
+        size_t size = 100;
+        auto data = std::shared_ptr<T[]>(new T[size]);
+
+        xbuf adapt(data.get(), size, data);
+        xbuf adapt2(adapt);
+        EXPECT_EQ(adapt.size(), adapt2.size());
+        EXPECT_EQ(adapt.data(), adapt2.data());
+
+        xbuf adapt3(std::move(adapt2));
+        EXPECT_EQ(adapt.size(), adapt3.size());
+        EXPECT_EQ(adapt.data(), adapt3.data());
+
+        size_t size2 = 50;
+        XT_EXPECT_THROW(adapt.resize(size2), std::runtime_error);
+        XT_EXPECT_NO_THROW(adapt.resize(size));
     }
 }


### PR DESCRIPTION
This pull request fixes the support for shared pointer by xtensor_adaptor/xbuffer_adaptor. The default constructor was declared but not implemented. A default implementation is sufficient. Also the move operators are brought 

# Checklist

- [ ] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

This small correction fix a link error when shared_ptr backing storage is used. It transforms an explicit constructor to a default constructor, otherwise the implementation is missing.

This pull request also adds unit tests for xbuffer_adaptor and xtensor_adaptor when a shared_ptr is used for backing storage. It tests the compilability and the semantic.
