### PR TITLE
Avoid warnings in compiler version checks

### DIFF
--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -1087,10 +1087,8 @@ namespace xt
         return xfunction_type(detail::lambda_adapt<F>(std::forward<F>(lambda)), std::forward<E>(args)...);
     }
 
-#define XTENSOR_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-
 // Workaround for MSVC 2015 & GCC 4.9
-#if (defined(_MSC_VER) && _MSC_VER < 1910) || (defined(__GNUC__) && GCC_VERSION < 49999)
+#if (defined(_MSC_VER) && _MSC_VER < 1910) || (defined(__GNUC__) && __GNUC__ < 5)
 #define XTENSOR_DISABLE_LAMBDA_FCT
 #endif
 
@@ -1160,7 +1158,6 @@ namespace xt
 #endif
     }
 
-#undef XTENSOR_GCC_VERSION
 #undef XTENSOR_DISABLE_LAMBDA_FCT
 
     namespace detail

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -30,7 +30,7 @@
 
 #include "xtensor_config.hpp"
 
-#if (_MSC_VER >= 1910)
+#if (defined(_MSC_VER) && _MSC_VER >= 1910)
 #define NOEXCEPT(T)
 #else
 #define NOEXCEPT(T) noexcept(T)


### PR DESCRIPTION
GCC 13 may give warnings like:

```
/home/maik/scratch/schaap/everybeam/include/xtensor/xutils.hpp:33:6: error: "_MSC_VER" is not defined, evaluates to 0 [-Werror=undef]
   33 | #if (_MSC_VER >= 1910)
      |      ^~~~~~~~
In file included from /home/maik/scratch/schaap/everybeam/include/xtensor/xcontainer.hpp:25,
                 from /home/maik/scratch/schaap/everybeam/include/xtensor/xtensor.hpp:20:
/home/maik/scratch/schaap/everybeam/include/xtensor/xmath.hpp:1077:69: error: "GCC_VERSION" is not defined, evaluates to 0 [-Werror=undef]
 1077 | #if (defined(_MSC_VER) && _MSC_VER < 1910) || (defined(__GNUC__) && GCC_VERSION < 49999)
      |                                                                     ^~~~~~~~~~~
```

This PR avoids these warnings by 
- Adding a check if _MSC_VER is defined.
- Avoiding using GCC_VERSION, since checking against __GNUC__ should suffice.