### PR TITLE
fixed typo in right_shift description

### DIFF
--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -466,9 +466,9 @@ namespace xt
 
     /**
      * @ingroup bitwise_operators
-     * @brief Bitwise left shift
+     * @brief Bitwise right shift
      *
-     * Returns an \ref xfunction for the element-wise bitwise left shift of e1
+     * Returns an \ref xfunction for the element-wise bitwise right shift of e1
      * by e2.
      * @param e1 an \ref xexpression
      * @param e2 an \ref xexpression


### PR DESCRIPTION
# Checklist

- [X] The title and commit message(s) are descriptive.
- [X] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

Fixes typo in documentation entry for `xt::right_shift` that incorrectly describes it as if referring to `xt::left_shift`.
