### PR TITLE
fix template disambiguation syntax on MSVC

### DIFF
--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -1249,7 +1249,7 @@ namespace xt
 
                         for (std::size_t i = 0; i < simd_size; ++i)
                         {
-                            res_stepper.template store_simd(fct_stepper.template step_simd<value_type>());
+                            res_stepper.template store_simd<>(fct_stepper.template step_simd<value_type>());
                         }
                         for (std::size_t i = 0; i < simd_rest; ++i)
                         {


### PR DESCRIPTION
MSCV currently emits a syntax error on line (TBB with SIMD branch) https://github.com/xtensor-stack/xtensor/blob/8c0a484f04eccd0dbc0e25eb58a97de000fb048b/include/xtensor/xassign.hpp#L1252

Adds a simple syntax helper for MSVC (not sure what the standard says here). 

```cpp
res_stepper.template store_simd<>(fct_stepper.template step_simd<value_type>()); 
```

FIXES #2736 (note that compiling with /Zc:lambda on MSVC is currently required to avoid this compiler bug https://developercommunity.visualstudio.com/t/lambda-fails-to-implicitly-capture-constexpr-value/610504 )