### PR TITLE
Add a bounds check and negative slice support to strided view fill_args

### DIFF
--- a/include/xtensor/xstrided_view_base.hpp
+++ b/include/xtensor/xstrided_view_base.hpp
@@ -903,6 +903,11 @@ namespace xt
                     if (ptr != nullptr)
                     {
                         auto slice0 = static_cast<old_strides_value_type>(*ptr);
+            	        if (slice0 < 0) slice0 += shape[i_ax];
+            	        if (slice0 < 0 || slice0 >= shape[i_ax])
+                        {
+                            XTENSOR_THROW(std::runtime_error, "Slice index out of range.");
+                        }
                         new_offset += static_cast<std::size_t>(slice0 * old_strides[i_ax]);
                     }
                     else if (xtl::get_if<xt::xnewaxis_tag>(&slices[i]) != nullptr)


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

Currently, when slicing a strided view, it may slice outside of the bounds unnoticed. 
Ranges already support both negative indices (same as here) as well as bounds checks (clamped).

The behavior in this PR mimics NumPy behavior for negative and out of bounds index access.
