### PR TITLE
Fix compile issue with clang 19.1.1

### DIFF
--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -1174,7 +1174,7 @@ namespace xt
 
                 for (std::size_t i = 0; i < simd_size; ++i)
                 {
-                    res_stepper.template store_simd(fct_stepper.template step_simd<value_type>());
+                    res_stepper.store_simd(fct_stepper.template step_simd<value_type>());
                 }
                 for (std::size_t i = 0; i < simd_rest; ++i)
                 {
@@ -1249,7 +1249,7 @@ namespace xt
 
                         for (std::size_t i = 0; i < simd_size; ++i)
                         {
-                            res_stepper.template store_simd(fct_stepper.template step_simd<value_type>());
+                            res_stepper.store_simd(fct_stepper.template step_simd<value_type>());
                         }
                         for (std::size_t i = 0; i < simd_rest; ++i)
                         {


### PR DESCRIPTION
# Checklist

- [x ] The title and commit message(s) are descriptive.
- [ x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

Parallel assigner branches had a probably outdated use of the simd  stepper template.
