### PR TITLE
Introducing xtensor Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Doxygen -> gh-pages](https://github.com/xtensor-stack/xtensor/workflows/gh-pages/badge.svg)](https://xtensor-stack.github.io/xtensor)
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/xtensor-stack/xtensor/stable?filepath=notebooks%2Fxtensor.ipynb)
 [![Join the Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/QuantStack/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20xtensor%20Guru-006BFF)](https://gurubase.io/g/xtensor)
 
 Multi-dimensional arrays with broadcasting and lazy computing.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [xtensor Guru](https://gurubase.io/g/xtensor) to Gurubase. xtensor Guru uses the data from this repo and data from the [docs](http://xtensor.readthedocs.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "xtensor Guru", which highlights that xtensor now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable xtensor Guru in Gurubase, just let me know that's totally fine.
