### PR TITLE
Disable spurious gcc warning in `xfunction::broadcast_shape`

### DIFF
--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -397,7 +397,7 @@ namespace xt
 
         tuple_type m_e;
         functor_type m_f;
-        mutable xfunction_cache<detail::promote_index<typename std::decay_t<CT>::shape_type...>> m_cache;
+        mutable xfunction_cache<detail::promote_index<typename std::decay_t<CT>::shape_type...>> m_cache{};
 
         friend class xfunction_iterator<F, CT...>;
         friend class xfunction_stepper<F, CT...>;
@@ -721,7 +721,13 @@ namespace xt
     {
         if (m_cache.is_initialized && reuse_cache)
         {
+            // Disable spurious warning when copying into a 1-sized `std::array`
+            // in gcc >= 12.4.0; see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107852
+            #pragma GCC diagnostic push
+            #pragma GCC diagnostic ignored "-Warray-bounds"
+            #pragma GCC diagnostic ignored "-Wstringop-overflow"
             std::copy(m_cache.shape.cbegin(), m_cache.shape.cend(), shape.begin());
+            #pragma GCC diagnostic pop
             return m_cache.is_trivial;
         }
         else


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Recent versions of gcc emit an incorrect `array-bounds` warning when copying the cached shape into the passed `input`, if the latter is of type `std::array<size_t, 1>`.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107852
