### PR TITLE
Enabling rich display for xeus-cpp-lite

### DIFF
--- a/include/xtensor/io/xio.hpp
+++ b/include/xtensor/io/xio.hpp
@@ -827,6 +827,6 @@ namespace xt
 
 // Backward compatibility: include xmime.hpp in xio.hpp by default.
 
-#ifdef __CLING__
+#if defined(__CLING__) || defined(__CLANG_REPL__)
 #include "xmime.hpp"
 #endif


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here.
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->

While trying xcpp::display with xeus-cpp-lite, I see this 

![image](https://github.com/user-attachments/assets/d5a7f062-a571-413c-93f9-0b2c5e78c2f4)
