### PR TITLE
Add braces around initializers.

### DIFF
--- a/include/xtensor/misc/xmanipulation.hpp
+++ b/include/xtensor/misc/xmanipulation.hpp
@@ -611,7 +611,7 @@ namespace xt
     template <class E, class Tag = check_policy::none>
     inline auto squeeze(E&& e, std::size_t axis, Tag check_policy = Tag())
     {
-        return squeeze(std::forward<E>(e), std::array<std::size_t, 1>{axis}, check_policy);
+        return squeeze(std::forward<E>(e), std::array<std::size_t, 1>{{axis}}, check_policy);
     }
 
     /// @endcond

--- a/include/xtensor/views/xslice.hpp
+++ b/include/xtensor/views/xslice.hpp
@@ -761,7 +761,7 @@ namespace xt
         }
 
         XTENSOR_GLOBAL_CONSTEXPR xtuph _{};
-        XTENSOR_GLOBAL_CONSTEXPR rangemaker<> _r = rangemaker<>({0, 0, 0});
+        XTENSOR_GLOBAL_CONSTEXPR rangemaker<> _r = rangemaker<>({{0, 0, 0}});
         XTENSOR_GLOBAL_CONSTEXPR xall_tag _a{};
         XTENSOR_GLOBAL_CONSTEXPR xnewaxis_tag _n{};
         XTENSOR_GLOBAL_CONSTEXPR xellipsis_tag _e{};


### PR DESCRIPTION
GCC 13.3 requires an additional layer of braces around brace-initializers for certain types. We've seen this in other projects before, and the addition of the additional layer of braces has always been fine with all other compilers.