### PR TITLE
Remove deprecated constexpr definitions

### DIFF
--- a/include/xtensor/containers/xfixed.hpp
+++ b/include/xtensor/containers/xfixed.hpp
@@ -381,21 +381,6 @@ namespace xt
         friend class xcontainer<xfixed_container<ET, S, L, SH, Tag>>;
     };
 
-#ifdef XTENSOR_HAS_CONSTEXPR_ENHANCED
-    // Out of line definitions to prevent linker errors prior to C++17
-    template <class ET, class S, layout_type L, bool SH, class Tag>
-    constexpr
-        typename xfixed_container<ET, S, L, SH, Tag>::inner_shape_type xfixed_container<ET, S, L, SH, Tag>::m_shape;
-
-    template <class ET, class S, layout_type L, bool SH, class Tag>
-    constexpr
-        typename xfixed_container<ET, S, L, SH, Tag>::inner_strides_type xfixed_container<ET, S, L, SH, Tag>::m_strides;
-
-    template <class ET, class S, layout_type L, bool SH, class Tag>
-    constexpr typename xfixed_container<ET, S, L, SH, Tag>::inner_backstrides_type
-        xfixed_container<ET, S, L, SH, Tag>::m_backstrides;
-#endif
-
     /****************************************
      * xfixed_container_adaptor declaration *
      ****************************************/
@@ -517,21 +502,6 @@ namespace xt
 
         friend class xcontainer<xfixed_adaptor<EC, S, L, SH, Tag>>;
     };
-
-#ifdef XTENSOR_HAS_CONSTEXPR_ENHANCED
-    // Out of line definitions to prevent linker errors prior to C++17
-    template <class EC, class S, layout_type L, bool SH, class Tag>
-    constexpr
-        typename xfixed_adaptor<EC, S, L, SH, Tag>::inner_shape_type xfixed_adaptor<EC, S, L, SH, Tag>::m_shape;
-
-    template <class EC, class S, layout_type L, bool SH, class Tag>
-    constexpr
-        typename xfixed_adaptor<EC, S, L, SH, Tag>::inner_strides_type xfixed_adaptor<EC, S, L, SH, Tag>::m_strides;
-
-    template <class EC, class S, layout_type L, bool SH, class Tag>
-    constexpr typename xfixed_adaptor<EC, S, L, SH, Tag>::inner_backstrides_type
-        xfixed_adaptor<EC, S, L, SH, Tag>::m_backstrides;
-#endif
 
     /************************************
      * xfixed_container implementation *

--- a/include/xtensor/containers/xstorage.hpp
+++ b/include/xtensor/containers/xstorage.hpp
@@ -1731,11 +1731,6 @@ namespace xt
         XTENSOR_CONSTEXPR_ENHANCED_STATIC cast_type m_array = cast_type({X...});
     };
 
-#ifdef XTENSOR_HAS_CONSTEXPR_ENHANCED
-    template <std::size_t... X>
-    constexpr typename fixed_shape<X...>::cast_type fixed_shape<X...>::m_array;
-#endif
-
 #undef XTENSOR_FIXED_SHAPE_CONSTEXPR
 
     template <class E, std::ptrdiff_t Start, std::ptrdiff_t End = -1>

--- a/include/xtensor/core/xfunction.hpp
+++ b/include/xtensor/core/xfunction.hpp
@@ -67,18 +67,6 @@ namespace xt
             XTENSOR_CONSTEXPR_ENHANCED_STATIC bool is_initialized = true;
         };
 
-#ifdef XTENSOR_HAS_CONSTEXPR_ENHANCED
-        // Out of line definitions to prevent linker errors prior to C++17
-        template <std::size_t... N, class is_shape_trivial>
-        constexpr fixed_shape<N...> xfunction_cache_impl<fixed_shape<N...>, is_shape_trivial>::shape;
-
-        template <std::size_t... N, class is_shape_trivial>
-        constexpr bool xfunction_cache_impl<fixed_shape<N...>, is_shape_trivial>::is_trivial;
-
-        template <std::size_t... N, class is_shape_trivial>
-        constexpr bool xfunction_cache_impl<fixed_shape<N...>, is_shape_trivial>::is_initialized;
-#endif
-
         template <class... CT>
         struct xfunction_bool_load_type
         {


### PR DESCRIPTION
# Checklist

- [X] The title and commit message(s) are descriptive.
- [X] Small commits made to fix your PR have been squashed to avoid history pollution.
- [X] Tests have been added for new features or bug fixes.
- [X] API of new functions and classes are documented.

# Description

C++17 compiler is required now, so these lines are unnecessary.