### PR TITLE
added a mapper that maps the indexes of a view to the indices of a container

### DIFF
--- a/include/xtensor/views/index_mapper.hpp
+++ b/include/xtensor/views/index_mapper.hpp
@@ -19,6 +19,16 @@ namespace xt
     struct index_mapper;
 
     /**
+     * @enum access_t
+     * @brief Defines the access policy for the underlying container.
+     */
+    enum class access_t
+    {
+        SAFE,   ///< Use .at() accessor (bounds checked).
+        UNSAFE  ///< Use operator() accessor (no bounds checking).
+    };
+
+    /**
      * @class index_mapper
      * @brief A helper class for mapping indices between views and their underlying containers.
      *
@@ -45,6 +55,17 @@ namespace xt
     template <class UnderlyingContainer, class... Slices>
     class index_mapper<xt::xview<UnderlyingContainer, Slices...>>
     {
+    public:
+
+        /// @brief The view type this mapper works with
+        using view_type = xt::xview<UnderlyingContainer, Slices...>;
+
+        /// @brief Reference type of the underlying view.
+        using reference = typename xt::xview<UnderlyingContainer, Slices...>::reference;
+
+        /// @brief Const reference type of the underlying view.
+        using const_reference = typename xt::xview<UnderlyingContainer, Slices...>::const_reference;
+
         /// @brief Total number of explicitly passed slices in the view
         static constexpr size_t n_slices = sizeof...(Slices);
 
@@ -52,38 +73,77 @@ namespace xt
         static constexpr size_t nb_integral_slices = (std::is_integral_v<Slices> + ...);
 
         /// @brief Number of slices that are xt::newaxis (insert a  dimension)
-        static constexpr size_t nb_new_axis_slices = (xt::detail::is_newaxis<Slices>::value + ...);
+        static constexpr size_t nb_new_axis_slices = (xt::detail::is_newaxis_v<Slices> + ...);
 
         /**
          * Compute how many indices are needed to address the underlying container
          * when given N indices in the view.
          */
         template <std::integral... Indices>
-        static constexpr size_t n_indices_full_v = size_t(
-            sizeof...(Indices) + nb_integral_slices - nb_new_axis_slices
-        );
+        static constexpr size_t n_indices_full_v = size_t(sizeof...(Indices) + nb_integral_slices);
 
-    public:
+        /**
+         * @brief Map view indices to container reference using UNSAFE access.
+         * @param container The source container.
+         * @param view The view defining the mapping.
+         * @param indices The indices in view-space.
+         * @return Reference to the element in the container.
+         */
+        template <std::integral... Indices>
+        reference map(UnderlyingContainer& container, const view_type& view, const Indices... indices) const;
 
-        /// @brief The view type this mapper works with
-        using view_type = xt::xview<UnderlyingContainer, Slices...>;
+        /**
+         * @brief Map view indices to container const_reference using UNSAFE access.
+         * @param container The source container.
+         * @param view The view defining the mapping.
+         * @param indices The indices in view-space.
+         * @return Reference to the element in the container.
+         */
+        template <std::integral... Indices>
+        const_reference
+        cmap(const UnderlyingContainer& container, const view_type& view, const Indices... indices) const;
 
-        ///<  @brief Value type of the underlying container
-        using value_type = typename xt::xview<UnderlyingContainer, Slices...>::value_type;
+        /**
+         * @brief Map view indices to container reference using SAFE access.
+         * @param container The source container.
+         * @param view The view defining the mapping.
+         * @param indices The indices in view-space.
+         * @return Reference to the element in the container.
+         */
+        template <std::integral... Indices>
+        reference map_at(UnderlyingContainer& container, const view_type& view, const Indices... indices) const;
+
+        /**
+         * @brief Map view indices to container const_reference using SAFE access.
+         * @param container The source container.
+         * @param view The view defining the mapping.
+         * @param indices The indices in view-space.
+         * @return Reference to the element in the container.
+         */
+        template <std::integral... Indices>
+        const_reference
+        cmap_at(const UnderlyingContainer& container, const view_type& view, const Indices... indices) const;
+
+        /// @brief Return the dimensionality of the view
+        size_t dimension(const UnderlyingContainer& container) const;
 
     private:
 
+        /// @brief Alias for selecting reference type based on const-correctness.
+        template <bool IS_CONST>
+        using conditional_reference = std::conditional_t<IS_CONST, const_reference, reference>;
+
         /// @brief Helper type alias for the I-th slice type
         template <size_t I>
-        using ith_slice_type = std::tuple_element_t<I, std::tuple<Slices...>>;
+        using slice_type = std::tuple_element_t<I, std::tuple<Slices...>>;
 
         /// @brief True if the I-th slice is an integral slice (fixed index)
         template <size_t I>
-        static consteval bool is_ith_slice_integral();
+        static consteval bool is_slice_integral();
 
         /// @brief True if the I-th slice is a newaxis slice
         template <size_t I>
-        static consteval bool is_ith_slice_new_axis();
+        static consteval bool is_slice_new_axis();
 
         /**
          * Helper metafunction to build an index_sequence that skips
@@ -96,25 +156,25 @@ namespace xt
         struct indices_sequence_helper
         {
             // we add the current axis
-            using not_new_axis_type = typename indices_sequence_helper<first + 1, bound, indices..., first>::Type;
+            using not_new_axis_type = typename indices_sequence_helper<first + 1, bound, indices..., first>::type;
 
             // we skip the current axis
-            using new_axis_type = typename indices_sequence_helper<first + 1, bound, indices...>::Type;
+            using new_axis_type = typename indices_sequence_helper<first + 1, bound, indices...>::type;
 
-            // NOTE: is_ith_slice_new_axis works even if first >= sizeof...(Slices)
-            using Type = std::conditional_t<is_ith_slice_new_axis<first>(), new_axis_type, not_new_axis_type>;
+            // NOTE: is_slice_new_axis works even if first >= sizeof...(Slices)
+            using type = std::conditional_t<is_slice_new_axis<first>(), new_axis_type, not_new_axis_type>;
         };
 
         /// @brief Base case: recursion termination
         template <size_t bound, size_t... indices>
         struct indices_sequence_helper<bound, bound, indices...>
         {
-            using Type = std::index_sequence<indices...>;
+            using type = std::index_sequence<indices...>;
         };
 
         ///<  @brief Index sequence of non-newaxis slices
         template <size_t bound>
-        using indices_sequence = indices_sequence_helper<0, bound>::Type;
+        using indices_sequence = indices_sequence_helper<0, bound>::type;
 
         /**
          * @brief Maps an index for a specific slice to the corresponding index in the underlying container.
@@ -135,90 +195,73 @@ namespace xt
         size_t map_ith_index(const view_type& view, const Index i) const;
 
         /**
-         * @brief Maps all indices and accesses the container.
+         * @brief Main recursion/logic handler for mapping operations.
+         * Handles dimension dropping if the provided index count exceeds view dimensionality.
          *
-         * @tparam Is Index sequence for parameter pack expansion.
-         * @param container The underlying container to access.
-         * @param view The view providing slice information.
-         * @param indices Array of indices for all slices.
-         * @return value_type The value at the mapped location in the container.
+         * @tparam IS_CONST Boolean flag; true if the operation is on a const container.
+         * @tparam ACCESS The access policy (SAFE for .at(), UNSAFE for operator()).
+         * @param is_const Tag used for compile-time dispatching of const-correctness.
+         * @param container The underlying container (xarray, xtensor, etc.) being accessed.
+         * @param access Tag used for compile-time dispatching of the access method.
+         * @param view The xview instance that defines the coordinate transformation.
+         * @param firstIndice The current leading index in the coordinate pack.
+         * @param otherIndices The remaining indices in the coordinate pack.
          */
-        template <size_t n_indices, size_t... Is>
-        value_type map_all_indices(
-            const UnderlyingContainer& container,
+        template <bool IS_CONST, access_t ACCESS, std::integral FirstIndice, std::integral... OtherIndices>
+        conditional_reference<IS_CONST> map_main(
+            std::bool_constant<IS_CONST> /* is_const */,
+            std::conditional_t<IS_CONST, const UnderlyingContainer&, UnderlyingContainer&> container,
+            std::integral_constant<access_t, ACCESS> /* access */,
             const view_type& view,
-            std::index_sequence<Is...>,
-            const std::array<size_t, n_indices>& indices
+            const FirstIndice firstIndice,
+            const OtherIndices... otherIndices
         ) const;
 
         /**
-         * @brief Maps all indices and accesses the container with bounds checking.
+         * @brief Base case for map_main recursion, where no indices is supplied and assumes (0, 0, ...).
          *
-         * Same as `map_all_indices` but uses `container.at()` which performs bounds checking.
-         *
-         * @tparam Is Index sequence for parameter pack expansion.
-         * @param container The underlying container to access.
-         * @param view The view providing slice information.
-         * @param indices Array of indices for all slices.
-         * @return value_type The value at the mapped location in the container.
-         *
-         * @throws std::out_of_range if any index is out of bounds.
+         * @tparam IS_CONST Boolean flag; true if the operation is on a const container.
+         * @tparam ACCESS The access policy (SAFE for .at(), UNSAFE for operator()).
+         * @param is_const Tag used for compile-time dispatching of const-correctness.
+         * @param container The underlying container (xarray, xtensor, etc.) being accessed.
+         * @param access Tag used for compile-time dispatching of the access method.
+         * @param view The xview instance that defines the coordinate transformation.
          */
-        template <size_t n_indices, size_t... Is>
-        value_type map_at_all_indices(
-            const UnderlyingContainer& container,
+        template <bool IS_CONST, access_t ACCESS>
+        conditional_reference<IS_CONST> map_main(
+            std::bool_constant<IS_CONST> /* is_const */,
+            std::conditional_t<IS_CONST, const UnderlyingContainer&, UnderlyingContainer&> container,
+            std::integral_constant<access_t, ACCESS> /* access */,
+            const view_type& view
+        ) const;
+
+        /**
+         * @brief Maps all indices and accesses the container.
+         *
+         * @tparam IS_CONST Boolean flag for const-correctness.
+         * @tparam ACCESS The access policy (SAFE or UNSAFE).
+         * @tparam n_indices The size of the index array (calculated from view/container info).
+         * @tparam Is A pack of indices `0, 1, ..., n-1` used to unroll the mapping loop.
+         * @param is_const Tag for const-correctness dispatch.
+         * @param container The underlying container being accessed.
+         * @param access Tag for access method dispatch.
+         * @param view The xview instance providing the slice transformations.
+         * @param is_seq An index sequence used to drive the parameter pack expansion.
+         * @param indices An array containing the view-space indices to be mapped.
+         */
+        template <bool IS_CONST, access_t ACCESS, size_t n_indices, size_t... Is>
+        conditional_reference<IS_CONST> map_all_indices(
+            std::bool_constant<IS_CONST> /* is_const */,
+            std::conditional_t<IS_CONST, const UnderlyingContainer&, UnderlyingContainer&> container,
+            std::integral_constant<access_t, ACCESS> /* access */,
             const view_type& view,
-            std::index_sequence<Is...>,
+            std::index_sequence<Is...> /* is_seq */,
             const std::array<size_t, n_indices>& indices
         ) const;
 
         /// @brief Expand view indices into a full index array, inserting dummy indices for integral slices
         template <std::integral... Indices>
         std::array<size_t, n_indices_full_v<Indices...>> get_indices_full(const Indices... indices) const;
-
-    public:
-
-        /**
-         * @brief Maps view indices to container indices and returns the value.
-         *
-         * Converts the provided indices (for the free dimensions of the view) to
-         * the corresponding indices in the underlying container and returns the value.
-         *
-         * @tparam Indices Types of the indices (must be integral).
-         * @param container The underlying container to access.
-         * @param view The view providing slice information.
-         * @param indices The indices for the free dimensions of the view.
-         * @return value_type The value at the mapped location in the container.
-         *
-         * @example
-         * @code
-         * // For view(a, 1, all(), all()):
-         * mapper.map(a, view, i, j);  // Maps to a(1, i, j)
-         * @endcode
-         */
-        template <std::integral... Indices>
-        value_type
-        map(const UnderlyingContainer& container, const view_type& view, const Indices... indices) const;
-
-        /**
-         * @brief Maps view indices to container indices with bounds checking.
-         *
-         * Same as `map()` but uses bounds-checked access via `container.at()`.
-         *
-         * @tparam Indices Types of the indices (must be integral).
-         * @param container The underlying container to access.
-         * @param view The view providing slice information.
-         * @param indices The indices for the free dimensions of the view.
-         * @return value_type The value at the mapped location in the container.
-         *
-         * @throws std::out_of_range if any mapped index is out of bounds.
-         */
-        template <std::integral... Indices>
-        value_type
-        map_at(const UnderlyingContainer& container, const view_type& view, const Indices... indices) const;
-
-        /// @brief Return the dimensionality of the view
-        size_t dimension(const UnderlyingContainer& container) const;
     };
 
     /*******************************
@@ -227,11 +270,11 @@ namespace xt
 
     template <class UnderlyingContainer, class... Slices>
     template <size_t I>
-    consteval bool index_mapper<xt::xview<UnderlyingContainer, Slices...>>::is_ith_slice_integral()
+    consteval bool index_mapper<xt::xview<UnderlyingContainer, Slices...>>::is_slice_integral()
     {
         if constexpr (I < sizeof...(Slices))
         {
-            return std::is_integral_v<ith_slice_type<I>>;
+            return std::is_integral_v<slice_type<I>>;
         }
         else
         {
@@ -241,11 +284,11 @@ namespace xt
 
     template <class UnderlyingContainer, class... Slices>
     template <size_t I>
-    consteval bool index_mapper<xt::xview<UnderlyingContainer, Slices...>>::is_ith_slice_new_axis()
+    consteval bool index_mapper<xt::xview<UnderlyingContainer, Slices...>>::is_slice_new_axis()
     {
         if constexpr (I < sizeof...(Slices))
         {
-            return xt::detail::is_newaxis<ith_slice_type<I>>::value;
+            return xt::detail::is_newaxis_v<slice_type<I>>;
         }
         else
         {
@@ -268,7 +311,7 @@ namespace xt
         {
             auto it = std::cbegin(args);
 
-            ((args_full[Is] = (is_ith_slice_integral<Is>()) ? size_t(0) : *it++), ...);
+            ((args_full[Is] = (is_slice_integral<Is>()) ? size_t(0) : *it++), ...);
         };
 
         fill_args_full(std::make_index_sequence<n_indices_full>{});
@@ -279,51 +322,175 @@ namespace xt
     template <class UnderlyingContainer, class... Slices>
     template <std::integral... Indices>
     auto index_mapper<xt::xview<UnderlyingContainer, Slices...>>::map(
+        UnderlyingContainer& container,
+        const view_type& view,
+        const Indices... indices
+    ) const -> reference
+    {
+        return map_main(
+            std::false_type{},
+            container,
+            std::integral_constant<access_t, access_t::UNSAFE>{},
+            view,
+            indices...
+        );
+    }
+
+    template <class UnderlyingContainer, class... Slices>
+    template <std::integral... Indices>
+    auto index_mapper<xt::xview<UnderlyingContainer, Slices...>>::cmap(
         const UnderlyingContainer& container,
         const view_type& view,
         const Indices... indices
-    ) const -> value_type
+    ) const -> const_reference
     {
-        constexpr size_t n_indices_full = n_indices_full_v<Indices...>;
-
-        return map_all_indices(container, view, indices_sequence<n_indices_full>{}, get_indices_full(indices...));
+        return map_main(
+            std::true_type{},
+            container,
+            std::integral_constant<access_t, access_t::UNSAFE>{},
+            view,
+            indices...
+        );
     }
 
     template <class UnderlyingContainer, class... Slices>
     template <std::integral... Indices>
     auto index_mapper<xt::xview<UnderlyingContainer, Slices...>>::map_at(
+        UnderlyingContainer& container,
+        const view_type& view,
+        const Indices... indices
+    ) const -> reference
+    {
+        return map_main(
+            std::false_type{},
+            container,
+            std::integral_constant<access_t, access_t::SAFE>{},
+            view,
+            indices...
+        );
+    }
+
+    template <class UnderlyingContainer, class... Slices>
+    template <std::integral... Indices>
+    auto index_mapper<xt::xview<UnderlyingContainer, Slices...>>::cmap_at(
         const UnderlyingContainer& container,
         const view_type& view,
         const Indices... indices
-    ) const -> value_type
+    ) const -> const_reference
     {
-        constexpr size_t n_indices_full = n_indices_full_v<Indices...>;
-
-        return map_at_all_indices(container, view, indices_sequence<n_indices_full>{}, get_indices_full(indices...));
+        return map_main(
+            std::true_type{},
+            container,
+            std::integral_constant<access_t, access_t::SAFE>{},
+            view,
+            indices...
+        );
     }
 
     template <class UnderlyingContainer, class... Slices>
-    template <size_t n_indices, size_t... Is>
+    template <bool IS_CONST, access_t ACCESS, std::integral FirstIndice, std::integral... OtherIndices>
+    auto index_mapper<xt::xview<UnderlyingContainer, Slices...>>::map_main(
+        std::bool_constant<IS_CONST> is_const,
+        std::conditional_t<IS_CONST, const UnderlyingContainer&, UnderlyingContainer&> container,
+        std::integral_constant<access_t, ACCESS> access,
+        const view_type& view,
+        const FirstIndice firstIndice,
+        const OtherIndices... otherIndices
+    ) const -> conditional_reference<IS_CONST>
+    {
+        constexpr size_t n_indices_full = n_indices_full_v<FirstIndice, OtherIndices...>;
+
+        constexpr size_t underlying_n_dimensions = xt::static_dimension<
+            typename std::decay_t<UnderlyingContainer>::shape_type>::value;
+
+        // If there is too many indices, we need to drop the first ones.
+        // If the number of dimensions of the underlying container is known at compile time we can drop them
+        // at compile time Else a runtime-test is requires, which, breaks vectorization.
+        // I don't know if we can do it in another way.
+
+        if constexpr (underlying_n_dimensions != size_t(-1))
+        {
+            // the number of dimensions of the underlying container is known at compile time.
+            constexpr size_t n_dimensions = underlying_n_dimensions - nb_integral_slices + nb_new_axis_slices;
+
+            // we can perform compile time checks
+            if constexpr (1 + sizeof...(OtherIndices) > n_dimensions)
+            {
+                return map_main(is_const, container, access, view, otherIndices...);
+            }
+            else
+            {
+                return map_all_indices(
+                    is_const,
+                    container,
+                    access,
+                    view,
+                    indices_sequence<n_indices_full>{},
+                    get_indices_full(firstIndice, otherIndices...)
+                );
+            }
+        }
+        else
+        {
+            // we need execution time checks
+            if (1 + sizeof...(OtherIndices) > dimension(container))
+            {
+                return map_main(is_const, container, access, view, otherIndices...);
+            }
+            else
+            {
+                return map_all_indices(
+                    is_const,
+                    container,
+                    access,
+                    view,
+                    indices_sequence<n_indices_full>{},
+                    get_indices_full(firstIndice, otherIndices...)
+                );
+            }
+        }
+    }
+
+    template <class UnderlyingContainer, class... Slices>
+    template <bool IS_CONST, access_t ACCESS>
+    auto index_mapper<xt::xview<UnderlyingContainer, Slices...>>::map_main(
+        std::bool_constant<IS_CONST> is_const,
+        std::conditional_t<IS_CONST, const UnderlyingContainer&, UnderlyingContainer&> container,
+        std::integral_constant<access_t, ACCESS> access,
+        const view_type& view
+    ) const -> conditional_reference<IS_CONST>
+    {
+        constexpr size_t n_indices_full = n_indices_full_v<>;
+
+        return map_all_indices(
+            is_const,
+            container,
+            access,
+            view,
+            indices_sequence<n_indices_full>{},
+            get_indices_full()
+        );
+    }
+
+    template <class UnderlyingContainer, class... Slices>
+    template <bool IS_CONST, access_t ACCESS, size_t n_indices, size_t... Is>
     auto index_mapper<xt::xview<UnderlyingContainer, Slices...>>::map_all_indices(
-        const UnderlyingContainer& container,
+        std::bool_constant<IS_CONST> /* is_const */,
+        std::conditional_t<IS_CONST, const UnderlyingContainer&, UnderlyingContainer&> container,
+        std::integral_constant<access_t, ACCESS> /* access */,
         const view_type& view,
-        std::index_sequence<Is...>,
+        std::index_sequence<Is...> /* is_seq */,
         const std::array<size_t, n_indices>& indices
-    ) const -> value_type
+    ) const -> conditional_reference<IS_CONST>
     {
-        return container(map_ith_index<Is>(view, indices[Is])...);
-    }
-
-    template <class UnderlyingContainer, class... Slices>
-    template <size_t n_indices, size_t... Is>
-    auto index_mapper<xt::xview<UnderlyingContainer, Slices...>>::map_at_all_indices(
-        const UnderlyingContainer& container,
-        const view_type& view,
-        std::index_sequence<Is...>,
-        const std::array<size_t, n_indices>& indices
-    ) const -> value_type
-    {
-        return container.at(map_ith_index<Is>(view, indices[Is])...);
+        if constexpr (ACCESS == access_t::SAFE)
+        {
+            return container.at(map_ith_index<Is>(view, indices[Is])...);
+        }
+        else
+        {
+            return container(map_ith_index<Is>(view, indices[Is])...);
+        }
     }
 
     template <class UnderlyingContainer, class... Slices>
@@ -337,7 +504,7 @@ namespace xt
             // if the slice is explicitly specified, use it
             using current_slice = std::tuple_element_t<I, std::tuple<Slices...>>;
 
-            static_assert(not xt::detail::is_newaxis<current_slice>::value);
+            static_assert(not xt::detail::is_newaxis_v<current_slice>);
 
             const auto& slice = std::get<I>(view.slices());
 

--- a/include/xtensor/views/xview_utils.hpp
+++ b/include/xtensor/views/xview_utils.hpp
@@ -149,6 +149,9 @@ namespace xt
         {
         };
 
+        template <class T>
+        constexpr bool is_newaxis_v = is_newaxis<T>::value;
+
         template <class T, class... S>
         struct newaxis_count_impl
         {

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -360,6 +360,16 @@ namespace xt
         EXPECT_EQ(a(1, 1, 0), mapper1.map(a, view1, 1, 0));
         EXPECT_EQ(a(1, 1, 1), mapper1.map(a, view1, 1, 1));
         XT_EXPECT_ANY_THROW(mapper1.map_at(a, view1, 10, 10));
+
+        auto view2 = view(a, 1);
+        index_mapper<decltype(view2)> mapper2;
+
+        EXPECT_EQ(size_t(2), mapper2.dimension(a));
+        EXPECT_EQ(a(1, 0, 0), mapper2.map(a, view2, 0, 0));
+        EXPECT_EQ(a(1, 0, 1), mapper2.map(a, view2, 0, 1));
+        EXPECT_EQ(a(1, 1, 0), mapper2.map(a, view2, 1, 0));
+        EXPECT_EQ(a(1, 1, 1), mapper2.map(a, view2, 1, 1));
+        XT_EXPECT_ANY_THROW(mapper2.map_at(a, view2, 10, 10));
     }
 
     TEST(xview, integral_count)
@@ -424,6 +434,32 @@ namespace xt
         // EXPECT_EQ(v3(1), arr(0, 2));
         EXPECT_EQ(v3(1, 1), arr(1, 2));
         EXPECT_EQ(v3(2, 3, 1, 1), arr(1, 2));
+    }
+
+    TEST(xview_mapping, access)
+    {
+        xt::xarray<double> arr{{1.0, 2.0, 3.0}, {2.0, 5.0, 7.0}, {2.0, 5.0, 7.0}};
+
+        auto v1 = xt::view(arr, 1, xt::range(1, 3));
+        index_mapper<decltype(v1)> mapper1;
+
+        EXPECT_EQ(mapper1.map(arr, v1), arr(0, 1));
+        EXPECT_EQ(mapper1.map(arr, v1, 1), arr(1, 2));
+        EXPECT_EQ(mapper1.map(arr, v1, 1, 1), arr(1, 2));
+
+        auto v2 = xt::view(arr, all(), newaxis(), all());
+        index_mapper<decltype(v2)> mapper2;
+
+        // EXPECT_EQ(v2(1), arr(0, 1));
+        EXPECT_EQ(mapper2.map(arr, v2, 1, 0, 2), arr(1, 2));
+        EXPECT_EQ(mapper2.map(arr, v2, 2, 1, 0, 2), arr(1, 2));
+
+        auto v3 = xt::view(arr, xt::range(0, 2), xt::range(1, 3));
+        index_mapper<decltype(v3)> mapper3;
+
+        // EXPECT_EQ(v3(1), arr(0, 2));
+        EXPECT_EQ(mapper3.map(arr, v3, 1, 1), arr(1, 2));
+        EXPECT_EQ(mapper3.map(arr, v3, 2, 3, 1, 1), arr(1, 2));
     }
 
     TEST(xview, unchecked)


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

The `index_mapper` class provides functionality to convert indices from a view's coordinate system
to the corresponding indices in the underlying container. This is particularly useful for views
that contain integral slices (fixed indices), as these slices reduce the dimensionality of the view.

Example:
```cpp
xt::xarray<double> a = xt::arange(24).reshape({2, 3, 4});
auto view1 = xt::view(a, 1, xt::all(), xt::all());  // Fixed first dimension
index_mapper<decltype(view1)> mapper;

// Map view indices (i,j) to container indices (1,i,j)
double val = mapper.map(a, view1, 0, 0);  // Returns a(1, 0, 0)
double val2 = mapper.map(a, view1, 1, 2); // Returns a(1, 1, 2)
 ```
