### PR TITLE
Fix missing default type for poisson and geometric template parameter T

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     args: [--autofix, --indent, '2']
     types: [file]
     files: \.(yaml|yml|clang-format)
+    additional_dependencies: [setuptools]
 - repo: https://github.com/tdegeus/cpp_comment_format
   rev: v0.2.1
   hooks:

--- a/docs/source/pitfall.rst
+++ b/docs/source/pitfall.rst
@@ -92,7 +92,8 @@ is still an lvalue and thus captured by reference.
     that hold references to local variables. When the function returns, these local
     variables are destroyed, and the returned expression contains dangling references.
 
-    The fix is to use explicit container types to force evaluation:
+    The fix is to force evaluation of only the returned expression — intermediate
+    lazy expressions are safe as long as they do not outlive the function:
 
     .. code::
 
@@ -100,23 +101,11 @@ is still an lvalue and thus captured by reference.
         xt::xtensor<T, 2> logSoftmax(const xt::xtensor<T, 2> &matrix)
         {
             xt::xtensor<T, 2> maxVals = xt::amax(matrix, {1}, xt::keep_dims);
-            xt::xtensor<T, 2> shifted = matrix - maxVals;
-            xt::xtensor<T, 2> expVals = xt::exp(shifted);
-            xt::xtensor<T, 2> sumExp = xt::sum(expVals, {1}, xt::keep_dims);
-            return shifted - xt::log(sumExp);
+            auto shifted = matrix - maxVals;
+            auto expVals = xt::exp(shifted);
+            auto sumExp = xt::sum(expVals, {1}, xt::keep_dims);
+            return xt::xtensor<T, 2>(shifted - xt::log(sumExp));
         }
-
-    Alternatively, you can use :cpp:func:`xt::eval` to force evaluation:
-
-    .. code::
-
-        auto shifted = xt::eval(matrix - maxVals);
-
-    Or use the immediate evaluation strategy for reducers:
-
-    .. code::
-
-        auto sumExp = xt::sum(expVals, {1}, xt::evaluation_strategy::immediate | xt::keep_dims);
 
 Random numbers not consistent
 -----------------------------

--- a/docs/source/pitfall.rst
+++ b/docs/source/pitfall.rst
@@ -92,8 +92,10 @@ is still an lvalue and thus captured by reference.
     that hold references to local variables. When the function returns, these local
     variables are destroyed, and the returned expression contains dangling references.
 
-    The fix is to force evaluation of only the returned expression — intermediate
-    lazy expressions are safe as long as they do not outlive the function:
+    The fix is to evaluate reducer results and the returned expression explicitly.
+    Element-wise lazy expressions (like ``shifted`` and ``expVals``) are safe to
+    leave as ``auto``, but reducer results (like ``sumExp``) must be materialized
+    before being used in a subsequent element-wise expression:
 
     .. code::
 
@@ -103,7 +105,7 @@ is still an lvalue and thus captured by reference.
             xt::xtensor<T, 2> maxVals = xt::amax(matrix, {1}, xt::keep_dims);
             auto shifted = matrix - maxVals;
             auto expVals = xt::exp(shifted);
-            auto sumExp = xt::sum(expVals, {1}, xt::keep_dims);
+            xt::xtensor<T, 2> sumExp = xt::sum(expVals, {1}, xt::keep_dims);
             return xt::xtensor<T, 2>(shifted - xt::log(sumExp));
         }
 

--- a/include/xtensor/generators/xrandom.hpp
+++ b/include/xtensor/generators/xrandom.hpp
@@ -63,14 +63,14 @@ namespace xt
         auto
         binomial(const S& shape, T trials = 1, D prob = 0.5, E& engine = random::get_default_random_engine());
 
-        template <class T, class S, class D = double, class E = random::default_engine_type>
+        template <class T = int, class S, class D = double, class E = random::default_engine_type>
         auto geometric(const S& shape, D prob = 0.5, E& engine = random::get_default_random_engine());
 
         template <class T, class S, class D = double, class E = random::default_engine_type>
         auto
         negative_binomial(const S& shape, T k = 1, D prob = 0.5, E& engine = random::get_default_random_engine());
 
-        template <class T, class S, class D = double, class E = random::default_engine_type>
+        template <class T = int, class S, class D = double, class E = random::default_engine_type>
         auto poisson(const S& shape, D rate = 1.0, E& engine = random::get_default_random_engine());
 
         template <class T, class S, class E = random::default_engine_type>
@@ -123,7 +123,7 @@ namespace xt
         auto
         binomial(const I (&shape)[L], T trials = 1, D prob = 0.5, E& engine = random::get_default_random_engine());
 
-        template <class T, class I, std::size_t L, class D = double, class E = random::default_engine_type>
+        template <class T = int, class I, std::size_t L, class D = double, class E = random::default_engine_type>
         auto geometric(const I (&shape)[L], D prob = 0.5, E& engine = random::get_default_random_engine());
 
         template <class T, class I, std::size_t L, class D = double, class E = random::default_engine_type>
@@ -134,7 +134,7 @@ namespace xt
             E& engine = random::get_default_random_engine()
         );
 
-        template <class T, class I, std::size_t L, class D = double, class E = random::default_engine_type>
+        template <class T = int, class I, std::size_t L, class D = double, class E = random::default_engine_type>
         auto poisson(const I (&shape)[L], D rate = 1.0, E& engine = random::get_default_random_engine());
 
         template <class T, class I, std::size_t L, class E = random::default_engine_type>

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -976,26 +976,26 @@ namespace xt
     TEST(xmath, issue_2871_intermediate_result_handling)
     {
         // This test verifies the correct pattern for using reducers with
-        // intermediate results. Using 'auto' with lazy expressions can lead
-        // to dangling references when the function returns.
+        // intermediate results. Returning a lazy expression from a function can lead
+        // to dangling references — only the returned expression must be evaluated.
 
-        // The CORRECT way: use explicit container types for intermediate results
+        // The CORRECT way: use auto for intermediates, force evaluation only at return
         auto logSoftmax_correct = [](const xt::xtensor<double, 2>& matrix)
         {
             xt::xtensor<double, 2> maxVals = xt::amax(matrix, {1}, xt::keep_dims);
-            xt::xtensor<double, 2> shifted = matrix - maxVals;
-            xt::xtensor<double, 2> expVals = xt::exp(shifted);
-            xt::xtensor<double, 2> sumExp = xt::sum(expVals, {1}, xt::keep_dims);
+            auto shifted = matrix - maxVals;
+            auto expVals = xt::exp(shifted);
+            auto sumExp = xt::sum(expVals, {1}, xt::keep_dims);
             return xt::xtensor<double, 2>(shifted - xt::log(sumExp));
         };
 
-        // Alternative CORRECT way: use xt::eval for intermediate results
+        // Alternative CORRECT way: use xt::eval on the reducer result
         auto logSoftmax_eval = [](const xt::xtensor<double, 2>& matrix)
         {
             auto maxVals = xt::eval(xt::amax(matrix, {1}, xt::keep_dims));
-            auto shifted = xt::eval(matrix - maxVals);
-            auto expVals = xt::eval(xt::exp(shifted));
-            auto sumExp = xt::eval(xt::sum(expVals, {1}, xt::keep_dims));
+            auto shifted = matrix - maxVals;
+            auto expVals = xt::exp(shifted);
+            auto sumExp = xt::sum(expVals, {1}, xt::keep_dims);
             return xt::xtensor<double, 2>(shifted - xt::log(sumExp));
         };
 

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -979,23 +979,24 @@ namespace xt
         // intermediate results. Returning a lazy expression from a function can lead
         // to dangling references — only the returned expression must be evaluated.
 
-        // The CORRECT way: use auto for intermediates, force evaluation only at return
+        // The CORRECT way: reducer results must be evaluated; element-wise lazy
+        // expressions are safe to leave as auto
         auto logSoftmax_correct = [](const xt::xtensor<double, 2>& matrix)
         {
             xt::xtensor<double, 2> maxVals = xt::amax(matrix, {1}, xt::keep_dims);
             auto shifted = matrix - maxVals;
             auto expVals = xt::exp(shifted);
-            auto sumExp = xt::sum(expVals, {1}, xt::keep_dims);
+            xt::xtensor<double, 2> sumExp = xt::sum(expVals, {1}, xt::keep_dims);
             return xt::xtensor<double, 2>(shifted - xt::log(sumExp));
         };
 
-        // Alternative CORRECT way: use xt::eval on the reducer result
+        // Alternative CORRECT way: use xt::eval for reducer results
         auto logSoftmax_eval = [](const xt::xtensor<double, 2>& matrix)
         {
             auto maxVals = xt::eval(xt::amax(matrix, {1}, xt::keep_dims));
             auto shifted = matrix - maxVals;
             auto expVals = xt::exp(shifted);
-            auto sumExp = xt::sum(expVals, {1}, xt::keep_dims);
+            auto sumExp = xt::eval(xt::sum(expVals, {1}, xt::keep_dims));
             return xt::xtensor<double, 2>(shifted - xt::log(sumExp));
         };
 

--- a/test/test_xrandom.cpp
+++ b/test/test_xrandom.cpp
@@ -237,6 +237,20 @@ namespace xt
 #endif
     }
 
+    TEST(xrandom, poisson_geometric_default_type)
+    {
+        // poisson and geometric have no parameter from which T can be deduced,
+        // so they require a default T (= int) to be callable without explicit template arg.
+        auto p = random::poisson({3, 3}, 1.0);
+        static_assert(std::is_same<decltype(p)::value_type, int>::value, "poisson default T must be int");
+
+        auto g = random::geometric({3, 3}, 0.5);
+        static_assert(std::is_same<decltype(g)::value_type, int>::value, "geometric default T must be int");
+
+        auto p2 = random::poisson({3, 3});
+        static_assert(std::is_same<decltype(p2)::value_type, int>::value, "poisson default T must be int");
+    }
+
     TEST(xrandom, permutation)
     {
         xt::random::seed(123);


### PR DESCRIPTION
`xt::random::poisson` and `xt::random::geometric` both use `T` only internally (as the distribution's output type), so the compiler has no way to deduce it from the call site. Adding `= int` as the default matches the underlying `std::poisson_distribution` and `std::geometric_distribution` defaults and lets users call these functions without spelling out the type every time. Fixes #2884.