### PR TITLE
Removed constexpr workarounds

### DIFF
--- a/include/xtensor/containers/xcontainer.hpp
+++ b/include/xtensor/containers/xcontainer.hpp
@@ -114,11 +114,11 @@ namespace xt
 
         size_type size() const noexcept;
 
-        XTENSOR_CONSTEXPR_RETURN size_type dimension() const noexcept;
+        constexpr size_type dimension() const noexcept;
 
-        XTENSOR_CONSTEXPR_RETURN const inner_shape_type& shape() const noexcept;
-        XTENSOR_CONSTEXPR_RETURN const inner_strides_type& strides() const noexcept;
-        XTENSOR_CONSTEXPR_RETURN const inner_backstrides_type& backstrides() const noexcept;
+        constexpr const inner_shape_type& shape() const noexcept;
+        constexpr const inner_strides_type& strides() const noexcept;
+        constexpr const inner_backstrides_type& backstrides() const noexcept;
 
         template <class T>
         void fill(const T& value);
@@ -373,7 +373,7 @@ namespace xt
      * Returns the number of dimensions of the container.
      */
     template <class D>
-    XTENSOR_CONSTEXPR_RETURN auto xcontainer<D>::dimension() const noexcept -> size_type
+    constexpr auto xcontainer<D>::dimension() const noexcept -> size_type
     {
         return shape().size();
     }
@@ -382,7 +382,7 @@ namespace xt
      * Returns the shape of the container.
      */
     template <class D>
-    XTENSOR_CONSTEXPR_RETURN auto xcontainer<D>::shape() const noexcept -> const inner_shape_type&
+    constexpr auto xcontainer<D>::shape() const noexcept -> const inner_shape_type&
     {
         return derived_cast().shape_impl();
     }
@@ -391,7 +391,7 @@ namespace xt
      * Returns the strides of the container.
      */
     template <class D>
-    XTENSOR_CONSTEXPR_RETURN auto xcontainer<D>::strides() const noexcept -> const inner_strides_type&
+    constexpr auto xcontainer<D>::strides() const noexcept -> const inner_strides_type&
     {
         return derived_cast().strides_impl();
     }
@@ -400,7 +400,7 @@ namespace xt
      * Returns the backstrides of the container.
      */
     template <class D>
-    XTENSOR_CONSTEXPR_RETURN auto xcontainer<D>::backstrides() const noexcept -> const inner_backstrides_type&
+    constexpr auto xcontainer<D>::backstrides() const noexcept -> const inner_backstrides_type&
     {
         return derived_cast().backstrides_impl();
     }

--- a/include/xtensor/containers/xfixed.hpp
+++ b/include/xtensor/containers/xfixed.hpp
@@ -373,9 +373,9 @@ namespace xt
         storage_type& storage_impl() noexcept;
         const storage_type& storage_impl() const noexcept;
 
-        XTENSOR_CONSTEXPR_RETURN const inner_shape_type& shape_impl() const noexcept;
-        XTENSOR_CONSTEXPR_RETURN const inner_strides_type& strides_impl() const noexcept;
-        XTENSOR_CONSTEXPR_RETURN const inner_backstrides_type& backstrides_impl() const noexcept;
+        constexpr const inner_shape_type& shape_impl() const noexcept;
+        constexpr const inner_strides_type& strides_impl() const noexcept;
+        constexpr const inner_backstrides_type& backstrides_impl() const noexcept;
 
         friend class xcontainer<xfixed_container<ET, S, L, SH, Tag>>;
     };
@@ -495,9 +495,9 @@ namespace xt
         storage_type& storage_impl() noexcept;
         const storage_type& storage_impl() const noexcept;
 
-        XTENSOR_CONSTEXPR_RETURN const inner_shape_type& shape_impl() const noexcept;
-        XTENSOR_CONSTEXPR_RETURN const inner_strides_type& strides_impl() const noexcept;
-        XTENSOR_CONSTEXPR_RETURN const inner_backstrides_type& backstrides_impl() const noexcept;
+        constexpr const inner_shape_type& shape_impl() const noexcept;
+        constexpr const inner_strides_type& strides_impl() const noexcept;
+        constexpr const inner_backstrides_type& backstrides_impl() const noexcept;
 
         friend class xcontainer<xfixed_adaptor<EC, S, L, SH, Tag>>;
     };
@@ -740,21 +740,20 @@ namespace xt
     }
 
     template <class ET, class S, layout_type L, bool SH, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_container<ET, S, L, SH, Tag>::shape_impl() const noexcept
-        -> const inner_shape_type&
+    constexpr auto xfixed_container<ET, S, L, SH, Tag>::shape_impl() const noexcept -> const inner_shape_type&
     {
         return m_shape;
     }
 
     template <class ET, class S, layout_type L, bool SH, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_container<ET, S, L, SH, Tag>::strides_impl() const noexcept
+    constexpr auto xfixed_container<ET, S, L, SH, Tag>::strides_impl() const noexcept
         -> const inner_strides_type&
     {
         return m_strides;
     }
 
     template <class ET, class S, layout_type L, bool SH, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_container<ET, S, L, SH, Tag>::backstrides_impl() const noexcept
+    constexpr auto xfixed_container<ET, S, L, SH, Tag>::backstrides_impl() const noexcept
         -> const inner_backstrides_type&
     {
         return m_backstrides;
@@ -937,21 +936,20 @@ namespace xt
     }
 
     template <class EC, class S, layout_type L, bool SH, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_adaptor<EC, S, L, SH, Tag>::shape_impl() const noexcept
-        -> const inner_shape_type&
+    constexpr auto xfixed_adaptor<EC, S, L, SH, Tag>::shape_impl() const noexcept -> const inner_shape_type&
     {
         return m_shape;
     }
 
     template <class EC, class S, layout_type L, bool SH, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_adaptor<EC, S, L, SH, Tag>::strides_impl() const noexcept
+    constexpr auto xfixed_adaptor<EC, S, L, SH, Tag>::strides_impl() const noexcept
         -> const inner_strides_type&
     {
         return m_strides;
     }
 
     template <class EC, class S, layout_type L, bool SH, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_adaptor<EC, S, L, SH, Tag>::backstrides_impl() const noexcept
+    constexpr auto xfixed_adaptor<EC, S, L, SH, Tag>::backstrides_impl() const noexcept
         -> const inner_backstrides_type&
     {
         return m_backstrides;

--- a/include/xtensor/containers/xscalar.hpp
+++ b/include/xtensor/containers/xscalar.hpp
@@ -466,25 +466,25 @@ namespace xt
      *****************************/
 
     template <class CT>
-    XTENSOR_CONSTEXPR_RETURN auto linear_begin(xscalar<CT>& c) noexcept -> decltype(c.dummy_begin())
+    constexpr auto linear_begin(xscalar<CT>& c) noexcept -> decltype(c.dummy_begin())
     {
         return c.dummy_begin();
     }
 
     template <class CT>
-    XTENSOR_CONSTEXPR_RETURN auto linear_end(xscalar<CT>& c) noexcept -> decltype(c.dummy_end())
+    constexpr auto linear_end(xscalar<CT>& c) noexcept -> decltype(c.dummy_end())
     {
         return c.dummy_end();
     }
 
     template <class CT>
-    XTENSOR_CONSTEXPR_RETURN auto linear_begin(const xscalar<CT>& c) noexcept -> decltype(c.dummy_begin())
+    constexpr auto linear_begin(const xscalar<CT>& c) noexcept -> decltype(c.dummy_begin())
     {
         return c.dummy_begin();
     }
 
     template <class CT>
-    XTENSOR_CONSTEXPR_RETURN auto linear_end(const xscalar<CT>& c) noexcept -> decltype(c.dummy_end())
+    constexpr auto linear_end(const xscalar<CT>& c) noexcept -> decltype(c.dummy_end())
     {
         return c.dummy_end();
     }

--- a/include/xtensor/containers/xstorage.hpp
+++ b/include/xtensor/containers/xstorage.hpp
@@ -1658,13 +1658,7 @@ namespace xt
     {
     public:
 
-#if defined(_MSC_VER)
-        using cast_type = std::array<std::size_t, sizeof...(X)>;
-#define XTENSOR_FIXED_SHAPE_CONSTEXPR inline
-#else
         using cast_type = const_array<std::size_t, sizeof...(X)>;
-#define XTENSOR_FIXED_SHAPE_CONSTEXPR constexpr
-#endif
         using value_type = std::size_t;
         using size_type = std::size_t;
         using const_iterator = typename cast_type::const_iterator;
@@ -1681,17 +1675,17 @@ namespace xt
             return std::get<idx>(tmp_cast_type{X...});
         }
 
-        XTENSOR_FIXED_SHAPE_CONSTEXPR operator cast_type() const
+        constexpr operator cast_type() const
         {
             return cast_type({X...});
         }
 
-        XTENSOR_FIXED_SHAPE_CONSTEXPR auto begin() const
+        constexpr auto begin() const
         {
             return m_array.begin();
         }
 
-        XTENSOR_FIXED_SHAPE_CONSTEXPR auto end() const
+        constexpr auto end() const
         {
             return m_array.end();
         }
@@ -1706,22 +1700,22 @@ namespace xt
             return m_array.rend();
         }
 
-        XTENSOR_FIXED_SHAPE_CONSTEXPR auto cbegin() const
+        constexpr auto cbegin() const
         {
             return m_array.cbegin();
         }
 
-        XTENSOR_FIXED_SHAPE_CONSTEXPR auto cend() const
+        constexpr auto cend() const
         {
             return m_array.cend();
         }
 
-        XTENSOR_FIXED_SHAPE_CONSTEXPR std::size_t operator[](std::size_t idx) const
+        constexpr std::size_t operator[](std::size_t idx) const
         {
             return m_array[idx];
         }
 
-        XTENSOR_FIXED_SHAPE_CONSTEXPR bool empty() const
+        constexpr bool empty() const
         {
             return sizeof...(X) == 0;
         }
@@ -1730,8 +1724,6 @@ namespace xt
 
         XTENSOR_CONSTEXPR_ENHANCED_STATIC cast_type m_array = cast_type({X...});
     };
-
-#undef XTENSOR_FIXED_SHAPE_CONSTEXPR
 
     template <class E, std::ptrdiff_t Start, std::ptrdiff_t End = -1>
     class sequence_view

--- a/include/xtensor/core/xiterator.hpp
+++ b/include/xtensor/core/xiterator.hpp
@@ -417,7 +417,7 @@ namespace xt
     }
 
     template <class C>
-    XTENSOR_CONSTEXPR_RETURN auto linear_begin(C& c) noexcept
+    constexpr auto linear_begin(C& c) noexcept
     {
         if constexpr (detail::has_linear_iterator<C>::value)
         {
@@ -430,7 +430,7 @@ namespace xt
     }
 
     template <class C>
-    XTENSOR_CONSTEXPR_RETURN auto linear_end(C& c) noexcept
+    constexpr auto linear_end(C& c) noexcept
     {
         if constexpr (detail::has_linear_iterator<C>::value)
         {
@@ -443,7 +443,7 @@ namespace xt
     }
 
     template <class C>
-    XTENSOR_CONSTEXPR_RETURN auto linear_begin(const C& c) noexcept
+    constexpr auto linear_begin(const C& c) noexcept
     {
         if constexpr (detail::has_linear_iterator<C>::value)
         {
@@ -456,7 +456,7 @@ namespace xt
     }
 
     template <class C>
-    XTENSOR_CONSTEXPR_RETURN auto linear_end(const C& c) noexcept
+    constexpr auto linear_end(const C& c) noexcept
     {
         if constexpr (detail::has_linear_iterator<C>::value)
         {

--- a/include/xtensor/core/xtensor_config.hpp
+++ b/include/xtensor/core/xtensor_config.hpp
@@ -35,17 +35,12 @@
 
 // Workaround for some missing constexpr functionality in MSVC 2015 and MSVC 2017 x86
 #if defined(_MSC_VER)
-#define XTENSOR_CONSTEXPR_ENHANCED const
 // The following must not be defined to const, otherwise
 // it prevents generation of copy operators of classes
 // containing XTENSOR_CONSTEXPR_ENHANCED_STATIC members
 #define XTENSOR_CONSTEXPR_ENHANCED_STATIC
-#define XTENSOR_CONSTEXPR_RETURN inline
 #else
-#define XTENSOR_CONSTEXPR_ENHANCED constexpr
-#define XTENSOR_CONSTEXPR_RETURN constexpr
 #define XTENSOR_CONSTEXPR_ENHANCED_STATIC constexpr static
-#define XTENSOR_HAS_CONSTEXPR_ENHANCED
 #endif
 
 #ifndef XTENSOR_DEFAULT_DATA_CONTAINER

--- a/include/xtensor/views/xbroadcast.hpp
+++ b/include/xtensor/views/xbroadcast.hpp
@@ -96,25 +96,25 @@ namespace xt
      *****************************/
 
     template <class CT, class X>
-    XTENSOR_CONSTEXPR_RETURN auto linear_begin(xbroadcast<CT, X>& c) noexcept
+    constexpr auto linear_begin(xbroadcast<CT, X>& c) noexcept
     {
         return linear_begin(c.expression());
     }
 
     template <class CT, class X>
-    XTENSOR_CONSTEXPR_RETURN auto linear_end(xbroadcast<CT, X>& c) noexcept
+    constexpr auto linear_end(xbroadcast<CT, X>& c) noexcept
     {
         return linear_end(c.expression());
     }
 
     template <class CT, class X>
-    XTENSOR_CONSTEXPR_RETURN auto linear_begin(const xbroadcast<CT, X>& c) noexcept
+    constexpr auto linear_begin(const xbroadcast<CT, X>& c) noexcept
     {
         return linear_begin(c.expression());
     }
 
     template <class CT, class X>
-    XTENSOR_CONSTEXPR_RETURN auto linear_end(const xbroadcast<CT, X>& c) noexcept
+    constexpr auto linear_end(const xbroadcast<CT, X>& c) noexcept
     {
         return linear_end(c.expression());
     }

--- a/include/xtensor/views/xslice.hpp
+++ b/include/xtensor/views/xslice.hpp
@@ -21,16 +21,6 @@
 #include "../core/xtensor_config.hpp"
 #include "../utils/xutils.hpp"
 
-#ifndef XTENSOR_CONSTEXPR
-#if (defined(_MSC_VER) || __GNUC__ < 8)
-#define XTENSOR_CONSTEXPR inline
-#define XTENSOR_GLOBAL_CONSTEXPR static const
-#else
-#define XTENSOR_CONSTEXPR constexpr
-#define XTENSOR_GLOBAL_CONSTEXPR constexpr
-#endif
-#endif
-
 namespace xt
 {
 
@@ -70,11 +60,11 @@ namespace xt
      * slice tags *
      **************/
 
-#define DEFINE_TAG_CONVERSION(NAME)                 \
-    template <class T>                              \
-    XTENSOR_CONSTEXPR NAME convert() const noexcept \
-    {                                               \
-        return NAME();                              \
+#define DEFINE_TAG_CONVERSION(NAME)         \
+    template <class T>                      \
+    constexpr NAME convert() const noexcept \
+    {                                       \
+        return NAME();                      \
     }
 
     struct xall_tag
@@ -642,12 +632,12 @@ namespace xt
             std::ptrdiff_t rng[3];  // = { 0, 0, 0 };
         };
 
-        XTENSOR_CONSTEXPR xtuph get_tuph_or_val(std::ptrdiff_t /*val*/, std::true_type)
+        constexpr xtuph get_tuph_or_val(std::ptrdiff_t /*val*/, std::true_type)
         {
             return xtuph();
         }
 
-        XTENSOR_CONSTEXPR std::ptrdiff_t get_tuph_or_val(std::ptrdiff_t val, std::false_type)
+        constexpr std::ptrdiff_t get_tuph_or_val(std::ptrdiff_t val, std::false_type)
         {
             return val;
         }
@@ -655,7 +645,7 @@ namespace xt
         template <class A, class B, class C>
         struct rangemaker<A, B, C>
         {
-            XTENSOR_CONSTEXPR operator xrange_adaptor<A, B, C>()
+            constexpr operator xrange_adaptor<A, B, C>()
             {
                 return xrange_adaptor<A, B, C>(
                     {get_tuph_or_val(rng[0], std::is_same<A, xtuph>()),
@@ -670,7 +660,7 @@ namespace xt
         template <class A, class B>
         struct rangemaker<A, B>
         {
-            XTENSOR_CONSTEXPR operator xrange_adaptor<A, B, xt::placeholders::xtuph>()
+            constexpr operator xrange_adaptor<A, B, xt::placeholders::xtuph>()
             {
                 return xrange_adaptor<A, B, xt::placeholders::xtuph>(
                     {get_tuph_or_val(rng[0], std::is_same<A, xtuph>()),
@@ -683,7 +673,7 @@ namespace xt
         };
 
         template <class... OA>
-        XTENSOR_CONSTEXPR auto operator|(const rangemaker<OA...>& rng, const std::ptrdiff_t& t)
+        constexpr auto operator|(const rangemaker<OA...>& rng, const std::ptrdiff_t& t)
         {
             auto nrng = rangemaker<OA..., std::ptrdiff_t>({rng.rng[0], rng.rng[1], rng.rng[2]});
             nrng.rng[sizeof...(OA)] = t;
@@ -691,17 +681,17 @@ namespace xt
         }
 
         template <class... OA>
-        XTENSOR_CONSTEXPR auto operator|(const rangemaker<OA...>& rng, const xt::placeholders::xtuph& /*t*/)
+        constexpr auto operator|(const rangemaker<OA...>& rng, const xt::placeholders::xtuph& /*t*/)
         {
             auto nrng = rangemaker<OA..., xt::placeholders::xtuph>({rng.rng[0], rng.rng[1], rng.rng[2]});
             return nrng;
         }
 
-        XTENSOR_GLOBAL_CONSTEXPR xtuph _{};
-        XTENSOR_GLOBAL_CONSTEXPR rangemaker<> _r = rangemaker<>({{0, 0, 0}});
-        XTENSOR_GLOBAL_CONSTEXPR xall_tag _a{};
-        XTENSOR_GLOBAL_CONSTEXPR xnewaxis_tag _n{};
-        XTENSOR_GLOBAL_CONSTEXPR xellipsis_tag _e{};
+        constexpr xtuph _{};
+        constexpr rangemaker<> _r = rangemaker<>({{0, 0, 0}});
+        constexpr xall_tag _a{};
+        constexpr xnewaxis_tag _n{};
+        constexpr xellipsis_tag _e{};
     }
 
     inline auto xnone()
@@ -1597,7 +1587,5 @@ namespace xt
         return !(*this == rhs);
     }
 }
-
-#undef XTENSOR_CONSTEXPR
 
 #endif


### PR DESCRIPTION
This workaround is for old compilers not supported anymore.
Edit: `XTENSOR_CONSTEXPR_ENHANCED_STATIC` is still required on Windows.