### PR TITLE
Fix xview assignment through leading newaxis slices

### DIFF
--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -1645,8 +1645,9 @@ namespace xt
     {
         if constexpr (lesser_condition<I>::value)
         {
-            return sliced_access<I - integral_count_before<S...>(I) + newaxis_count_before<S...>(I + 1)>(
-                std::get<I + newaxis_count_before<S...>(I + 1)>(m_slices),
+            constexpr size_type slice_index = newaxis_skip<S...>(I);
+            return sliced_access<slice_index - integral_count_before<S...>(slice_index)>(
+                std::get<slice_index>(m_slices),
                 args...
             );
         }

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -1591,6 +1591,45 @@ namespace xt
         EXPECT_EQ(a, b);
     }
 
+    TEST(xview, assign_through_multiple_leading_newaxis)
+    {
+        SUBCASE("updates the underlying tensor for every element")
+        {
+            xt::xtensor<uint8_t, 2> tensor = xt::zeros<uint8_t>({4, 3});
+            auto view = xt::view(tensor, xt::newaxis(), xt::newaxis(), xt::newaxis(), xt::all(), xt::all());
+
+            uint8_t value = 0;
+            for (std::size_t row = 0; row < 4; ++row)
+            {
+                for (std::size_t col = 0; col < 3; ++col)
+                {
+                    view(std::size_t{0}, std::size_t{0}, std::size_t{0}, row, col) = value;
+                    EXPECT_EQ(tensor(row, col), value);
+                    ++value;
+                }
+            }
+
+            EXPECT_EQ(tensor, xt::arange<uint8_t>(12).reshape({4, 3}));
+        }
+
+        SUBCASE("preserves bool assignment semantics")
+        {
+            xt::xtensor<bool, 2> tensor = xt::zeros<bool>({4, 3});
+            auto view = xt::view(tensor, xt::newaxis(), xt::newaxis(), xt::newaxis(), xt::all(), xt::all());
+
+            for (std::size_t row = 0; row < 4; ++row)
+            {
+                for (std::size_t col = 0; col < 3; ++col)
+                {
+                    view(std::size_t{0}, std::size_t{0}, std::size_t{0}, row, col) = true;
+                    EXPECT_TRUE(tensor(row, col));
+                }
+            }
+
+            EXPECT_EQ(tensor, xt::ones<bool>({4, 3}));
+        }
+    }
+
     TEST(xview, in_bounds)
     {
         xt::xtensor<size_t, 2> a = {{0, 1, 2}, {3, 4, 5}};


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

This PR fixes incorrect index mapping in xview assignments when a view starts with one or more newaxis() slices.

The change updates the index computation to use a newaxis-aware slice index before applying integral-slice adjustments. That keeps writes through views with multiple leading newaxis() entries aligned with the correct element in the underlying tensor.