### PR TITLE
Enhance xmasked_view support for output streaming

### DIFF
--- a/include/xtensor/io/xio.hpp
+++ b/include/xtensor/io/xio.hpp
@@ -17,6 +17,8 @@
 #include <sstream>
 #include <string>
 
+#include "xtl/xmasked_value_meta.hpp"
+
 #include "../core/xexpression.hpp"
 #include "../core/xmath.hpp"
 #include "../views/xstrided_view.hpp"
@@ -615,7 +617,8 @@ namespace xt
         struct printer<
             T,
             std::enable_if_t<
-                !xtl::is_fundamental<typename T::value_type>::value && !xtl::is_complex<typename T::value_type>::value>>
+                !xtl::is_fundamental<typename T::value_type>::value
+                && !xtl::is_complex<typename T::value_type>::value>>
         {
             using const_reference = typename T::const_reference;
             using value_type = std::decay_t<typename T::value_type>;
@@ -646,7 +649,14 @@ namespace xt
             void update(const_reference val)
             {
                 std::stringstream buf;
-                buf << val;
+                if constexpr (xtl::is_xmasked_value<value_type>::value)
+                {
+                    buf << +val;
+                }
+                else
+                {
+                    buf << val;
+                }
                 std::string s = buf.str();
                 if (int(s.size()) > m_width)
                 {

--- a/include/xtensor/io/xio.hpp
+++ b/include/xtensor/io/xio.hpp
@@ -17,11 +17,10 @@
 #include <sstream>
 #include <string>
 
-#include "xtl/xmasked_value_meta.hpp"
-
 #include "../core/xexpression.hpp"
 #include "../core/xmath.hpp"
 #include "../views/xstrided_view.hpp"
+#include "xtl/xmasked_value_meta.hpp"
 
 namespace xt
 {
@@ -617,8 +616,7 @@ namespace xt
         struct printer<
             T,
             std::enable_if_t<
-                !xtl::is_fundamental<typename T::value_type>::value
-                && !xtl::is_complex<typename T::value_type>::value>>
+                !xtl::is_fundamental<typename T::value_type>::value && !xtl::is_complex<typename T::value_type>::value>>
         {
             using const_reference = typename T::const_reference;
             using value_type = std::decay_t<typename T::value_type>;

--- a/test/test_xmasked_view.cpp
+++ b/test/test_xmasked_view.cpp
@@ -7,6 +7,8 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
+#include <sstream>
+
 #include "xtensor/io/xio.hpp"
 #include "xtensor/optional/xoptional_assembly.hpp"
 #include "xtensor/views/xmasked_view.hpp"
@@ -208,6 +210,21 @@ namespace xt
         masked_data += 3.;
         xarray<double> expected2 = {{6.65, 6.65, 6.65}, {6.65, 5., -6.}, {6.65, 8., 6.65}};
         EXPECT_EQ(data, expected2);
+    }
+
+    TEST(xmasked_view, non_optional_data_stream)
+    {
+        const xarray<double> data = {{1., 5., 3.}, {4., 5., 6.}};
+        const xarray<bool> mask = {{true, false, false}, {false, true, false}};
+
+        const auto masked_data = masked_view(data, mask);
+
+        std::stringstream out;
+        out << masked_data;
+
+        const std::string expected = "{{     1, masked, masked},\n"
+                                     " {masked,      5, masked}}";
+        EXPECT_EQ(out.str(), expected);
     }
 
     TEST(xmasked_view, assign)


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Fix `xt::masked_view` pretty-printing when the underlying data is non-optional.
Related to: #2495

The generic non-fundamental printer was streaming masked proxy values directly, which could lose the correct masked/value state during formatting. This change keeps the existing generic printer path but handles `xtl::xmasked_value` with a compile-time branch and streams a stabilized value via unary `+`.

## Changes

- include `xtl/xmasked_value_meta.hpp` in `xio.hpp`
- update the generic non-fundamental printer to use `if constexpr`
- stream masked values with `buf << +val`
- add a regression test for `masked_view` stream output on plain `xarray` data