### PR TITLE
Masked view lazy streaming

### DIFF
--- a/include/xtensor/core/xmath.hpp
+++ b/include/xtensor/core/xmath.hpp
@@ -614,9 +614,8 @@ namespace xt
                     {
                         return return_type(
                             static_cast<value_type>(
-                                detail::masked_data(t1) < detail::masked_data(t2)
-                                    ? detail::masked_data(t1)
-                                    : detail::masked_data(t2)
+                                detail::masked_data(t1) < detail::masked_data(t2) ? detail::masked_data(t1)
+                                                                                  : detail::masked_data(t2)
                             ),
                             true
                         );
@@ -654,9 +653,8 @@ namespace xt
                     {
                         return return_type(
                             static_cast<value_type>(
-                                detail::masked_data(t1) > detail::masked_data(t2)
-                                    ? detail::masked_data(t1)
-                                    : detail::masked_data(t2)
+                                detail::masked_data(t1) > detail::masked_data(t2) ? detail::masked_data(t1)
+                                                                                  : detail::masked_data(t2)
                             ),
                             true
                         );

--- a/include/xtensor/core/xmath.hpp
+++ b/include/xtensor/core/xmath.hpp
@@ -21,6 +21,7 @@
 #include <type_traits>
 
 #include <xtl/xcomplex.hpp>
+#include <xtl/xmasked_value.hpp>
 #include <xtl/xsequence.hpp>
 #include <xtl/xtype_traits.hpp>
 
@@ -569,13 +570,64 @@ namespace xt
 
     namespace math
     {
+        namespace detail
+        {
+            template <typename T>
+            constexpr decltype(auto) masked_data(const T& value) noexcept
+            {
+                return value;
+            }
+
+            template <typename T, typename B>
+            constexpr decltype(auto) masked_data(const xtl::xmasked_value<T, B>& value) noexcept
+            {
+                return value.value();
+            }
+
+            template <typename T>
+            constexpr bool masked_visible(const T&) noexcept
+            {
+                return true;
+            }
+
+            template <typename T, typename B>
+            constexpr bool masked_visible(const xtl::xmasked_value<T, B>& value) noexcept
+            {
+                return static_cast<bool>(value.visible());
+            }
+        }
+
         template <class T = void>
         struct minimum
         {
             template <class A1, class A2>
             constexpr auto operator()(const A1& t1, const A2& t2) const noexcept
             {
-                return xtl::select(t1 < t2, t1, t2);
+                if constexpr (xtl::is_xmasked_value<std::decay_t<A1>>::value || xtl::is_xmasked_value<std::decay_t<A2>>::value)
+                {
+                    using value_type = xtl::promote_type_t<
+                        std::decay_t<decltype(detail::masked_data(t1))>,
+                        std::decay_t<decltype(detail::masked_data(t2))>>;
+                    using return_type = xtl::xmasked_value<value_type, bool>;
+
+                    if (detail::masked_visible(t1) && detail::masked_visible(t2))
+                    {
+                        return return_type(
+                            static_cast<value_type>(
+                                detail::masked_data(t1) < detail::masked_data(t2)
+                                    ? detail::masked_data(t1)
+                                    : detail::masked_data(t2)
+                            ),
+                            true
+                        );
+                    }
+
+                    return return_type(value_type(0), false);
+                }
+                else
+                {
+                    return xtl::select(t1 < t2, t1, t2);
+                }
             }
 
             template <class A1, class A2>
@@ -591,7 +643,31 @@ namespace xt
             template <class A1, class A2>
             constexpr auto operator()(const A1& t1, const A2& t2) const noexcept
             {
-                return xtl::select(t1 > t2, t1, t2);
+                if constexpr (xtl::is_xmasked_value<std::decay_t<A1>>::value || xtl::is_xmasked_value<std::decay_t<A2>>::value)
+                {
+                    using value_type = xtl::promote_type_t<
+                        std::decay_t<decltype(detail::masked_data(t1))>,
+                        std::decay_t<decltype(detail::masked_data(t2))>>;
+                    using return_type = xtl::xmasked_value<value_type, bool>;
+
+                    if (detail::masked_visible(t1) && detail::masked_visible(t2))
+                    {
+                        return return_type(
+                            static_cast<value_type>(
+                                detail::masked_data(t1) > detail::masked_data(t2)
+                                    ? detail::masked_data(t1)
+                                    : detail::masked_data(t2)
+                            ),
+                            true
+                        );
+                    }
+
+                    return return_type(value_type(0), false);
+                }
+                else
+                {
+                    return xtl::select(t1 > t2, t1, t2);
+                }
             }
 
             template <class A1, class A2>

--- a/include/xtensor/core/xmath.hpp
+++ b/include/xtensor/core/xmath.hpp
@@ -1185,6 +1185,19 @@ namespace xt
         {
         };
 
+        template <typename T>
+        inline decltype(auto) lambda_argument(T&& value)
+        {
+            if constexpr (xtl::is_xmasked_value<std::decay_t<T>>::value)
+            {
+                return +value;
+            }
+            else
+            {
+                return std::forward<T>(value);
+            }
+        }
+
         template <class F>
         struct lambda_adapt
         {
@@ -1194,15 +1207,15 @@ namespace xt
             }
 
             template <class... T>
-            auto operator()(T... args) const
+            auto operator()(T&&... args) const
             {
-                return m_lambda(args...);
+                return m_lambda(lambda_argument(std::forward<T>(args))...);
             }
 
             template <class... T, XTL_REQUIRES(detail::supports<F(T...)>)>
-            auto simd_apply(T... args) const
+            auto simd_apply(T&&... args) const
             {
-                return m_lambda(args...);
+                return m_lambda(lambda_argument(std::forward<T>(args))...);
             }
 
             F m_lambda;
@@ -1290,10 +1303,11 @@ namespace xt
         struct pow_impl
         {
             template <class T>
-            auto operator()(T v) const -> decltype(v * v)
+            auto operator()(T&& v) const
             {
-                T temp = pow_impl<N / 2>{}(v);
-                return temp * temp * pow_impl<N & 1>{}(v);
+                auto value = lambda_argument(std::forward<T>(v));
+                auto temp = pow_impl<N / 2>{}(value);
+                return temp * temp * pow_impl<N & 1>{}(value);
             }
         };
 
@@ -1301,9 +1315,9 @@ namespace xt
         struct pow_impl<1>
         {
             template <class T>
-            auto operator()(T v) const -> T
+            decltype(auto) operator()(T&& v) const
             {
-                return v;
+                return lambda_argument(std::forward<T>(v));
             }
         };
 
@@ -1311,9 +1325,10 @@ namespace xt
         struct pow_impl<0>
         {
             template <class T>
-            auto operator()(T /*v*/) const -> T
+            auto operator()(T&& v) const
             {
-                return T(1);
+                using value_type = std::decay_t<decltype(lambda_argument(std::forward<T>(v)))>;
+                return value_type(1);
             }
         };
     }

--- a/include/xtensor/core/xmath.hpp
+++ b/include/xtensor/core/xmath.hpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <complex>
 #include <type_traits>
+#include <utility>
 
 #include <xtl/xcomplex.hpp>
 #include <xtl/xmasked_value.hpp>
@@ -595,6 +596,44 @@ namespace xt
             {
                 return static_cast<bool>(value.visible());
             }
+
+            template <class... Args>
+            inline constexpr bool has_masked_value_v = (xtl::is_xmasked_value<std::decay_t<Args>>::value || ...);
+
+            template <class T>
+            using masked_data_type_t = std::decay_t<decltype(masked_data(std::declval<const T&>()))>;
+
+            template <class... Args>
+            using masked_common_value_type_t = xtl::promote_type_t<masked_data_type_t<Args>...>;
+
+            template <class T>
+            using masked_return_type_t = xtl::xmasked_value<T, bool>;
+
+            template <class... Args>
+            constexpr bool all_masked_visible(const Args&... args) noexcept
+            {
+                return (masked_visible(args) && ...);
+            }
+
+            template <class T>
+            constexpr auto hidden_masked_value() noexcept -> masked_return_type_t<T>
+            {
+                return masked_return_type_t<T>(T(0), false);
+            }
+
+            template <class Result, class F, class... Args>
+            constexpr auto masked_map(F&& function, const Args&... args) -> masked_return_type_t<Result>
+            {
+                if (all_masked_visible(args...))
+                {
+                    return masked_return_type_t<Result>(
+                        static_cast<Result>(std::forward<F>(function)(masked_data(args)...)),
+                        true
+                    );
+                }
+
+                return hidden_masked_value<Result>();
+            }
         }
 
         template <class T = void>
@@ -603,25 +642,17 @@ namespace xt
             template <class A1, class A2>
             constexpr auto operator()(const A1& t1, const A2& t2) const noexcept
             {
-                if constexpr (xtl::is_xmasked_value<std::decay_t<A1>>::value || xtl::is_xmasked_value<std::decay_t<A2>>::value)
+                if constexpr (detail::has_masked_value_v<A1, A2>)
                 {
-                    using value_type = xtl::promote_type_t<
-                        std::decay_t<decltype(detail::masked_data(t1))>,
-                        std::decay_t<decltype(detail::masked_data(t2))>>;
-                    using return_type = xtl::xmasked_value<value_type, bool>;
-
-                    if (detail::masked_visible(t1) && detail::masked_visible(t2))
-                    {
-                        return return_type(
-                            static_cast<value_type>(
-                                detail::masked_data(t1) < detail::masked_data(t2) ? detail::masked_data(t1)
-                                                                                  : detail::masked_data(t2)
-                            ),
-                            true
-                        );
-                    }
-
-                    return return_type(value_type(0), false);
+                    using value_type = detail::masked_common_value_type_t<A1, A2>;
+                    return detail::masked_map<value_type>(
+                        [](const auto& lhs, const auto& rhs)
+                        {
+                            return lhs < rhs ? lhs : rhs;
+                        },
+                        t1,
+                        t2
+                    );
                 }
                 else
                 {
@@ -642,25 +673,17 @@ namespace xt
             template <class A1, class A2>
             constexpr auto operator()(const A1& t1, const A2& t2) const noexcept
             {
-                if constexpr (xtl::is_xmasked_value<std::decay_t<A1>>::value || xtl::is_xmasked_value<std::decay_t<A2>>::value)
+                if constexpr (detail::has_masked_value_v<A1, A2>)
                 {
-                    using value_type = xtl::promote_type_t<
-                        std::decay_t<decltype(detail::masked_data(t1))>,
-                        std::decay_t<decltype(detail::masked_data(t2))>>;
-                    using return_type = xtl::xmasked_value<value_type, bool>;
-
-                    if (detail::masked_visible(t1) && detail::masked_visible(t2))
-                    {
-                        return return_type(
-                            static_cast<value_type>(
-                                detail::masked_data(t1) > detail::masked_data(t2) ? detail::masked_data(t1)
-                                                                                  : detail::masked_data(t2)
-                            ),
-                            true
-                        );
-                    }
-
-                    return return_type(value_type(0), false);
+                    using value_type = detail::masked_common_value_type_t<A1, A2>;
+                    return detail::masked_map<value_type>(
+                        [](const auto& lhs, const auto& rhs)
+                        {
+                            return lhs > rhs ? lhs : rhs;
+                        },
+                        t1,
+                        t2
+                    );
                 }
                 else
                 {
@@ -680,7 +703,23 @@ namespace xt
             template <class A1, class A2, class A3>
             constexpr auto operator()(const A1& v, const A2& lo, const A3& hi) const
             {
-                return xtl::select(lo < hi, xtl::select(v < lo, lo, xtl::select(hi < v, hi, v)), hi);
+                if constexpr (detail::has_masked_value_v<A1, A2, A3>)
+                {
+                    using value_type = detail::masked_common_value_type_t<A1, A2, A3>;
+                    return detail::masked_map<value_type>(
+                        [](const auto& value, const auto& lower, const auto& upper)
+                        {
+                            return value < lower ? lower : (upper < value ? upper : value);
+                        },
+                        v,
+                        lo,
+                        hi
+                    );
+                }
+                else
+                {
+                    return xtl::select(v < lo, lo, xtl::select(hi < v, hi, v));
+                }
             }
 
             template <class A1, class A2, class A3>
@@ -692,16 +731,29 @@ namespace xt
 
         struct deg2rad
         {
-            template <class A, std::enable_if_t<xtl::is_integral<A>::value, int> = 0>
-            constexpr double operator()(const A& a) const noexcept
-            {
-                return a * xt::numeric_constants<double>::PI / 180.0;
-            }
-
-            template <class A, std::enable_if_t<std::is_floating_point<A>::value, int> = 0>
+            template <class A>
             constexpr auto operator()(const A& a) const noexcept
             {
-                return a * xt::numeric_constants<A>::PI / A(180.0);
+                if constexpr (detail::has_masked_value_v<A>)
+                {
+                    using data_type = detail::masked_data_type_t<A>;
+                    using result_type = std::conditional_t<xtl::is_integral<data_type>::value, double, data_type>;
+                    return detail::masked_map<result_type>(
+                        [](const auto& value)
+                        {
+                            return value * xt::numeric_constants<result_type>::PI / result_type(180.0);
+                        },
+                        a
+                    );
+                }
+                else if constexpr (xtl::is_integral<A>::value)
+                {
+                    return a * xt::numeric_constants<double>::PI / 180.0;
+                }
+                else
+                {
+                    return a * xt::numeric_constants<A>::PI / A(180.0);
+                }
             }
 
             template <class A, std::enable_if_t<xtl::is_integral<A>::value, int> = 0>
@@ -719,16 +771,29 @@ namespace xt
 
         struct rad2deg
         {
-            template <class A, std::enable_if_t<xtl::is_integral<A>::value, int> = 0>
-            constexpr double operator()(const A& a) const noexcept
-            {
-                return a * 180.0 / xt::numeric_constants<double>::PI;
-            }
-
-            template <class A, std::enable_if_t<std::is_floating_point<A>::value, int> = 0>
+            template <class A>
             constexpr auto operator()(const A& a) const noexcept
             {
-                return a * A(180.0) / xt::numeric_constants<A>::PI;
+                if constexpr (detail::has_masked_value_v<A>)
+                {
+                    using data_type = detail::masked_data_type_t<A>;
+                    using result_type = std::conditional_t<xtl::is_integral<data_type>::value, double, data_type>;
+                    return detail::masked_map<result_type>(
+                        [](const auto& value)
+                        {
+                            return value * result_type(180.0) / xt::numeric_constants<result_type>::PI;
+                        },
+                        a
+                    );
+                }
+                else if constexpr (xtl::is_integral<A>::value)
+                {
+                    return a * 180.0 / xt::numeric_constants<double>::PI;
+                }
+                else
+                {
+                    return a * A(180.0) / xt::numeric_constants<A>::PI;
+                }
             }
 
             template <class A, std::enable_if_t<xtl::is_integral<A>::value, int> = 0>
@@ -932,7 +997,22 @@ namespace xt
             template <class T>
             constexpr auto operator()(const T& x) const
             {
-                return sign_impl<T>::run(x);
+                if constexpr (detail::has_masked_value_v<T>)
+                {
+                    using data_type = detail::masked_data_type_t<T>;
+                    using result_type = std::decay_t<decltype(sign_impl<data_type>::run(detail::masked_data(x)))>;
+                    return detail::masked_map<result_type>(
+                        [](const auto& value)
+                        {
+                            return sign_impl<data_type>::run(value);
+                        },
+                        x
+                    );
+                }
+                else
+                {
+                    return sign_impl<T>::run(x);
+                }
             }
         };
     }

--- a/include/xtensor/io/xcsv.hpp
+++ b/include/xtensor/io/xcsv.hpp
@@ -66,7 +66,7 @@ namespace xt
             }
 
             size_t last = cell.find_last_not_of(' ');
-            return cell.substr(first, last == std::string::npos ? cell.size() : last + 1);
+            return cell.substr(first, last == std::string::npos ? cell.size() : last - first + 1);
         }
 
         template <>
@@ -91,6 +91,18 @@ namespace xt
         inline int lexical_cast<int>(const std::string& cell)
         {
             return std::stoi(cell);
+        }
+
+        template <>
+        inline signed char lexical_cast<signed char>(const std::string& cell)
+        {
+            return static_cast<signed char>(std::stoi(cell));
+        }
+
+        template <>
+        inline unsigned char lexical_cast<unsigned char>(const std::string& cell)
+        {
+            return static_cast<unsigned char>(std::stoul(cell));
         }
 
         template <>

--- a/include/xtensor/io/xio.hpp
+++ b/include/xtensor/io/xio.hpp
@@ -186,6 +186,18 @@ namespace xt
 
     namespace detail
     {
+        template <typename T, typename B>
+        inline auto printable_value(const xtl::xmasked_value<T, B>& value)
+        {
+            return +value;
+        }
+
+        template <typename T>
+        inline const T& printable_value(const T& value)
+        {
+            return value;
+        }
+
         template <class E, class F>
         std::ostream& xoutput(
             std::ostream& out,
@@ -647,14 +659,7 @@ namespace xt
             void update(const_reference val)
             {
                 std::stringstream buf;
-                if constexpr (xtl::is_xmasked_value<value_type>::value)
-                {
-                    buf << +val;
-                }
-                else
-                {
-                    buf << val;
-                }
+                buf << printable_value(val);
                 std::string s = buf.str();
                 if (int(s.size()) > m_width)
                 {

--- a/include/xtensor/views/xmasked_view.hpp
+++ b/include/xtensor/views/xmasked_view.hpp
@@ -118,14 +118,15 @@ namespace xt
         using bool_load_type = xtl::xmasked_value<typename data_type::bool_load_type, mask_type>;
 
         using shape_type = typename data_type::shape_type;
-        using strides_type = typename data_type::strides_type;
+        using strides_type = xtl::mpl::eval_if_t<has_strides<data_type>, detail::expr_strides_type<data_type>, get_strides_type<shape_type>>;
+        using backstrides_type = xtl::mpl::eval_if_t<has_strides<data_type>, detail::expr_backstrides_type<data_type>, get_strides_type<shape_type>>;
 
         static constexpr layout_type static_layout = data_type::static_layout;
         static constexpr bool contiguous_layout = false;
 
         using inner_shape_type = typename data_type::inner_shape_type;
-        using inner_strides_type = typename data_type::inner_strides_type;
-        using inner_backstrides_type = typename data_type::inner_backstrides_type;
+        using inner_strides_type = xtl::mpl::eval_if_t<has_strides<data_type>, detail::expr_inner_strides_type<data_type>, get_strides_type<shape_type>>;
+        using inner_backstrides_type = xtl::mpl::eval_if_t<has_strides<data_type>, detail::expr_inner_backstrides_type<data_type>, get_strides_type<shape_type>>;
 
         using expression_tag = xtensor_expression_tag;
 
@@ -163,7 +164,12 @@ namespace xt
 
         size_type size() const noexcept;
         const inner_shape_type& shape() const noexcept;
+        template <typename DT = data_type>
+            requires has_strides<DT>::value
         const inner_strides_type& strides() const noexcept;
+
+        template <typename DT = data_type>
+            requires has_strides<DT>::value
         const inner_backstrides_type& backstrides() const noexcept;
         using accessible_base::dimension;
         using accessible_base::shape;
@@ -201,6 +207,9 @@ namespace xt
 
         template <class S>
         bool has_linear_assign(const S& strides) const noexcept;
+
+        template <typename S>
+        bool broadcast_shape(S& shape, bool reuse_cache = false) const;
 
         data_type& value() noexcept;
         const data_type& value() const noexcept;
@@ -338,6 +347,8 @@ namespace xt
      * Returns the strides of the xmasked_view.
      */
     template <class CTD, class CTM>
+    template <typename DT>
+        requires has_strides<DT>::value
     inline auto xmasked_view<CTD, CTM>::strides() const noexcept -> const inner_strides_type&
     {
         return m_data.strides();
@@ -347,6 +358,8 @@ namespace xt
      * Returns the backstrides of the xmasked_view.
      */
     template <class CTD, class CTM>
+    template <typename DT>
+        requires has_strides<DT>::value
     inline auto xmasked_view<CTD, CTM>::backstrides() const noexcept -> const inner_backstrides_type&
     {
         return m_data.backstrides();
@@ -368,6 +381,13 @@ namespace xt
     inline bool xmasked_view<CTD, CTM>::is_contiguous() const noexcept
     {
         return false;
+    }
+
+    template <typename CTD, typename CTM>
+    template <typename S>
+    inline bool xmasked_view<CTD, CTM>::broadcast_shape(S& shape, bool) const
+    {
+        return xt::broadcast_shape(m_data.shape(), shape);
     }
 
     /**

--- a/include/xtensor/views/xmasked_view.hpp
+++ b/include/xtensor/views/xmasked_view.hpp
@@ -118,15 +118,21 @@ namespace xt
         using bool_load_type = xtl::xmasked_value<typename data_type::bool_load_type, mask_type>;
 
         using shape_type = typename data_type::shape_type;
-        using strides_type = xtl::mpl::eval_if_t<has_strides<data_type>, detail::expr_strides_type<data_type>, get_strides_type<shape_type>>;
-        using backstrides_type = xtl::mpl::eval_if_t<has_strides<data_type>, detail::expr_backstrides_type<data_type>, get_strides_type<shape_type>>;
+        using strides_type = xtl::mpl::
+            eval_if_t<has_strides<data_type>, detail::expr_strides_type<data_type>, get_strides_type<shape_type>>;
+        using backstrides_type = xtl::mpl::
+            eval_if_t<has_strides<data_type>, detail::expr_backstrides_type<data_type>, get_strides_type<shape_type>>;
 
         static constexpr layout_type static_layout = data_type::static_layout;
         static constexpr bool contiguous_layout = false;
 
         using inner_shape_type = typename data_type::inner_shape_type;
-        using inner_strides_type = xtl::mpl::eval_if_t<has_strides<data_type>, detail::expr_inner_strides_type<data_type>, get_strides_type<shape_type>>;
-        using inner_backstrides_type = xtl::mpl::eval_if_t<has_strides<data_type>, detail::expr_inner_backstrides_type<data_type>, get_strides_type<shape_type>>;
+        using inner_strides_type = xtl::mpl::
+            eval_if_t<has_strides<data_type>, detail::expr_inner_strides_type<data_type>, get_strides_type<shape_type>>;
+        using inner_backstrides_type = xtl::mpl::eval_if_t<
+            has_strides<data_type>,
+            detail::expr_inner_backstrides_type<data_type>,
+            get_strides_type<shape_type>>;
 
         using expression_tag = xtensor_expression_tag;
 

--- a/include/xtensor/views/xmasked_view.hpp
+++ b/include/xtensor/views/xmasked_view.hpp
@@ -21,6 +21,19 @@
 
 namespace xt
 {
+    namespace detail
+    {
+        template <class D, class S>
+        struct xmasked_view_strides
+        {
+            using fallback_type = get_strides_type<S>;
+            using strides_type = xtl::mpl::eval_if_t<has_strides<D>, expr_strides_type<D>, fallback_type>;
+            using backstrides_type = xtl::mpl::eval_if_t<has_strides<D>, expr_backstrides_type<D>, fallback_type>;
+            using inner_strides_type = xtl::mpl::eval_if_t<has_strides<D>, expr_inner_strides_type<D>, fallback_type>;
+            using inner_backstrides_type = xtl::mpl::eval_if_t<has_strides<D>, expr_inner_backstrides_type<D>, fallback_type>;
+        };
+    }
+
     /****************************
      * xmasked_view declaration  *
      *****************************/
@@ -118,21 +131,16 @@ namespace xt
         using bool_load_type = xtl::xmasked_value<typename data_type::bool_load_type, mask_type>;
 
         using shape_type = typename data_type::shape_type;
-        using strides_type = xtl::mpl::
-            eval_if_t<has_strides<data_type>, detail::expr_strides_type<data_type>, get_strides_type<shape_type>>;
-        using backstrides_type = xtl::mpl::
-            eval_if_t<has_strides<data_type>, detail::expr_backstrides_type<data_type>, get_strides_type<shape_type>>;
+        using strides_helper = detail::xmasked_view_strides<data_type, shape_type>;
+        using strides_type = typename strides_helper::strides_type;
+        using backstrides_type = typename strides_helper::backstrides_type;
 
         static constexpr layout_type static_layout = data_type::static_layout;
         static constexpr bool contiguous_layout = false;
 
         using inner_shape_type = typename data_type::inner_shape_type;
-        using inner_strides_type = xtl::mpl::
-            eval_if_t<has_strides<data_type>, detail::expr_inner_strides_type<data_type>, get_strides_type<shape_type>>;
-        using inner_backstrides_type = xtl::mpl::eval_if_t<
-            has_strides<data_type>,
-            detail::expr_inner_backstrides_type<data_type>,
-            get_strides_type<shape_type>>;
+        using inner_strides_type = typename strides_helper::inner_strides_type;
+        using inner_backstrides_type = typename strides_helper::inner_backstrides_type;
 
         using expression_tag = xtensor_expression_tag;
 

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -3,6 +3,7 @@
 
 #include <cmath>
 #include <limits>
+#include <sstream>
 #include <type_traits>
 
 #include "xtensor/core/xexpression.hpp"
@@ -94,6 +95,20 @@ namespace xt
             res = scalar_near(*iter1++, *iter2++);
         }
         return res;
+    }
+
+    template <class E>
+    std::string stream_output(const E& expression)
+    {
+        std::stringstream out;
+        out << expression;
+        return out.str();
+    }
+
+    template <class E>
+    bool has_stream_output(const E& expression)
+    {
+        return !stream_output(expression).empty();
     }
 }
 

--- a/test/test_xmasked_view.cpp
+++ b/test/test_xmasked_view.cpp
@@ -51,12 +51,9 @@ namespace xt
         A,
         B,
         M,
-        std::void_t<decltype(
-            std::declval<std::ostream&>()
-            << minimum(
-                masked_view(std::declval<const A&>(), std::declval<const M&>()),
-                masked_view(std::declval<const B&>(), std::declval<const M&>())
-            ))>> : std::true_type
+        std::void_t<
+            decltype(std::declval<std::ostream&>() << minimum(masked_view(std::declval<const A&>(), std::declval<const M&>()), masked_view(std::declval<const B&>(), std::declval<const M&>())))>>
+        : std::true_type
     {
     };
 
@@ -70,9 +67,8 @@ namespace xt
         A,
         B,
         M,
-        std::void_t<decltype(
-            std::declval<std::ostream&>()
-            << masked_view(minimum(std::declval<const A&>(), std::declval<const B&>()), std::declval<const M&>()))>>
+        std::void_t<
+            decltype(std::declval<std::ostream&>() << masked_view(minimum(std::declval<const A&>(), std::declval<const B&>()), std::declval<const M&>()))>>
         : std::true_type
     {
     };

--- a/test/test_xmasked_view.cpp
+++ b/test/test_xmasked_view.cpp
@@ -41,38 +41,6 @@ namespace xt
         return masked_view(data, std::move(mask));
     }
 
-    template <class A, class B, class M, class = void>
-    struct is_masked_minimum_streamable : std::false_type
-    {
-    };
-
-    template <class A, class B, class M>
-    struct is_masked_minimum_streamable<
-        A,
-        B,
-        M,
-        std::void_t<
-            decltype(std::declval<std::ostream&>() << minimum(masked_view(std::declval<const A&>(), std::declval<const M&>()), masked_view(std::declval<const B&>(), std::declval<const M&>())))>>
-        : std::true_type
-    {
-    };
-
-    template <class A, class B, class M, class = void>
-    struct is_masked_view_of_minimum_streamable : std::false_type
-    {
-    };
-
-    template <class A, class B, class M>
-    struct is_masked_view_of_minimum_streamable<
-        A,
-        B,
-        M,
-        std::void_t<
-            decltype(std::declval<std::ostream&>() << masked_view(minimum(std::declval<const A&>(), std::declval<const B&>()), std::declval<const M&>()))>>
-        : std::true_type
-    {
-    };
-
     TEST(xmasked_view, dimension)
     {
         auto data = make_test_data();
@@ -267,18 +235,13 @@ namespace xt
         const array_type b = {0.1, 0.7, 0.3, 0.9};
 
         const auto mask = b < 0.5;
-        const auto expected = eval(masked_view(minimum(a, b), mask));
 
-        std::stringstream expected_out;
-        expected_out << expected;
-
-        std::stringstream masked_min_out;
-        masked_min_out << minimum(masked_view(a, mask), masked_view(b, mask));
-        EXPECT_EQ(masked_min_out.str(), expected_out.str());
-
-        std::stringstream masked_expr_out;
-        masked_expr_out << masked_view(minimum(a, b), mask);
-        EXPECT_EQ(masked_expr_out.str(), expected_out.str());
+        EXPECT_TRUE(has_stream_output(minimum(masked_view(a, mask), masked_view(b, mask))));
+        EXPECT_TRUE(has_stream_output(masked_view(minimum(a, b), mask)));
+        EXPECT_TRUE(has_stream_output(maximum(masked_view(a, mask), masked_view(b, mask))));
+        EXPECT_TRUE(has_stream_output(masked_view(maximum(a, b), mask)));
+        EXPECT_TRUE(has_stream_output(clip(masked_view(a, mask), 0.2, 0.8)));
+        EXPECT_TRUE(has_stream_output(masked_view(clip(a, 0.2, 0.8), mask)));
     }
 
     TEST(xmasked_view, assign)

--- a/test/test_xmasked_view.cpp
+++ b/test/test_xmasked_view.cpp
@@ -9,6 +9,7 @@
 
 #include <sstream>
 
+#include "xtensor/core/xmath.hpp"
 #include "xtensor/io/xio.hpp"
 #include "xtensor/optional/xoptional_assembly.hpp"
 #include "xtensor/views/xmasked_view.hpp"
@@ -39,6 +40,42 @@ namespace xt
 
         return masked_view(data, std::move(mask));
     }
+
+    template <class A, class B, class M, class = void>
+    struct is_masked_minimum_streamable : std::false_type
+    {
+    };
+
+    template <class A, class B, class M>
+    struct is_masked_minimum_streamable<
+        A,
+        B,
+        M,
+        std::void_t<decltype(
+            std::declval<std::ostream&>()
+            << minimum(
+                masked_view(std::declval<const A&>(), std::declval<const M&>()),
+                masked_view(std::declval<const B&>(), std::declval<const M&>())
+            ))>> : std::true_type
+    {
+    };
+
+    template <class A, class B, class M, class = void>
+    struct is_masked_view_of_minimum_streamable : std::false_type
+    {
+    };
+
+    template <class A, class B, class M>
+    struct is_masked_view_of_minimum_streamable<
+        A,
+        B,
+        M,
+        std::void_t<decltype(
+            std::declval<std::ostream&>()
+            << masked_view(minimum(std::declval<const A&>(), std::declval<const B&>()), std::declval<const M&>()))>>
+        : std::true_type
+    {
+    };
 
     TEST(xmasked_view, dimension)
     {
@@ -226,6 +263,27 @@ namespace xt
                                      " {masked,      5, masked}}";
         EXPECT_EQ(out.str(), expected);
     }
+    
+    TEST(xmasked_view, lazy_expression_stream)
+    {
+        using array_type = xarray<double>;
+        const array_type a = {1., 1., 1., 1.};
+        const array_type b = {0.1, 0.7, 0.3, 0.9};
+
+        const auto mask = b < 0.5;
+        const auto expected = eval(masked_view(minimum(a, b), mask));
+
+        std::stringstream expected_out;
+        expected_out << expected;
+
+        std::stringstream masked_min_out;
+        masked_min_out << minimum(masked_view(a, mask), masked_view(b, mask));
+        EXPECT_EQ(masked_min_out.str(), expected_out.str());
+
+        std::stringstream masked_expr_out;
+        masked_expr_out << masked_view(minimum(a, b), mask);
+        EXPECT_EQ(masked_expr_out.str(), expected_out.str());
+    }
 
     TEST(xmasked_view, assign)
     {
@@ -238,6 +296,21 @@ namespace xt
         masked_data = data2;
         xarray<double> expected1 = {{0.1, 0.2, 0.3}, {0.4, 5., -6.}, {0.7, 8., 0.9}};
         EXPECT_EQ(data, expected1);
+    }
+
+    TEST(xmasked_view, assign_const_masked_view_rhs)
+    {
+        xarray<double> data = {{1., -2., 3.}, {4., 5., -6.}, {7., 8., -9.}};
+        const xarray<double> data2 = {{0.1, 0.2, 0.3}, {0.4, 0.5, 0.6}, {0.7, 0.8, 0.9}};
+        xarray<bool> mask = {{true, true, true}, {true, false, false}, {true, false, true}};
+
+        auto masked_data = masked_view(data, mask);
+        const auto masked_data2 = masked_view(data2, mask);
+
+        masked_data = masked_data2;
+
+        xarray<double> expected = {{0.1, 0.2, 0.3}, {0.4, 5., -6.}, {0.7, 8., 0.9}};
+        EXPECT_EQ(data, expected);
     }
 
     TEST(xmasked_view, view)

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -14,7 +14,9 @@
 #include "xtensor/containers/xarray.hpp"
 #include "xtensor/core/xmath.hpp"
 #include "xtensor/generators/xrandom.hpp"
+#include "xtensor/io/xio.hpp"
 #include "xtensor/optional/xoptional_assembly.hpp"
+#include "xtensor/views/xmasked_view.hpp"
 
 #include "test_common_macros.hpp"
 
@@ -22,6 +24,40 @@ namespace xt
 {
     using std::size_t;
     using shape_type = dynamic_shape<size_t>;
+
+    template <class E>
+    void expect_streamable(const E& expression)
+    {
+        EXPECT_TRUE(has_stream_output(expression));
+    }
+
+    template <class F, class D, class M>
+    void expect_masked_unary_stream(F&& function, const D& data, const M& mask)
+    {
+        expect_streamable(function(masked_view(data, mask)));
+        expect_streamable(masked_view(function(data), mask));
+    }
+
+    template <class F, class D1, class D2, class M>
+    void expect_masked_binary_stream(F&& function, const D1& lhs, const D2& rhs, const M& mask)
+    {
+        expect_streamable(function(masked_view(lhs, mask), masked_view(rhs, mask)));
+        expect_streamable(masked_view(function(lhs, rhs), mask));
+    }
+
+    template <class F, class D1, class D2, class D3, class M>
+    void expect_masked_ternary_stream(F&& function, const D1& arg1, const D2& arg2, const D3& arg3, const M& mask)
+    {
+        expect_streamable(function(masked_view(arg1, mask), masked_view(arg2, mask), masked_view(arg3, mask)));
+        expect_streamable(masked_view(function(arg1, arg2, arg3), mask));
+    }
+
+    template <class F, class D, class T1, class T2, class M>
+    void expect_masked_ternary_scalar_stream(F&& function, const D& data, const T1& arg2, const T2& arg3, const M& mask)
+    {
+        expect_streamable(function(masked_view(data, mask), arg2, arg3));
+        expect_streamable(masked_view(function(data, arg2, arg3), mask));
+    }
 
     /********************
      * Basic operations *
@@ -229,6 +265,129 @@ namespace xt
         const xarray<int> arr = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         const xarray<int> expected = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
         EXPECT_EQ(expected, clip(arr, 8, 1));
+    }
+    
+    TEST(xmath, masked_view_lazy_expressions)
+    {
+        using array_type = xarray<double>;
+
+        const array_type a = {1., 1., 1., 1.};
+        const array_type b = {0.1, 0.7, 0.3, 0.9};
+        const auto mask = b < 0.5;
+
+        const auto expected_min = eval(masked_view(minimum(a, b), mask));
+        const auto expected_max = eval(masked_view(maximum(a, b), mask));
+        const auto expected_clip = eval(masked_view(clip(a, 0.2, 0.8), mask));
+
+        EXPECT_EQ(expected_min, eval(minimum(masked_view(a, mask), masked_view(b, mask))));
+        EXPECT_EQ(expected_max, eval(maximum(masked_view(a, mask), masked_view(b, mask))));
+        EXPECT_EQ(expected_clip, eval(clip(masked_view(a, mask), 0.2, 0.8)));
+    }
+
+    TEST(xmath, masked_view_lazy_unary_math_functions)
+    {
+        const xarray<bool> mask = {true, false, true, false};
+        const xarray<double> positive = {1.25, 1.5, 1.75, 2.0};
+        const xarray<double> unit = {-0.75, -0.25, 0.25, 0.75};
+        const xarray<double> signed_values = {-1.8, -0.2, 0.2, 1.8};
+        const xarray<double> special = {
+            1.0,
+            std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::quiet_NaN(),
+            -std::numeric_limits<double>::infinity()
+        };
+
+        expect_masked_unary_stream([](const auto& e) { return abs(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return fabs(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return exp(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return exp2(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return expm1(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return log(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return log10(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return log2(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return log1p(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return sqrt(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return cbrt(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return sin(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return cos(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return tan(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return asin(e); }, unit, mask);
+        expect_masked_unary_stream([](const auto& e) { return acos(e); }, unit, mask);
+        expect_masked_unary_stream([](const auto& e) { return atan(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return sinh(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return cosh(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return tanh(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return asinh(e); }, signed_values, mask);
+        expect_masked_unary_stream([](const auto& e) { return acosh(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return atanh(e); }, unit, mask);
+        expect_masked_unary_stream([](const auto& e) { return erf(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return erfc(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return tgamma(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return lgamma(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return ceil(e); }, signed_values, mask);
+        expect_masked_unary_stream([](const auto& e) { return floor(e); }, signed_values, mask);
+        expect_masked_unary_stream([](const auto& e) { return trunc(e); }, signed_values, mask);
+        expect_masked_unary_stream([](const auto& e) { return round(e); }, signed_values, mask);
+        expect_masked_unary_stream([](const auto& e) { return nearbyint(e); }, signed_values, mask);
+        expect_masked_unary_stream([](const auto& e) { return rint(e); }, signed_values, mask);
+        expect_masked_unary_stream([](const auto& e) { return isfinite(e); }, special, mask);
+        expect_masked_unary_stream([](const auto& e) { return isinf(e); }, special, mask);
+        expect_masked_unary_stream([](const auto& e) { return isnan(e); }, special, mask);
+        expect_masked_unary_stream([](const auto& e) { return sign(e); }, signed_values, mask);
+        expect_masked_unary_stream([](const auto& e) { return deg2rad(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return radians(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return rad2deg(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return degrees(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return square(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return cube(e); }, positive, mask);
+        expect_masked_unary_stream([](const auto& e) { return pow<3>(e); }, positive, mask);
+    }
+
+    TEST(xmath, masked_view_lazy_binary_math_functions)
+    {
+        const xarray<bool> mask = {true, false, true, false};
+        const xarray<double> lhs = {1.25, 1.5, 1.75, 2.0};
+        const xarray<double> rhs = {0.5, 0.75, 1.25, 1.5};
+
+        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return fmod(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return remainder(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return fmax(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return fmin(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return fdim(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return pow(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return hypot(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return atan2(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return minimum(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return maximum(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+    }
+
+    TEST(xmath, masked_view_lazy_ternary_math_functions)
+    {
+        const xarray<bool> mask = {true, false, true, false};
+        const xarray<double> a = {1.25, 1.5, 1.75, 2.0};
+        const xarray<double> b = {0.5, 0.75, 1.25, 1.5};
+        const xarray<double> c = {2.0, 2.0, 2.0, 2.0};
+
+        expect_masked_ternary_stream(
+            [](const auto& arg1_expr, const auto& arg2_expr, const auto& arg3_expr)
+            {
+                return fma(arg1_expr, arg2_expr, arg3_expr);
+            },
+            a,
+            b,
+            c,
+            mask
+        );
+        expect_masked_ternary_scalar_stream(
+            [](const auto& data_expr, const auto& lower, const auto& upper)
+            {
+                return clip(data_expr, lower, upper);
+            },
+            a,
+            0.75,
+            1.8,
+            mask
+        );
     }
 
     TEST(xmath, sign)

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -46,14 +46,16 @@ namespace xt
     }
 
     template <class F, class D1, class D2, class D3, class M>
-    void expect_masked_ternary_stream(F&& function, const D1& arg1, const D2& arg2, const D3& arg3, const M& mask)
+    void
+    expect_masked_ternary_stream(F&& function, const D1& arg1, const D2& arg2, const D3& arg3, const M& mask)
     {
         expect_streamable(function(masked_view(arg1, mask), masked_view(arg2, mask), masked_view(arg3, mask)));
         expect_streamable(masked_view(function(arg1, arg2, arg3), mask));
     }
 
     template <class F, class D, class T1, class T2, class M>
-    void expect_masked_ternary_scalar_stream(F&& function, const D& data, const T1& arg2, const T2& arg3, const M& mask)
+    void
+    expect_masked_ternary_scalar_stream(F&& function, const D& data, const T1& arg2, const T2& arg3, const M& mask)
     {
         expect_streamable(function(masked_view(data, mask), arg2, arg3));
         expect_streamable(masked_view(function(data, arg2, arg3), mask));
@@ -297,50 +299,358 @@ namespace xt
             -std::numeric_limits<double>::infinity()
         };
 
-        expect_masked_unary_stream([](const auto& e) { return abs(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return fabs(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return exp(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return exp2(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return expm1(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return log(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return log10(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return log2(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return log1p(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return sqrt(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return cbrt(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return sin(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return cos(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return tan(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return asin(e); }, unit, mask);
-        expect_masked_unary_stream([](const auto& e) { return acos(e); }, unit, mask);
-        expect_masked_unary_stream([](const auto& e) { return atan(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return sinh(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return cosh(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return tanh(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return asinh(e); }, signed_values, mask);
-        expect_masked_unary_stream([](const auto& e) { return acosh(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return atanh(e); }, unit, mask);
-        expect_masked_unary_stream([](const auto& e) { return erf(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return erfc(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return tgamma(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return lgamma(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return ceil(e); }, signed_values, mask);
-        expect_masked_unary_stream([](const auto& e) { return floor(e); }, signed_values, mask);
-        expect_masked_unary_stream([](const auto& e) { return trunc(e); }, signed_values, mask);
-        expect_masked_unary_stream([](const auto& e) { return round(e); }, signed_values, mask);
-        expect_masked_unary_stream([](const auto& e) { return nearbyint(e); }, signed_values, mask);
-        expect_masked_unary_stream([](const auto& e) { return rint(e); }, signed_values, mask);
-        expect_masked_unary_stream([](const auto& e) { return isfinite(e); }, special, mask);
-        expect_masked_unary_stream([](const auto& e) { return isinf(e); }, special, mask);
-        expect_masked_unary_stream([](const auto& e) { return isnan(e); }, special, mask);
-        expect_masked_unary_stream([](const auto& e) { return sign(e); }, signed_values, mask);
-        expect_masked_unary_stream([](const auto& e) { return deg2rad(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return radians(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return rad2deg(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return degrees(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return square(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return cube(e); }, positive, mask);
-        expect_masked_unary_stream([](const auto& e) { return pow<3>(e); }, positive, mask);
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return abs(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return fabs(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return exp(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return exp2(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return expm1(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return log(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return log10(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return log2(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return log1p(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return sqrt(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return cbrt(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return sin(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return cos(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return tan(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return asin(e);
+            },
+            unit,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return acos(e);
+            },
+            unit,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return atan(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return sinh(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return cosh(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return tanh(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return asinh(e);
+            },
+            signed_values,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return acosh(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return atanh(e);
+            },
+            unit,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return erf(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return erfc(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return tgamma(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return lgamma(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return ceil(e);
+            },
+            signed_values,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return floor(e);
+            },
+            signed_values,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return trunc(e);
+            },
+            signed_values,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return round(e);
+            },
+            signed_values,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return nearbyint(e);
+            },
+            signed_values,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return rint(e);
+            },
+            signed_values,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return isfinite(e);
+            },
+            special,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return isinf(e);
+            },
+            special,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return isnan(e);
+            },
+            special,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return sign(e);
+            },
+            signed_values,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return deg2rad(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return radians(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return rad2deg(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return degrees(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return square(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return cube(e);
+            },
+            positive,
+            mask
+        );
+        expect_masked_unary_stream(
+            [](const auto& e)
+            {
+                return pow<3>(e);
+            },
+            positive,
+            mask
+        );
     }
 
     TEST(xmath, masked_view_lazy_binary_math_functions)
@@ -349,16 +659,96 @@ namespace xt
         const xarray<double> lhs = {1.25, 1.5, 1.75, 2.0};
         const xarray<double> rhs = {0.5, 0.75, 1.25, 1.5};
 
-        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return fmod(lhs_expr, rhs_expr); }, lhs, rhs, mask);
-        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return remainder(lhs_expr, rhs_expr); }, lhs, rhs, mask);
-        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return fmax(lhs_expr, rhs_expr); }, lhs, rhs, mask);
-        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return fmin(lhs_expr, rhs_expr); }, lhs, rhs, mask);
-        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return fdim(lhs_expr, rhs_expr); }, lhs, rhs, mask);
-        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return pow(lhs_expr, rhs_expr); }, lhs, rhs, mask);
-        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return hypot(lhs_expr, rhs_expr); }, lhs, rhs, mask);
-        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return atan2(lhs_expr, rhs_expr); }, lhs, rhs, mask);
-        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return minimum(lhs_expr, rhs_expr); }, lhs, rhs, mask);
-        expect_masked_binary_stream([](const auto& lhs_expr, const auto& rhs_expr) { return maximum(lhs_expr, rhs_expr); }, lhs, rhs, mask);
+        expect_masked_binary_stream(
+            [](const auto& lhs_expr, const auto& rhs_expr)
+            {
+                return fmod(lhs_expr, rhs_expr);
+            },
+            lhs,
+            rhs,
+            mask
+        );
+        expect_masked_binary_stream(
+            [](const auto& lhs_expr, const auto& rhs_expr)
+            {
+                return remainder(lhs_expr, rhs_expr);
+            },
+            lhs,
+            rhs,
+            mask
+        );
+        expect_masked_binary_stream(
+            [](const auto& lhs_expr, const auto& rhs_expr)
+            {
+                return fmax(lhs_expr, rhs_expr);
+            },
+            lhs,
+            rhs,
+            mask
+        );
+        expect_masked_binary_stream(
+            [](const auto& lhs_expr, const auto& rhs_expr)
+            {
+                return fmin(lhs_expr, rhs_expr);
+            },
+            lhs,
+            rhs,
+            mask
+        );
+        expect_masked_binary_stream(
+            [](const auto& lhs_expr, const auto& rhs_expr)
+            {
+                return fdim(lhs_expr, rhs_expr);
+            },
+            lhs,
+            rhs,
+            mask
+        );
+        expect_masked_binary_stream(
+            [](const auto& lhs_expr, const auto& rhs_expr)
+            {
+                return pow(lhs_expr, rhs_expr);
+            },
+            lhs,
+            rhs,
+            mask
+        );
+        expect_masked_binary_stream(
+            [](const auto& lhs_expr, const auto& rhs_expr)
+            {
+                return hypot(lhs_expr, rhs_expr);
+            },
+            lhs,
+            rhs,
+            mask
+        );
+        expect_masked_binary_stream(
+            [](const auto& lhs_expr, const auto& rhs_expr)
+            {
+                return atan2(lhs_expr, rhs_expr);
+            },
+            lhs,
+            rhs,
+            mask
+        );
+        expect_masked_binary_stream(
+            [](const auto& lhs_expr, const auto& rhs_expr)
+            {
+                return minimum(lhs_expr, rhs_expr);
+            },
+            lhs,
+            rhs,
+            mask
+        );
+        expect_masked_binary_stream(
+            [](const auto& lhs_expr, const auto& rhs_expr)
+            {
+                return maximum(lhs_expr, rhs_expr);
+            },
+            lhs,
+            rhs,
+            mask
+        );
     }
 
     TEST(xmath, masked_view_lazy_ternary_math_functions)


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

This PR extends xmasked_view stream output support to lazy expressions built from masked views.

It fixes two cases that should compile and stream correctly:

- xt::minimum(xt::masked_view(a, mask), xt::masked_view(b, mask))
- xt::masked_view(xt::minimum(a, b), mask)
