### PR TITLE
Fix CSV reader to handle 8-bit integers

### DIFF
--- a/include/xtensor/io/xcsv.hpp
+++ b/include/xtensor/io/xcsv.hpp
@@ -66,7 +66,7 @@ namespace xt
             }
 
             size_t last = cell.find_last_not_of(' ');
-            return cell.substr(first, last == std::string::npos ? cell.size() : last + 1);
+            return cell.substr(first, last == std::string::npos ? cell.size() : last - first + 1);
         }
 
         template <>
@@ -91,6 +91,18 @@ namespace xt
         inline int lexical_cast<int>(const std::string& cell)
         {
             return std::stoi(cell);
+        }
+
+        template <>
+        inline signed char lexical_cast<signed char>(const std::string& cell)
+        {
+            return static_cast<signed char>(std::stoi(cell));
+        }
+
+        template <>
+        inline unsigned char lexical_cast<unsigned char>(const std::string& cell)
+        {
+            return static_cast<unsigned char>(std::stoul(cell));
         }
 
         template <>

--- a/test/test_xcsv.cpp
+++ b/test/test_xcsv.cpp
@@ -43,6 +43,20 @@ namespace xt
         ASSERT_TRUE(all(equal(res, exp)));
     }
 
+    TEST(xcsv, load_binary_matrix)
+    {
+        const std::string source = "1,0,1\n"
+                                   "0,1,1";
+
+        std::stringstream source_stream(source);
+
+        const xtensor<uint8_t, 2> res = load_csv<uint8_t>(source_stream);
+
+        const xtensor<uint8_t, 2> exp{{1, 0, 1}, {0, 1, 1}};
+
+        ASSERT_TRUE(all(equal(res, exp)));
+    }
+
     TEST(xcsv, load_double_with_options)
     {
         std::string source = "A B C D\n"
@@ -58,6 +72,56 @@ namespace xt
         xtensor<double, 2> exp{{1.0, 2.0, 3.0, 4.0}, {10.0, 12.0, 15.0, 18.0}};
 
         ASSERT_TRUE(all(equal(res, exp)));
+    }
+
+    TEST(xcsv, load_string_trims_cells)
+    {
+        const std::string source = "  alpha  , beta,gamma   \n delta,  epsilon , zeta  ";
+
+        std::stringstream source_stream(source);
+
+        const xtensor<std::string, 2> res = load_csv<std::string>(source_stream);
+
+        ASSERT_EQ(res.shape()[0], std::size_t(2));
+        ASSERT_EQ(res.shape()[1], std::size_t(3));
+        ASSERT_EQ(res(0, 0), "alpha");
+        ASSERT_EQ(res(0, 1), "beta");
+        ASSERT_EQ(res(0, 2), "gamma");
+        ASSERT_EQ(res(1, 0), "delta");
+        ASSERT_EQ(res(1, 1), "epsilon");
+        ASSERT_EQ(res(1, 2), "zeta");
+    }
+
+    TEST(xcsv, load_file_uses_config)
+    {
+        const std::string source = "metadata\n"
+                                   "//ignore this row\n"
+                                   "1;2;3\n"
+                                   "4;5;6\n"
+                                   "7;8;9";
+
+        std::stringstream source_stream(source);
+        xcsv_config config;
+        config.delimiter = ';';
+        config.skip_rows = 1;
+        config.max_rows = 2;
+        config.comments = "//";
+
+        xtensor<int, 2> res = {{0, 0, 0}};
+        load_file(source_stream, res, config);
+
+        const xtensor<int, 2> exp{{1, 2, 3}, {4, 5, 6}};
+
+        ASSERT_TRUE(all(equal(res, exp)));
+    }
+
+    TEST(xcsv, load_inconsistent_rows_throws)
+    {
+        const std::string source = "1,2,3\n4,5";
+
+        std::stringstream source_stream(source);
+
+        XT_EXPECT_THROW(load_csv<int>(source_stream), std::runtime_error);
     }
 
     TEST(xcsv, dump_1D)
@@ -78,5 +142,24 @@ namespace xt
 
         dump_csv(res, data);
         ASSERT_EQ("1,2,3,4\n10,12,15,18\n", res.str());
+    }
+
+    TEST(xcsv, dump_file_matches_dump_csv)
+    {
+        xtensor<int, 2> data{{1, 2}, {3, 4}};
+        std::stringstream res;
+        xcsv_config config;
+
+        dump_file(res, data, config);
+
+        ASSERT_EQ("1,2\n3,4\n", res.str());
+    }
+
+    TEST(xcsv, dump_higher_dimension_throws)
+    {
+        xtensor<double, 3> data{{{1.0, 2.0}, {3.0, 4.0}}};
+        std::stringstream res;
+
+        XT_EXPECT_THROW(dump_csv(res, data), std::runtime_error);
     }
 }


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Address #2453

This PR fixes `xcsv` parsing for 8-bit integer types and adds focused test coverage around CSV load and dump behavior.

- fix `lexical_cast` for `signed char` and `unsigned char` so CSV values like `0` and `1` are parsed numerically instead of through character extraction
- fix string cell trimming so leading and trailing spaces are removed correctly
