### PR TITLE
Prevent buffer overflow when assigning to fixed-dimension xtensor with mismatched rank

### DIFF
--- a/include/xtensor/containers/xcontainer.hpp
+++ b/include/xtensor/containers/xcontainer.hpp
@@ -997,10 +997,10 @@ namespace xt
     template <class S>
     inline void xstrided_container<D>::resize(S&& shape, bool force)
     {
-        XTENSOR_ASSERT_MSG(
+        XTENSOR_PRECONDITION(
             detail::check_resize_dimension(m_shape, shape),
             "cannot change the number of dimensions of xtensor"
-        )
+        );
         std::size_t dim = shape.size();
         if (m_shape.size() != dim || !std::equal(std::begin(shape), std::end(shape), std::begin(m_shape))
             || force)

--- a/include/xtensor/io/xcsv.hpp
+++ b/include/xtensor/io/xcsv.hpp
@@ -66,7 +66,7 @@ namespace xt
             }
 
             size_t last = cell.find_last_not_of(' ');
-            return cell.substr(first, last == std::string::npos ? cell.size() : last + 1);
+            return cell.substr(first, last == std::string::npos ? cell.size() : last - first + 1);
         }
 
         template <>
@@ -91,6 +91,18 @@ namespace xt
         inline int lexical_cast<int>(const std::string& cell)
         {
             return std::stoi(cell);
+        }
+
+        template <>
+        inline signed char lexical_cast<signed char>(const std::string& cell)
+        {
+            return static_cast<signed char>(std::stoi(cell));
+        }
+
+        template <>
+        inline unsigned char lexical_cast<unsigned char>(const std::string& cell)
+        {
+            return static_cast<unsigned char>(std::stoul(cell));
         }
 
         template <>

--- a/test/test_xassign.cpp
+++ b/test/test_xassign.cpp
@@ -15,6 +15,7 @@
 #include "xtensor/containers/xtensor.hpp"
 #include "xtensor/core/xassign.hpp"
 #include "xtensor/core/xnoalias.hpp"
+#include "xtensor/misc/xmanipulation.hpp"
 
 #include "test_common.hpp"
 #include "test_common_macros.hpp"
@@ -166,5 +167,11 @@ namespace xt
             EXPECT_EQ(a.shape(0), 2);
             EXPECT_EQ(a.shape(1), 3);
         }
+    }
+
+    TEST(xassign, fixed_dimension_mismatch)
+    {
+        auto a = xt::xtensor<float, 1>::from_shape({2});
+        XT_ASSERT_THROW(a = xt::expand_dims(a, 0), std::runtime_error);
     }
 }


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Addressing https://github.com/xtensor-stack/xtensor/issues/2792

Assigning a higher-dimensional expression to a fixed-rank [xtensor<T, N>] caused a buffer overflow (stack smashing) in release builds:

```c++
auto a = xt::xtensor<float, 1>::from_shape({2});
a = xt::expand_dims(a, 0);  // expand_dims returns 2D view, shape {1, 2}
// buffer overflow: resize truncates shape {1,2} -> {1}, then copies 2 elements into 1 element buffer
```