### PR TITLE
Fix clip function behavior when a_min is greater than a_max

### DIFF
--- a/include/xtensor/core/xmath.hpp
+++ b/include/xtensor/core/xmath.hpp
@@ -606,13 +606,13 @@ namespace xt
             template <class A1, class A2, class A3>
             constexpr auto operator()(const A1& v, const A2& lo, const A3& hi) const
             {
-                return xtl::select(v < lo, lo, xtl::select(hi < v, hi, v));
+                return xtl::select(lo < hi, xtl::select(v < lo, lo, xtl::select(hi < v, hi, v)), hi);
             }
 
             template <class A1, class A2, class A3>
             constexpr auto simd_apply(const A1& v, const A2& lo, const A3& hi) const
             {
-                return xt_simd::select(v < lo, lo, xt_simd::select(hi < v, hi, v));
+                return xt_simd::select(lo < hi, xt_simd::select(v < lo, lo, xt_simd::select(hi < v, hi, v)), hi);
             }
         };
 

--- a/include/xtensor/io/xcsv.hpp
+++ b/include/xtensor/io/xcsv.hpp
@@ -66,7 +66,7 @@ namespace xt
             }
 
             size_t last = cell.find_last_not_of(' ');
-            return cell.substr(first, last == std::string::npos ? cell.size() : last + 1);
+            return cell.substr(first, last == std::string::npos ? cell.size() : last - first + 1);
         }
 
         template <>
@@ -91,6 +91,18 @@ namespace xt
         inline int lexical_cast<int>(const std::string& cell)
         {
             return std::stoi(cell);
+        }
+
+        template <>
+        inline signed char lexical_cast<signed char>(const std::string& cell)
+        {
+            return static_cast<signed char>(std::stoi(cell));
+        }
+
+        template <>
+        inline unsigned char lexical_cast<unsigned char>(const std::string& cell)
+        {
+            return static_cast<unsigned char>(std::stoul(cell));
         }
 
         template <>

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -222,6 +222,15 @@ namespace xt
         EXPECT_EQ(res1, clip(opt_a, 2.0, 4.0));
     }
 
+    TEST(xmath, clip_amin_greater_than_amax)
+    {
+        // NumPy-compatible behavior: when a_min > a_max, all values
+        // are set to a_max (the hi bound).
+        const xarray<int> arr = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        const xarray<int> expected = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+        EXPECT_EQ(expected, clip(arr, 8, 1));
+    }
+
     TEST(xmath, sign)
     {
         shape_type shape = {3, 2};


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

Address #2860 

Now `clips` follow the rule: When a_min is greater than a_max, clip returns an array in which all values are equal to a_max
