### PR TITLE
Fix poisson and geometric missing default for template parameter T

### DIFF
--- a/include/xtensor/generators/xrandom.hpp
+++ b/include/xtensor/generators/xrandom.hpp
@@ -63,14 +63,14 @@ namespace xt
         auto
         binomial(const S& shape, T trials = 1, D prob = 0.5, E& engine = random::get_default_random_engine());
 
-        template <class T, class S, class D = double, class E = random::default_engine_type>
+        template <class T = int, class S, class D = double, class E = random::default_engine_type>
         auto geometric(const S& shape, D prob = 0.5, E& engine = random::get_default_random_engine());
 
         template <class T, class S, class D = double, class E = random::default_engine_type>
         auto
         negative_binomial(const S& shape, T k = 1, D prob = 0.5, E& engine = random::get_default_random_engine());
 
-        template <class T, class S, class D = double, class E = random::default_engine_type>
+        template <class T = int, class S, class D = double, class E = random::default_engine_type>
         auto poisson(const S& shape, D rate = 1.0, E& engine = random::get_default_random_engine());
 
         template <class T, class S, class E = random::default_engine_type>
@@ -123,7 +123,7 @@ namespace xt
         auto
         binomial(const I (&shape)[L], T trials = 1, D prob = 0.5, E& engine = random::get_default_random_engine());
 
-        template <class T, class I, std::size_t L, class D = double, class E = random::default_engine_type>
+        template <class T = int, class I, std::size_t L, class D = double, class E = random::default_engine_type>
         auto geometric(const I (&shape)[L], D prob = 0.5, E& engine = random::get_default_random_engine());
 
         template <class T, class I, std::size_t L, class D = double, class E = random::default_engine_type>
@@ -134,7 +134,7 @@ namespace xt
             E& engine = random::get_default_random_engine()
         );
 
-        template <class T, class I, std::size_t L, class D = double, class E = random::default_engine_type>
+        template <class T = int, class I, std::size_t L, class D = double, class E = random::default_engine_type>
         auto poisson(const I (&shape)[L], D rate = 1.0, E& engine = random::get_default_random_engine());
 
         template <class T, class I, std::size_t L, class E = random::default_engine_type>

--- a/test/test_xrandom.cpp
+++ b/test/test_xrandom.cpp
@@ -237,6 +237,20 @@ namespace xt
 #endif
     }
 
+    TEST(xrandom, poisson_geometric_default_type)
+    {
+        // poisson and geometric have no parameter from which T can be deduced,
+        // so they require a default T (= int) to be callable without explicit template arg.
+        auto p = random::poisson({3, 3}, 1.0);
+        static_assert(std::is_same<decltype(p)::value_type, int>::value, "poisson default T must be int");
+
+        auto g = random::geometric({3, 3}, 0.5);
+        static_assert(std::is_same<decltype(g)::value_type, int>::value, "geometric default T must be int");
+
+        auto p2 = random::poisson({3, 3});
+        static_assert(std::is_same<decltype(p2)::value_type, int>::value, "poisson default T must be int");
+    }
+
     TEST(xrandom, permutation)
     {
         xt::random::seed(123);


### PR DESCRIPTION
Cherry-picked last commit from #2893, easier to do so than rebasing.