### PR TITLE
Partial elimination of TMP from xutils.hpp and patches for dependencies

### DIFF
--- a/include/xtensor/core/xassign.hpp
+++ b/include/xtensor/core/xassign.hpp
@@ -214,7 +214,7 @@ namespace xt
     template <class E1, class E2>
     inline void assign_xexpression(xexpression<E1>& e1, const xexpression<E2>& e2)
     {
-        if constexpr (has_assign_to<E1, E2>())
+        if constexpr (assignable_to<E1, E2>)
         {
             e2.derived_cast().assign_to(e1);
         }
@@ -266,14 +266,14 @@ namespace xt
         }
 
         template <class E1, class E2>
-        inline auto is_linear_assign(const E1& e1, const E2& e2) -> std::enable_if_t<has_strides<E1>(), bool>
+        inline auto is_linear_assign(const E1& e1, const E2& e2) -> std::enable_if_t<strided_expression<E1>, bool>
         {
             return (E1::contiguous_layout && E2::contiguous_layout && linear_static_layout<E1, E2>())
                    || (e1.is_contiguous() && e2.has_linear_assign(e1.strides()));
         }
 
         template <class E1, class E2>
-        inline auto is_linear_assign(const E1&, const E2&) -> std::enable_if_t<!has_strides<E1>(), bool>
+        inline auto is_linear_assign(const E1&, const E2&) -> std::enable_if_t<!strided_expression<E1>, bool>
         {
             return false;
         }
@@ -303,7 +303,7 @@ namespace xt
                 return std::is_reference<typename T::stepper::reference>::value;
             }
 
-            static constexpr bool value = has_strides<T>() && has_step_leading<typename T::stepper>::value
+            static constexpr bool value = strided_expression<T> && has_step_leading<typename T::stepper>::value
                                           && stepper_deref();
         };
 
@@ -1001,13 +1001,13 @@ namespace xt
             const strides_type& m_strides;
         };
 
-        template <bool possible = true, class E1, class E2, std::enable_if_t<!has_strides<E1>() || !possible, bool> = true>
+        template <bool possible = true, class E1, class E2, std::enable_if_t<!strided_expression<E1> || !possible, bool> = true>
         loop_sizes_t get_loop_sizes(const E1& e1, const E2&)
         {
             return {false, true, 1, e1.size(), e1.dimension(), e1.dimension()};
         }
 
-        template <bool possible = true, class E1, class E2, std::enable_if_t<has_strides<E1>() && possible, bool> = true>
+        template <bool possible = true, class E1, class E2, std::enable_if_t<strided_expression<E1> && possible, bool> = true>
         loop_sizes_t get_loop_sizes(const E1& e1, const E2& e2)
         {
             using shape_value_type = typename E1::shape_type::value_type;

--- a/include/xtensor/core/xassign.hpp
+++ b/include/xtensor/core/xassign.hpp
@@ -214,7 +214,7 @@ namespace xt
     template <class E1, class E2>
     inline void assign_xexpression(xexpression<E1>& e1, const xexpression<E2>& e2)
     {
-        if constexpr (assignable_to<E1, E2>)
+        if constexpr (assignable_expression<E1, E2>)
         {
             e2.derived_cast().assign_to(e1);
         }
@@ -266,7 +266,8 @@ namespace xt
         }
 
         template <class E1, class E2>
-        inline auto is_linear_assign(const E1& e1, const E2& e2) -> std::enable_if_t<strided_expression<E1>, bool>
+        inline auto is_linear_assign(const E1& e1, const E2& e2)
+            -> std::enable_if_t<strided_expression<E1>, bool>
         {
             return (E1::contiguous_layout && E2::contiguous_layout && linear_static_layout<E1, E2>())
                    || (e1.is_contiguous() && e2.has_linear_assign(e1.strides()));
@@ -303,8 +304,8 @@ namespace xt
                 return std::is_reference<typename T::stepper::reference>::value;
             }
 
-            static constexpr bool value = strided_expression<T> && has_step_leading<typename T::stepper>::value
-                                          && stepper_deref();
+            static constexpr bool value = strided_expression<T>
+                                          && has_step_leading<typename T::stepper>::value && stepper_deref();
         };
 
         template <class T>

--- a/include/xtensor/core/xassign.hpp
+++ b/include/xtensor/core/xassign.hpp
@@ -266,8 +266,7 @@ namespace xt
         }
 
         template <class E1, class E2>
-        inline auto is_linear_assign(const E1& e1, const E2& e2)
-            -> std::enable_if_t<has_strides<E1>(), bool>
+        inline auto is_linear_assign(const E1& e1, const E2& e2) -> std::enable_if_t<has_strides<E1>(), bool>
         {
             return (E1::contiguous_layout && E2::contiguous_layout && linear_static_layout<E1, E2>())
                    || (e1.is_contiguous() && e2.has_linear_assign(e1.strides()));
@@ -304,8 +303,8 @@ namespace xt
                 return std::is_reference<typename T::stepper::reference>::value;
             }
 
-            static constexpr bool value = has_strides<T>()
-                                          && has_step_leading<typename T::stepper>::value && stepper_deref();
+            static constexpr bool value = has_strides<T>() && has_step_leading<typename T::stepper>::value
+                                          && stepper_deref();
         };
 
         template <class T>

--- a/include/xtensor/core/xassign.hpp
+++ b/include/xtensor/core/xassign.hpp
@@ -214,7 +214,7 @@ namespace xt
     template <class E1, class E2>
     inline void assign_xexpression(xexpression<E1>& e1, const xexpression<E2>& e2)
     {
-        if constexpr (has_assign_to<E1, E2>::value)
+        if constexpr (has_assign_to<E1, E2>())
         {
             e2.derived_cast().assign_to(e1);
         }
@@ -267,14 +267,14 @@ namespace xt
 
         template <class E1, class E2>
         inline auto is_linear_assign(const E1& e1, const E2& e2)
-            -> std::enable_if_t<has_strides<E1>::value, bool>
+            -> std::enable_if_t<has_strides<E1>(), bool>
         {
             return (E1::contiguous_layout && E2::contiguous_layout && linear_static_layout<E1, E2>())
                    || (e1.is_contiguous() && e2.has_linear_assign(e1.strides()));
         }
 
         template <class E1, class E2>
-        inline auto is_linear_assign(const E1&, const E2&) -> std::enable_if_t<!has_strides<E1>::value, bool>
+        inline auto is_linear_assign(const E1&, const E2&) -> std::enable_if_t<!has_strides<E1>(), bool>
         {
             return false;
         }
@@ -304,7 +304,7 @@ namespace xt
                 return std::is_reference<typename T::stepper::reference>::value;
             }
 
-            static constexpr bool value = has_strides<T>::value
+            static constexpr bool value = has_strides<T>()
                                           && has_step_leading<typename T::stepper>::value && stepper_deref();
         };
 
@@ -1002,13 +1002,13 @@ namespace xt
             const strides_type& m_strides;
         };
 
-        template <bool possible = true, class E1, class E2, std::enable_if_t<!has_strides<E1>::value || !possible, bool> = true>
+        template <bool possible = true, class E1, class E2, std::enable_if_t<!has_strides<E1>() || !possible, bool> = true>
         loop_sizes_t get_loop_sizes(const E1& e1, const E2&)
         {
             return {false, true, 1, e1.size(), e1.dimension(), e1.dimension()};
         }
 
-        template <bool possible = true, class E1, class E2, std::enable_if_t<has_strides<E1>::value && possible, bool> = true>
+        template <bool possible = true, class E1, class E2, std::enable_if_t<has_strides<E1>() && possible, bool> = true>
         loop_sizes_t get_loop_sizes(const E1& e1, const E2& e2)
         {
             using shape_value_type = typename E1::shape_type::value_type;

--- a/include/xtensor/core/xassign.hpp
+++ b/include/xtensor/core/xassign.hpp
@@ -214,7 +214,7 @@ namespace xt
     template <class E1, class E2>
     inline void assign_xexpression(xexpression<E1>& e1, const xexpression<E2>& e2)
     {
-        if constexpr (assignable_expression<E1, E2>)
+        if constexpr (assignable_to_expression<E1, E2>)
         {
             e2.derived_cast().assign_to(e1);
         }

--- a/include/xtensor/core/xeval.hpp
+++ b/include/xtensor/core/xeval.hpp
@@ -155,8 +155,7 @@ namespace xt
     /// @cond DOXYGEN_INCLUDE_SFINAE
     template <layout_type L = layout_type::any, class E>
     inline auto as_strided(E&& e) -> std::enable_if_t<
-        (!(has_data_interface<std::decay_t<E>>() && detail::has_same_layout<L, E>()))
-            && detail::has_fixed_dims<E>(),
+        (!(has_data_interface<std::decay_t<E>>() && detail::has_same_layout<L, E>())) && detail::has_fixed_dims<E>(),
         detail::as_xtensor_container_t<E, L>>
     {
         return e;

--- a/include/xtensor/core/xeval.hpp
+++ b/include/xtensor/core/xeval.hpp
@@ -155,7 +155,8 @@ namespace xt
     /// @cond DOXYGEN_INCLUDE_SFINAE
     template <layout_type L = layout_type::any, class E>
     inline auto as_strided(E&& e) -> std::enable_if_t<
-        (!(data_interface_expression<std::decay_t<E>> && detail::has_same_layout<L, E>())) && detail::has_fixed_dims<E>(),
+        (!(data_interface_expression<std::decay_t<E>> && detail::has_same_layout<L, E>()))
+            && detail::has_fixed_dims<E>(),
         detail::as_xtensor_container_t<E, L>>
     {
         return e;

--- a/include/xtensor/core/xeval.hpp
+++ b/include/xtensor/core/xeval.hpp
@@ -147,7 +147,7 @@ namespace xt
      */
     template <layout_type L = layout_type::any, class E>
     inline auto as_strided(E&& e)
-        -> std::enable_if_t<has_data_interface<std::decay_t<E>>::value && detail::has_same_layout<L, E>(), E&&>
+        -> std::enable_if_t<has_data_interface<std::decay_t<E>>() && detail::has_same_layout<L, E>(), E&&>
     {
         return std::forward<E>(e);
     }
@@ -155,7 +155,7 @@ namespace xt
     /// @cond DOXYGEN_INCLUDE_SFINAE
     template <layout_type L = layout_type::any, class E>
     inline auto as_strided(E&& e) -> std::enable_if_t<
-        (!(has_data_interface<std::decay_t<E>>::value && detail::has_same_layout<L, E>()))
+        (!(has_data_interface<std::decay_t<E>>() && detail::has_same_layout<L, E>()))
             && detail::has_fixed_dims<E>(),
         detail::as_xtensor_container_t<E, L>>
     {
@@ -164,7 +164,7 @@ namespace xt
 
     template <layout_type L = layout_type::any, class E>
     inline auto as_strided(E&& e) -> std::enable_if_t<
-        (!(has_data_interface<std::decay_t<E>>::value && detail::has_same_layout<L, E>()))
+        (!(has_data_interface<std::decay_t<E>>() && detail::has_same_layout<L, E>()))
             && (!detail::has_fixed_dims<E>()),
         detail::as_xarray_container_t<E, L>>
     {

--- a/include/xtensor/core/xeval.hpp
+++ b/include/xtensor/core/xeval.hpp
@@ -147,7 +147,7 @@ namespace xt
      */
     template <layout_type L = layout_type::any, class E>
     inline auto as_strided(E&& e)
-        -> std::enable_if_t<has_data_interface<std::decay_t<E>>() && detail::has_same_layout<L, E>(), E&&>
+        -> std::enable_if_t<data_interface_expression<std::decay_t<E>> && detail::has_same_layout<L, E>(), E&&>
     {
         return std::forward<E>(e);
     }
@@ -155,7 +155,7 @@ namespace xt
     /// @cond DOXYGEN_INCLUDE_SFINAE
     template <layout_type L = layout_type::any, class E>
     inline auto as_strided(E&& e) -> std::enable_if_t<
-        (!(has_data_interface<std::decay_t<E>>() && detail::has_same_layout<L, E>())) && detail::has_fixed_dims<E>(),
+        (!(data_interface_expression<std::decay_t<E>> && detail::has_same_layout<L, E>())) && detail::has_fixed_dims<E>(),
         detail::as_xtensor_container_t<E, L>>
     {
         return e;
@@ -163,7 +163,7 @@ namespace xt
 
     template <layout_type L = layout_type::any, class E>
     inline auto as_strided(E&& e) -> std::enable_if_t<
-        (!(has_data_interface<std::decay_t<E>>() && detail::has_same_layout<L, E>()))
+        (!(data_interface_expression<std::decay_t<E>> && detail::has_same_layout<L, E>()))
             && (!detail::has_fixed_dims<E>()),
         detail::as_xarray_container_t<E, L>>
     {

--- a/include/xtensor/core/xexpression.hpp
+++ b/include/xtensor/core/xexpression.hpp
@@ -653,32 +653,31 @@ namespace xt
         }
 
         template <class T = E>
-        std::enable_if_t<raw_pointer_accessible_expression<T>, pointer> data() noexcept
+        std::enable_if_t<data_interface_expression<T>, pointer> data() noexcept
         {
             return m_ptr->data();
         }
 
         template <class T = E>
-        std::enable_if_t<raw_pointer_accessible_expression<T>, pointer> data() const noexcept
+        std::enable_if_t<data_interface_expression<T>, pointer> data() const noexcept
         {
             return m_ptr->data();
         }
 
         template <class T = E>
-        std::enable_if_t<raw_pointer_accessible_expression<T>, size_type> data_offset() const noexcept
+        std::enable_if_t<data_interface_expression<T>, size_type> data_offset() const noexcept
         {
             return m_ptr->data_offset();
         }
 
         template <class T = E>
-        std::enable_if_t<raw_pointer_accessible_expression<T>, typename T::storage_type&> storage() noexcept
+        std::enable_if_t<data_interface_expression<T>, typename T::storage_type&> storage() noexcept
         {
             return m_ptr->storage();
         }
 
         template <class T = E>
-        std::enable_if_t<raw_pointer_accessible_expression<T>, const typename T::storage_type&>
-        storage() const noexcept
+        std::enable_if_t<data_interface_expression<T>, const typename T::storage_type&> storage() const noexcept
         {
             return m_ptr->storage();
         }

--- a/include/xtensor/core/xexpression.hpp
+++ b/include/xtensor/core/xexpression.hpp
@@ -525,15 +525,16 @@ namespace xt
         using inner_shape_type = typename E::inner_shape_type;
         using shape_type = typename E::shape_type;
 
-        using strides_type = xtl::mpl::
-            eval_if_t<has_strides<E>, detail::expr_strides_type<E>, get_strides_type<shape_type>>;
-        using backstrides_type = xtl::mpl::
-            eval_if_t<has_strides<E>, detail::expr_backstrides_type<E>, get_strides_type<shape_type>>;
-        using inner_strides_type = xtl::mpl::
-            eval_if_t<has_strides<E>, detail::expr_inner_strides_type<E>, get_strides_type<shape_type>>;
-        using inner_backstrides_type = xtl::mpl::
-            eval_if_t<has_strides<E>, detail::expr_inner_backstrides_type<E>, get_strides_type<shape_type>>;
-        using storage_type = xtl::mpl::eval_if_t<has_storage_type<E>, detail::expr_storage_type<E>, make_invalid_type<>>;
+        using strides_type = typename std::
+            conditional_t<has_strides<E>(), detail::expr_strides_type<E>, get_strides_type<shape_type>>::type;
+        using backstrides_type = typename std::
+            conditional_t<has_strides<E>(), detail::expr_backstrides_type<E>, get_strides_type<shape_type>>::type;
+        using inner_strides_type = typename std::
+            conditional_t<has_strides<E>(), detail::expr_inner_strides_type<E>, get_strides_type<shape_type>>::type;
+        using inner_backstrides_type = typename std::
+            conditional_t<has_strides<E>(), detail::expr_inner_backstrides_type<E>, get_strides_type<shape_type>>::type;
+        using storage_type = typename std::
+            conditional_t<has_storage_type<E>(), detail::expr_storage_type<E>, make_invalid_type<>>::type;
 
         using stepper = typename E::stepper;
         using const_stepper = typename E::const_stepper;
@@ -638,43 +639,43 @@ namespace xt
         }
 
         template <class T = E>
-        std::enable_if_t<has_strides<T>::value, const inner_strides_type&> strides() const
+        std::enable_if_t<has_strides<T>(), const inner_strides_type&> strides() const
         {
             return m_ptr->strides();
         }
 
         template <class T = E>
-        std::enable_if_t<has_strides<T>::value, const inner_strides_type&> backstrides() const
+        std::enable_if_t<has_strides<T>(), const inner_strides_type&> backstrides() const
         {
             return m_ptr->backstrides();
         }
 
         template <class T = E>
-        std::enable_if_t<has_data_interface<T>::value, pointer> data() noexcept
+        std::enable_if_t<has_data_interface<T>(), pointer> data() noexcept
         {
             return m_ptr->data();
         }
 
         template <class T = E>
-        std::enable_if_t<has_data_interface<T>::value, pointer> data() const noexcept
+        std::enable_if_t<has_data_interface<T>(), pointer> data() const noexcept
         {
             return m_ptr->data();
         }
 
         template <class T = E>
-        std::enable_if_t<has_data_interface<T>::value, size_type> data_offset() const noexcept
+        std::enable_if_t<has_data_interface<T>(), size_type> data_offset() const noexcept
         {
             return m_ptr->data_offset();
         }
 
         template <class T = E>
-        std::enable_if_t<has_data_interface<T>::value, typename T::storage_type&> storage() noexcept
+        std::enable_if_t<has_data_interface<T>(), typename T::storage_type&> storage() noexcept
         {
             return m_ptr->storage();
         }
 
         template <class T = E>
-        std::enable_if_t<has_data_interface<T>::value, const typename T::storage_type&> storage() const noexcept
+        std::enable_if_t<has_data_interface<T>(), const typename T::storage_type&> storage() const noexcept
         {
             return m_ptr->storage();
         }

--- a/include/xtensor/core/xexpression.hpp
+++ b/include/xtensor/core/xexpression.hpp
@@ -526,15 +526,17 @@ namespace xt
         using shape_type = typename E::shape_type;
 
         using strides_type = typename std::
-            conditional_t<has_strides<E>(), detail::expr_strides_type<E>, get_strides_type<shape_type>>::type;
+            conditional_t<strided_expression<E>, detail::expr_strides_type<E>, get_strides_type<shape_type>>::type;
         using backstrides_type = typename std::
-            conditional_t<has_strides<E>(), detail::expr_backstrides_type<E>, get_strides_type<shape_type>>::type;
+            conditional_t<strided_expression<E>, detail::expr_backstrides_type<E>, get_strides_type<shape_type>>::type;
         using inner_strides_type = typename std::
-            conditional_t<has_strides<E>(), detail::expr_inner_strides_type<E>, get_strides_type<shape_type>>::type;
-        using inner_backstrides_type = typename std::
-            conditional_t<has_strides<E>(), detail::expr_inner_backstrides_type<E>, get_strides_type<shape_type>>::type;
+            conditional_t<strided_expression<E>, detail::expr_inner_strides_type<E>, get_strides_type<shape_type>>::type;
+        using inner_backstrides_type = typename std::conditional_t<
+            strided_expression<E>,
+            detail::expr_inner_backstrides_type<E>,
+            get_strides_type<shape_type>>::type;
         using storage_type = typename std::
-            conditional_t<has_storage_type<E>(), detail::expr_storage_type<E>, make_invalid_type<>>::type;
+            conditional_t<container_expression<E>, detail::expr_storage_type<E>, make_invalid_type<>>::type;
 
         using stepper = typename E::stepper;
         using const_stepper = typename E::const_stepper;
@@ -639,43 +641,44 @@ namespace xt
         }
 
         template <class T = E>
-        std::enable_if_t<has_strides<T>(), const inner_strides_type&> strides() const
+        std::enable_if_t<strided_expression<T>, const inner_strides_type&> strides() const
         {
             return m_ptr->strides();
         }
 
         template <class T = E>
-        std::enable_if_t<has_strides<T>(), const inner_strides_type&> backstrides() const
+        std::enable_if_t<strided_expression<T>, const inner_strides_type&> backstrides() const
         {
             return m_ptr->backstrides();
         }
 
         template <class T = E>
-        std::enable_if_t<has_data_interface<T>(), pointer> data() noexcept
+        std::enable_if_t<raw_pointer_accessible_expression<T>, pointer> data() noexcept
         {
             return m_ptr->data();
         }
 
         template <class T = E>
-        std::enable_if_t<has_data_interface<T>(), pointer> data() const noexcept
+        std::enable_if_t<raw_pointer_accessible_expression<T>, pointer> data() const noexcept
         {
             return m_ptr->data();
         }
 
         template <class T = E>
-        std::enable_if_t<has_data_interface<T>(), size_type> data_offset() const noexcept
+        std::enable_if_t<raw_pointer_accessible_expression<T>, size_type> data_offset() const noexcept
         {
             return m_ptr->data_offset();
         }
 
         template <class T = E>
-        std::enable_if_t<has_data_interface<T>(), typename T::storage_type&> storage() noexcept
+        std::enable_if_t<raw_pointer_accessible_expression<T>, typename T::storage_type&> storage() noexcept
         {
             return m_ptr->storage();
         }
 
         template <class T = E>
-        std::enable_if_t<has_data_interface<T>(), const typename T::storage_type&> storage() const noexcept
+        std::enable_if_t<raw_pointer_accessible_expression<T>, const typename T::storage_type&>
+        storage() const noexcept
         {
             return m_ptr->storage();
         }

--- a/include/xtensor/core/xfunction.hpp
+++ b/include/xtensor/core/xfunction.hpp
@@ -156,7 +156,7 @@ namespace xt
     template <class E>
     struct overlapping_memory_checker_traits<
         E,
-        std::enable_if_t<!has_memory_address<E>() && is_specialization_of<xfunction, E>::value>>
+        std::enable_if_t<!addressable_expression<E> && is_specialization_of<xfunction, E>::value>>
     {
         template <std::size_t I = 0, class... T, std::enable_if_t<(I == sizeof...(T)), int> = 0>
         static bool check_tuple(const std::tuple<T...>&, const memory_range&)

--- a/include/xtensor/core/xfunction.hpp
+++ b/include/xtensor/core/xfunction.hpp
@@ -133,7 +133,7 @@ namespace xt
     struct xcontainer_inner_types<xfunction<F, CT...>>
     {
         // Added indirection for MSVC 2017 bug with the operator value_type()
-        using func_return_type = typename meta_identity<
+        using func_return_type = typename std::type_identity<
             decltype(std::declval<F>()(std::declval<xvalue_type_t<std::decay_t<CT>>>()...))>::type;
         using value_type = std::decay_t<func_return_type>;
         using reference = func_return_type;
@@ -156,7 +156,7 @@ namespace xt
     template <class E>
     struct overlapping_memory_checker_traits<
         E,
-        std::enable_if_t<!has_memory_address<E>::value && is_specialization_of<xfunction, E>::value>>
+        std::enable_if_t<!has_memory_address<E>() && is_specialization_of<xfunction, E>::value>>
     {
         template <std::size_t I = 0, class... T, std::enable_if_t<(I == sizeof...(T)), int> = 0>
         static bool check_tuple(const std::tuple<T...>&, const memory_range&)

--- a/include/xtensor/core/xfunction.hpp
+++ b/include/xtensor/core/xfunction.hpp
@@ -156,7 +156,7 @@ namespace xt
     template <class E>
     struct overlapping_memory_checker_traits<
         E,
-        std::enable_if_t<!addressable_expression<E> && is_specialization_of<xfunction, E>::value>>
+        std::enable_if_t<!addressable_to_expression<E> && is_specialization_of<xfunction, E>::value>>
     {
         template <std::size_t I = 0, class... T, std::enable_if_t<(I == sizeof...(T)), int> = 0>
         static bool check_tuple(const std::tuple<T...>&, const memory_range&)

--- a/include/xtensor/core/xiterable.hpp
+++ b/include/xtensor/core/xiterable.hpp
@@ -293,7 +293,7 @@ namespace xt
         };
 
         template <class D>
-        using linear_iterator_traits = linear_iterator_traits_impl<D, has_storage_type<D>()>;
+        using linear_iterator_traits = linear_iterator_traits_impl<D, container_expression<D>>;
     }
 
     /**

--- a/include/xtensor/core/xiterable.hpp
+++ b/include/xtensor/core/xiterable.hpp
@@ -293,7 +293,7 @@ namespace xt
         };
 
         template <class D>
-        using linear_iterator_traits = linear_iterator_traits_impl<D, has_storage_type<D>::value>;
+        using linear_iterator_traits = linear_iterator_traits_impl<D, has_storage_type<D>()>;
     }
 
     /**

--- a/include/xtensor/core/xmath.hpp
+++ b/include/xtensor/core/xmath.hpp
@@ -350,13 +350,13 @@ namespace xt
     namespace detail
     {
         template <class R, class T>
-        std::enable_if_t<!has_iterator_interface<R>(), R> fill_init(T init)
+        std::enable_if_t<!iterable_expression<R>, R> fill_init(T init)
         {
             return R(init);
         }
 
         template <class R, class T>
-        std::enable_if_t<has_iterator_interface<R>(), R> fill_init(T init)
+        std::enable_if_t<iterable_expression<R>, R> fill_init(T init)
         {
             R result;
             std::fill(std::begin(result), std::end(result), init);

--- a/include/xtensor/core/xmath.hpp
+++ b/include/xtensor/core/xmath.hpp
@@ -350,13 +350,13 @@ namespace xt
     namespace detail
     {
         template <class R, class T>
-        std::enable_if_t<!has_iterator_interface<R>::value, R> fill_init(T init)
+        std::enable_if_t<!has_iterator_interface<R>(), R> fill_init(T init)
         {
             return R(init);
         }
 
         template <class R, class T>
-        std::enable_if_t<has_iterator_interface<R>::value, R> fill_init(T init)
+        std::enable_if_t<has_iterator_interface<R>(), R> fill_init(T init)
         {
             R result;
             std::fill(std::begin(result), std::end(result), init);

--- a/include/xtensor/core/xsemantic.hpp
+++ b/include/xtensor/core/xsemantic.hpp
@@ -224,7 +224,7 @@ namespace xt
     template <class E>
     struct overlapping_memory_checker_traits<
         E,
-        std::enable_if_t<!has_memory_address<E>::value && is_crtp_base_of<xview_semantic, E>::value>>
+        std::enable_if_t<!has_memory_address<E>() && is_crtp_base_of<xview_semantic, E>::value>>
     {
         static bool check_overlap(const E& expr, const memory_range& dst_range)
         {

--- a/include/xtensor/core/xsemantic.hpp
+++ b/include/xtensor/core/xsemantic.hpp
@@ -224,7 +224,7 @@ namespace xt
     template <class E>
     struct overlapping_memory_checker_traits<
         E,
-        std::enable_if_t<!has_memory_address<E>() && is_crtp_base_of<xview_semantic, E>::value>>
+        std::enable_if_t<!addressable_expression<E> && is_crtp_base_of<xview_semantic, E>::value>>
     {
         static bool check_overlap(const E& expr, const memory_range& dst_range)
         {

--- a/include/xtensor/core/xsemantic.hpp
+++ b/include/xtensor/core/xsemantic.hpp
@@ -224,7 +224,7 @@ namespace xt
     template <class E>
     struct overlapping_memory_checker_traits<
         E,
-        std::enable_if_t<!addressable_expression<E> && is_crtp_base_of<xview_semantic, E>::value>>
+        std::enable_if_t<!addressable_to_expression<E> && is_crtp_base_of<xview_semantic, E>::value>>
     {
         static bool check_overlap(const E& expr, const memory_range& dst_range)
         {

--- a/include/xtensor/core/xshape.hpp
+++ b/include/xtensor/core/xshape.hpp
@@ -138,7 +138,7 @@ namespace xt
      * @param shape the shape to test
      * @return bool
      */
-    template <class E, class S, class = typename std::enable_if_t<has_iterator_interface<S>()>>
+    template <class E, class S, class = typename std::enable_if_t<iterable_expression<S>>>
     inline bool has_shape(const E& e, const S& shape)
     {
         return e.shape().size() == shape.size()

--- a/include/xtensor/core/xshape.hpp
+++ b/include/xtensor/core/xshape.hpp
@@ -138,7 +138,7 @@ namespace xt
      * @param shape the shape to test
      * @return bool
      */
-    template <class E, class S, class = typename std::enable_if_t<has_iterator_interface<S>::value>>
+    template <class E, class S, class = typename std::enable_if_t<has_iterator_interface<S>()>>
     inline bool has_shape(const E& e, const S& shape)
     {
         return e.shape().size() == shape.size()

--- a/include/xtensor/generators/xgenerator.hpp
+++ b/include/xtensor/generators/xgenerator.hpp
@@ -167,7 +167,7 @@ namespace xt
 
         template <class E, class FE = F>
         void assign_to(xexpression<E>& e) const noexcept
-            requires(has_assign_to_v<E, FE>);
+            requires(assignable_expression<E, FE>);
 
         const functor_type& functor() const noexcept;
 
@@ -374,7 +374,7 @@ namespace xt
     template <class F, class R, class S>
     template <class E, class FE>
     inline void xgenerator<F, R, S>::assign_to(xexpression<E>& e) const noexcept
-        requires(has_assign_to_v<E, FE>)
+        requires(assignable_to<E, FE>)
     {
         e.derived_cast().resize(m_shape);
         m_f.assign_to(e);

--- a/include/xtensor/generators/xgenerator.hpp
+++ b/include/xtensor/generators/xgenerator.hpp
@@ -374,7 +374,7 @@ namespace xt
     template <class F, class R, class S>
     template <class E, class FE>
     inline void xgenerator<F, R, S>::assign_to(xexpression<E>& e) const noexcept
-        requires(assignable_to<E, FE>)
+        requires(assignable_expression<E, FE>)
     {
         e.derived_cast().resize(m_shape);
         m_f.assign_to(e);

--- a/include/xtensor/generators/xgenerator.hpp
+++ b/include/xtensor/generators/xgenerator.hpp
@@ -82,7 +82,7 @@ namespace xt
      *************************************/
 
     template <xgenerator_concept E>
-        requires(without_memory_address_concept<E>)
+        requires(!addressable_to_expression<std::decay_t<E>>)
     struct overlapping_memory_checker_traits<E>
     {
         static bool check_overlap(const E&, const memory_range&)
@@ -167,7 +167,7 @@ namespace xt
 
         template <class E, class FE = F>
         void assign_to(xexpression<E>& e) const noexcept
-            requires(assignable_expression<E, FE>);
+            requires(assignable_to_expression<E, FE>);
 
         const functor_type& functor() const noexcept;
 
@@ -374,7 +374,7 @@ namespace xt
     template <class F, class R, class S>
     template <class E, class FE>
     inline void xgenerator<F, R, S>::assign_to(xexpression<E>& e) const noexcept
-        requires(assignable_expression<E, FE>)
+        requires(assignable_to_expression<E, FE>)
     {
         e.derived_cast().resize(m_shape);
         m_f.assign_to(e);

--- a/include/xtensor/misc/xmanipulation.hpp
+++ b/include/xtensor/misc/xmanipulation.hpp
@@ -659,7 +659,7 @@ namespace xt
     template <std::size_t N, class E>
     inline auto atleast_Nd(E&& e)
     {
-        xstrided_slice_vector sv((std::max) (e.dimension(), N), all());
+        xstrided_slice_vector sv((std::max)(e.dimension(), N), all());
         if (e.dimension() < N)
         {
             std::size_t i = 0;

--- a/include/xtensor/misc/xmanipulation.hpp
+++ b/include/xtensor/misc/xmanipulation.hpp
@@ -214,7 +214,7 @@ namespace xt
         template <class E, class S, class X>
         inline void compute_transposed_strides(E&& e, const S& shape, X& strides)
         {
-            if constexpr (raw_pointer_accessible_expression<std::decay_t<E>>)
+            if constexpr (data_interface_expression<std::decay_t<E>>)
             {
                 std::copy(e.strides().crbegin(), e.strides().crend(), strides.begin());
             }

--- a/include/xtensor/misc/xmanipulation.hpp
+++ b/include/xtensor/misc/xmanipulation.hpp
@@ -214,7 +214,7 @@ namespace xt
         template <class E, class S, class X>
         inline void compute_transposed_strides(E&& e, const S& shape, X& strides)
         {
-            if constexpr (has_data_interface<std::decay_t<E>>())
+            if constexpr (raw_pointer_accessible_expression<std::decay_t<E>>)
             {
                 std::copy(e.strides().crbegin(), e.strides().crend(), strides.begin());
             }
@@ -659,7 +659,7 @@ namespace xt
     template <std::size_t N, class E>
     inline auto atleast_Nd(E&& e)
     {
-        xstrided_slice_vector sv((std::max)(e.dimension(), N), all());
+        xstrided_slice_vector sv((std::max) (e.dimension(), N), all());
         if (e.dimension() < N)
         {
             std::size_t i = 0;

--- a/include/xtensor/misc/xmanipulation.hpp
+++ b/include/xtensor/misc/xmanipulation.hpp
@@ -214,7 +214,7 @@ namespace xt
         template <class E, class S, class X>
         inline void compute_transposed_strides(E&& e, const S& shape, X& strides)
         {
-            if constexpr (has_data_interface<std::decay_t<E>>::value)
+            if constexpr (has_data_interface<std::decay_t<E>>())
             {
                 std::copy(e.strides().crbegin(), e.strides().crend(), strides.begin());
             }

--- a/include/xtensor/misc/xset_operation.hpp
+++ b/include/xtensor/misc/xset_operation.hpp
@@ -93,7 +93,7 @@ namespace xt
      */
     template <class E, class F>
     inline auto isin(E&& element, F&& test_elements) noexcept
-        requires(has_iterator_interface_concept<F>)
+        requires(iterable_expression<F>)
     {
         auto lambda = detail::lambda_isin<std::is_lvalue_reference<F>::value>::make(std::forward<F>(test_elements
         ));
@@ -150,7 +150,7 @@ namespace xt
      */
     template <class E, class F>
     inline auto in1d(E&& element, F&& test_elements) noexcept
-        requires(has_iterator_interface_concept<F>)
+        requires(iterable_expression<F>)
     {
         XTENSOR_ASSERT(element.dimension() == 1ul);
         XTENSOR_ASSERT(test_elements.dimension() == 1ul);

--- a/include/xtensor/misc/xset_operation.hpp
+++ b/include/xtensor/misc/xset_operation.hpp
@@ -11,7 +11,9 @@
 #define XTENSOR_XSET_OPERATION_HPP
 
 #include <algorithm>
+#include <iterator>
 #include <type_traits>
+
 
 #include <xtl/xsequence.hpp>
 
@@ -111,7 +113,7 @@ namespace xt
      * @param test_elements_end iterator to the end of an array
      * @return a boolean array
      */
-    template <class E, iterator_concept I>
+    template <class E, std::forward_iterator I>
     inline auto isin(E&& element, I&& test_elements_begin, I&& test_elements_end) noexcept
     {
         auto lambda = [&test_elements_begin, &test_elements_end](const auto& t)
@@ -168,7 +170,7 @@ namespace xt
      * @param test_elements_end iterator to the end of an array
      * @return a boolean array
      */
-    template <class E, iterator_concept I>
+    template <class E, std::forward_iterator I>
     inline auto in1d(E&& element, I&& test_elements_begin, I&& test_elements_end) noexcept
     {
         XTENSOR_ASSERT(element.dimension() == 1ul);

--- a/include/xtensor/misc/xset_operation.hpp
+++ b/include/xtensor/misc/xset_operation.hpp
@@ -14,7 +14,6 @@
 #include <iterator>
 #include <type_traits>
 
-
 #include <xtl/xsequence.hpp>
 
 #include "../containers/xscalar.hpp"

--- a/include/xtensor/utils/xutils.hpp
+++ b/include/xtensor/utils/xutils.hpp
@@ -462,20 +462,20 @@ namespace xt
      ******************/
 
     template <class T>
-    constexpr auto get_value_type()
+    struct get_value_type
     {
-        if constexpr (requires { typename T::value_type; })
-        {
-            return std::type_identity<typename T::value_type>{};
-        }
-        else
-        {
-            return std::type_identity<T>{};
-        }
-    }
+        using type = T;
+    };
 
     template <class T>
-    using get_value_type_t = typename decltype(get_value_type<T>())::type;
+        requires requires { typename T::value_type; }
+    struct get_value_type<T>
+    {
+        using type = typename T::value_type;
+    };
+
+    template <class T>
+    using get_value_type_t = typename get_value_type<T>::type;
 
     /**********************
      * get implementation *
@@ -883,60 +883,44 @@ namespace xt
         concept xbuffer_adaptor_type = is_xbuffer_adaptor_v<S>;
     }
 
-    template <class S>
-    constexpr auto get_strides()
-    {
-        if constexpr (detail::fixed_shape_type<S>)
-        {
-            // TODO we could compute the strides statically here.
-            //  But we'll need full constexpr support to have a
-            //  homogenous ``compute_strides`` method
-            return std::type_identity<std::array<std::ptrdiff_t, S::size()>>{};
-        }
-        else if constexpr (detail::xbuffer_adaptor_type<S>)
-        {
-            // In bindings this mapping is called by reshape_view with an inner shape of type
-            // xbuffer_adaptor.
-            // Since we cannot create a buffer adaptor holding data, we map it to an std::vector.
-            return std::type_identity<std::vector<typename S::value_type, typename S::allocator_type>>{};
-        }
-        else
-        {
-            return std::type_identity<typename rebind_container<std::ptrdiff_t, S>::type>{};
-        }
-    }
-
-    template <class S>
-    using get_strides_t = typename decltype(get_strides<S>())::type;
-
-    // Lazy metafunction wrapper around ``get_strides``. Kept so callers can defer the mapping
-    // inside ``std::conditional_t<cond, A, B>::type``, where ``::type`` is only evaluated on the
-    // selected branch (see xshared_expression in xexpression.hpp).
+    // Defers strides-type mapping so callers can use it inside std::conditional_t<cond, A, B>::type
+    // without evaluating both branches (see xshared_expression in xexpression.hpp).
     template <class S>
     struct get_strides_type
     {
-        using type = get_strides_t<S>;
+        using type = typename rebind_container<std::ptrdiff_t, S>::type;
     };
+
+    template <detail::fixed_shape_type S>
+    struct get_strides_type<S>
+    {
+        // TODO we could compute the strides statically here.
+        //  But we'll need full constexpr support to have a
+        //  homogenous ``compute_strides`` method
+        using type = std::array<std::ptrdiff_t, S::size()>;
+    };
+
+    template <detail::xbuffer_adaptor_type S>
+    struct get_strides_type<S>
+    {
+        // In bindings this mapping is called by reshape_view with an inner shape of type
+        // xbuffer_adaptor.
+        // Since we cannot create a buffer adaptor holding data, we map it to an std::vector.
+        using type = std::vector<typename S::value_type, typename S::allocator_type>;
+    };
+
+    template <class S>
+    using get_strides_t = typename get_strides_type<S>::type;
 
     /*******************
      * inner_reference *
      *******************/
-    template <class ST>
-    constexpr auto get_inner_reference()
-    {
-        using storage_type = std::decay_t<ST>;
-        if constexpr (std::is_const<std::remove_reference_t<ST>>::value)
-        {
-            return std::type_identity<typename storage_type::const_reference>{};
-        }
-        else
-        {
-            return std::type_identity<typename storage_type::reference>{};
-        }
-    }
 
     template <class ST>
-    using inner_reference_t = typename decltype(get_inner_reference<ST>())::type;
+    using inner_reference_t = std::conditional_t<
+        std::is_const<std::remove_reference_t<ST>>::value,
+        typename std::decay_t<ST>::const_reference,
+        typename std::decay_t<ST>::reference>;
 
     /************
      * get_rank *

--- a/include/xtensor/utils/xutils.hpp
+++ b/include/xtensor/utils/xutils.hpp
@@ -360,16 +360,14 @@ namespace xt
             res[i] = normalize_axis(expr.dimension(), axes[i]);
         }
 
-        XTENSOR_ASSERT(
-            std::all_of(
-                res.begin(),
-                res.end(),
-                [&expr](auto ax_el)
-                {
-                    return ax_el < expr.dimension();
-                }
-            )
-        );
+        XTENSOR_ASSERT(std::all_of(
+            res.begin(),
+            res.end(),
+            [&expr](auto ax_el)
+            {
+                return ax_el < expr.dimension();
+            }
+        ));
 
         return res;
     }
@@ -381,16 +379,14 @@ namespace xt
     normalize_axis(E& expr, C&& axes)
     {
         static_cast<void>(expr);
-        XTENSOR_ASSERT(
-            std::all_of(
-                axes.begin(),
-                axes.end(),
-                [&expr](auto ax_el)
-                {
-                    return ax_el < expr.dimension();
-                }
-            )
-        );
+        XTENSOR_ASSERT(std::all_of(
+            axes.begin(),
+            axes.end(),
+            [&expr](auto ax_el)
+            {
+                return ax_el < expr.dimension();
+            }
+        ));
         return std::forward<C>(axes);
     }
 
@@ -411,16 +407,14 @@ namespace xt
             }
         );
 
-        XTENSOR_ASSERT(
-            std::all_of(
-                res.begin(),
-                res.end(),
-                [&expr](auto ax_el)
-                {
-                    return ax_el < expr.dimension();
-                }
-            )
-        );
+        XTENSOR_ASSERT(std::all_of(
+            res.begin(),
+            res.end(),
+            [&expr](auto ax_el)
+            {
+                return ax_el < expr.dimension();
+            }
+        ));
 
         return res;
     }
@@ -435,16 +429,14 @@ namespace xt
         R res;
         xt::resize_container(res, std::size(axes));
         std::copy(std::begin(axes), std::end(axes), std::begin(res));
-        XTENSOR_ASSERT(
-            std::all_of(
-                res.begin(),
-                res.end(),
-                [&expr](auto ax_el)
-                {
-                    return ax_el < expr.dimension();
-                }
-            )
-        );
+        XTENSOR_ASSERT(std::all_of(
+            res.begin(),
+            res.end(),
+            [&expr](auto ax_el)
+            {
+                return ax_el < expr.dimension();
+            }
+        ));
         return res;
     }
 
@@ -454,16 +446,14 @@ namespace xt
         R&&>
     {
         static_cast<void>(expr);
-        XTENSOR_ASSERT(
-            std::all_of(
-                std::begin(axes),
-                std::end(axes),
-                [&expr](auto ax_el)
-                {
-                    return ax_el < expr.dimension();
-                }
-            )
-        );
+        XTENSOR_ASSERT(std::all_of(
+            std::begin(axes),
+            std::end(axes),
+            [&expr](auto ax_el)
+            {
+                return ax_el < expr.dimension();
+            }
+        ));
         return std::move(axes);
     }
 
@@ -540,9 +530,7 @@ namespace xt
     template <class T>
     concept has_storage_type_concept = requires {
         typename xcontainer_inner_types<T>::storage_type;
-        requires !std::is_same_v<
-                     typename std::remove_cv<typename xcontainer_inner_types<T>::storage_type>::type,
-                     invalid_type>;
+        requires !std::is_same_v<typename std::remove_cv<typename xcontainer_inner_types<T>::storage_type>::type, invalid_type>;
     };
 
     template <class T>
@@ -858,18 +846,18 @@ namespace xt
     {
         explicit overlapping_memory_checker(const Dst& aDst)
             : overlapping_memory_checker_base(
-                  [&]()
-                  {
-                      if (aDst.size() == 0)
-                      {
-                          return memory_range();
-                      }
-                      else
-                      {
-                          return memory_range(std::addressof(*aDst.begin()), std::addressof(*aDst.rbegin()));
-                      }
-                  }()
-              )
+                [&]()
+                {
+                    if (aDst.size() == 0)
+                    {
+                        return memory_range();
+                    }
+                    else
+                    {
+                        return memory_range(std::addressof(*aDst.begin()), std::addressof(*aDst.rbegin()));
+                    }
+                }()
+            )
         {
         }
     };

--- a/include/xtensor/utils/xutils.hpp
+++ b/include/xtensor/utils/xutils.hpp
@@ -360,14 +360,16 @@ namespace xt
             res[i] = normalize_axis(expr.dimension(), axes[i]);
         }
 
-        XTENSOR_ASSERT(std::all_of(
-            res.begin(),
-            res.end(),
-            [&expr](auto ax_el)
-            {
-                return ax_el < expr.dimension();
-            }
-        ));
+        XTENSOR_ASSERT(
+            std::all_of(
+                res.begin(),
+                res.end(),
+                [&expr](auto ax_el)
+                {
+                    return ax_el < expr.dimension();
+                }
+            )
+        );
 
         return res;
     }
@@ -379,14 +381,16 @@ namespace xt
     normalize_axis(E& expr, C&& axes)
     {
         static_cast<void>(expr);
-        XTENSOR_ASSERT(std::all_of(
-            axes.begin(),
-            axes.end(),
-            [&expr](auto ax_el)
-            {
-                return ax_el < expr.dimension();
-            }
-        ));
+        XTENSOR_ASSERT(
+            std::all_of(
+                axes.begin(),
+                axes.end(),
+                [&expr](auto ax_el)
+                {
+                    return ax_el < expr.dimension();
+                }
+            )
+        );
         return std::forward<C>(axes);
     }
 
@@ -407,14 +411,16 @@ namespace xt
             }
         );
 
-        XTENSOR_ASSERT(std::all_of(
-            res.begin(),
-            res.end(),
-            [&expr](auto ax_el)
-            {
-                return ax_el < expr.dimension();
-            }
-        ));
+        XTENSOR_ASSERT(
+            std::all_of(
+                res.begin(),
+                res.end(),
+                [&expr](auto ax_el)
+                {
+                    return ax_el < expr.dimension();
+                }
+            )
+        );
 
         return res;
     }
@@ -429,14 +435,16 @@ namespace xt
         R res;
         xt::resize_container(res, std::size(axes));
         std::copy(std::begin(axes), std::end(axes), std::begin(res));
-        XTENSOR_ASSERT(std::all_of(
-            res.begin(),
-            res.end(),
-            [&expr](auto ax_el)
-            {
-                return ax_el < expr.dimension();
-            }
-        ));
+        XTENSOR_ASSERT(
+            std::all_of(
+                res.begin(),
+                res.end(),
+                [&expr](auto ax_el)
+                {
+                    return ax_el < expr.dimension();
+                }
+            )
+        );
         return res;
     }
 
@@ -446,14 +454,16 @@ namespace xt
         R&&>
     {
         static_cast<void>(expr);
-        XTENSOR_ASSERT(std::all_of(
-            std::begin(axes),
-            std::end(axes),
-            [&expr](auto ax_el)
-            {
-                return ax_el < expr.dimension();
-            }
-        ));
+        XTENSOR_ASSERT(
+            std::all_of(
+                std::begin(axes),
+                std::end(axes),
+                [&expr](auto ax_el)
+                {
+                    return ax_el < expr.dimension();
+                }
+            )
+        );
         return std::move(axes);
     }
 
@@ -729,7 +739,7 @@ namespace xt
     }
 
     template <class E1, class E2>
-    constexpr bool has_assign_to_v = has_assign_to_concept<E1, E2>;
+    constexpr bool has_assign_to_v = has_assign_to<E1, E2>();
 
     /*************************************
      * overlapping_memory_checker_traits *
@@ -846,18 +856,18 @@ namespace xt
     {
         explicit overlapping_memory_checker(const Dst& aDst)
             : overlapping_memory_checker_base(
-                [&]()
-                {
-                    if (aDst.size() == 0)
-                    {
-                        return memory_range();
-                    }
-                    else
-                    {
-                        return memory_range(std::addressof(*aDst.begin()), std::addressof(*aDst.rbegin()));
-                    }
-                }()
-            )
+                  [&]()
+                  {
+                      if (aDst.size() == 0)
+                      {
+                          return memory_range();
+                      }
+                      else
+                      {
+                          return memory_range(std::addressof(*aDst.begin()), std::addressof(*aDst.rbegin()));
+                      }
+                  }()
+              )
         {
         }
     };
@@ -895,59 +905,88 @@ namespace xt
     };
 #endif
 
-    /********************
-     * get_strides_type *
-     ********************/
-
-    template <class S>
-    struct get_strides_type
-    {
-        using type = typename rebind_container<std::ptrdiff_t, S>::type;
-    };
-
-    template <std::size_t... I>
-    struct get_strides_type<fixed_shape<I...>>
-    {
-        // TODO we could compute the strides statically here.
-        //  But we'll need full constexpr support to have a
-        //  homogenous ``compute_strides`` method
-        using type = std::array<std::ptrdiff_t, sizeof...(I)>;
-    };
+    /***************
+     * get_strides *
+     ***************/
 
     template <class CP, class O, class A>
     class xbuffer_adaptor;
 
-    template <class CP, class O, class A>
-    struct get_strides_type<xbuffer_adaptor<CP, O, A>>
+    namespace detail
     {
-        // In bindings this mapping is called by reshape_view with an inner shape of type
-        // xbuffer_adaptor.
-        // Since we cannot create a buffer adaptor holding data, we map it to an std::vector.
-        using type = std::vector<
-            typename xbuffer_adaptor<CP, O, A>::value_type,
-            typename xbuffer_adaptor<CP, O, A>::allocator_type>;
+        template <class>
+        inline constexpr bool is_fixed_shape_v = false;
+
+        template <std::size_t... I>
+        inline constexpr bool is_fixed_shape_v<fixed_shape<I...>> = true;
+
+        template <class>
+        inline constexpr bool is_xbuffer_adaptor_v = false;
+
+        template <class CP, class O, class A>
+        inline constexpr bool is_xbuffer_adaptor_v<xbuffer_adaptor<CP, O, A>> = true;
+
+        template <class S>
+        concept fixed_shape_type = is_fixed_shape_v<S>;
+
+        template <class S>
+        concept xbuffer_adaptor_type = is_xbuffer_adaptor_v<S>;
+    }
+
+    template <class S>
+    constexpr auto get_strides()
+    {
+        if constexpr (detail::fixed_shape_type<S>)
+        {
+            // TODO we could compute the strides statically here.
+            //  But we'll need full constexpr support to have a
+            //  homogenous ``compute_strides`` method
+            return std::type_identity<std::array<std::ptrdiff_t, S::size()>>{};
+        }
+        else if constexpr (detail::xbuffer_adaptor_type<S>)
+        {
+            // In bindings this mapping is called by reshape_view with an inner shape of type
+            // xbuffer_adaptor.
+            // Since we cannot create a buffer adaptor holding data, we map it to an std::vector.
+            return std::type_identity<std::vector<typename S::value_type, typename S::allocator_type>>{};
+        }
+        else
+        {
+            return std::type_identity<typename rebind_container<std::ptrdiff_t, S>::type>{};
+        }
+    }
+
+    template <class S>
+    using get_strides_t = typename decltype(get_strides<S>())::type;
+
+    // Lazy metafunction wrapper around ``get_strides``. Kept so callers can defer the mapping
+    // inside ``std::conditional_t<cond, A, B>::type``, where ``::type`` is only evaluated on the
+    // selected branch (see xshared_expression in xexpression.hpp).
+    template <class S>
+    struct get_strides_type
+    {
+        using type = get_strides_t<S>;
     };
-
-
-    template <class C>
-    using get_strides_t = typename get_strides_type<C>::type;
 
     /*******************
      * inner_reference *
      *******************/
-
     template <class ST>
-    struct inner_reference
+    constexpr auto get_inner_reference()
     {
         using storage_type = std::decay_t<ST>;
-        using type = std::conditional_t<
-            std::is_const<std::remove_reference_t<ST>>::value,
-            typename storage_type::const_reference,
-            typename storage_type::reference>;
-    };
+        if constexpr (std::is_const<std::remove_reference_t<ST>>::value)
+        {
+            return std::type_identity<typename storage_type::const_reference>{};
+        }
+        else
+        {
+            return std::type_identity<typename storage_type::reference>{};
+        }
+    }
 
     template <class ST>
-    using inner_reference_t = typename inner_reference<ST>::type;
+    using inner_reference_t = typename decltype(get_inner_reference<ST>())::type;
 
     /************
      * get_rank *

--- a/include/xtensor/utils/xutils.hpp
+++ b/include/xtensor/utils/xutils.hpp
@@ -101,16 +101,6 @@ namespace xt
     template <class T, class R>
     using disable_integral_t = std::enable_if_t<!xtl::is_integral<T>::value, R>;
 
-    /********************************
-     * meta identity implementation *
-     ********************************/
-
-    template <class T>
-    struct meta_identity
-    {
-        using type = T;
-    };
-
     /***************************************
      * is_specialization_of implementation *
      ***************************************/
@@ -370,14 +360,16 @@ namespace xt
             res[i] = normalize_axis(expr.dimension(), axes[i]);
         }
 
-        XTENSOR_ASSERT(std::all_of(
-            res.begin(),
-            res.end(),
-            [&expr](auto ax_el)
-            {
-                return ax_el < expr.dimension();
-            }
-        ));
+        XTENSOR_ASSERT(
+            std::all_of(
+                res.begin(),
+                res.end(),
+                [&expr](auto ax_el)
+                {
+                    return ax_el < expr.dimension();
+                }
+            )
+        );
 
         return res;
     }
@@ -389,14 +381,16 @@ namespace xt
     normalize_axis(E& expr, C&& axes)
     {
         static_cast<void>(expr);
-        XTENSOR_ASSERT(std::all_of(
-            axes.begin(),
-            axes.end(),
-            [&expr](auto ax_el)
-            {
-                return ax_el < expr.dimension();
-            }
-        ));
+        XTENSOR_ASSERT(
+            std::all_of(
+                axes.begin(),
+                axes.end(),
+                [&expr](auto ax_el)
+                {
+                    return ax_el < expr.dimension();
+                }
+            )
+        );
         return std::forward<C>(axes);
     }
 
@@ -417,14 +411,16 @@ namespace xt
             }
         );
 
-        XTENSOR_ASSERT(std::all_of(
-            res.begin(),
-            res.end(),
-            [&expr](auto ax_el)
-            {
-                return ax_el < expr.dimension();
-            }
-        ));
+        XTENSOR_ASSERT(
+            std::all_of(
+                res.begin(),
+                res.end(),
+                [&expr](auto ax_el)
+                {
+                    return ax_el < expr.dimension();
+                }
+            )
+        );
 
         return res;
     }
@@ -439,14 +435,16 @@ namespace xt
         R res;
         xt::resize_container(res, std::size(axes));
         std::copy(std::begin(axes), std::end(axes), std::begin(res));
-        XTENSOR_ASSERT(std::all_of(
-            res.begin(),
-            res.end(),
-            [&expr](auto ax_el)
-            {
-                return ax_el < expr.dimension();
-            }
-        ));
+        XTENSOR_ASSERT(
+            std::all_of(
+                res.begin(),
+                res.end(),
+                [&expr](auto ax_el)
+                {
+                    return ax_el < expr.dimension();
+                }
+            )
+        );
         return res;
     }
 
@@ -456,14 +454,16 @@ namespace xt
         R&&>
     {
         static_cast<void>(expr);
-        XTENSOR_ASSERT(std::all_of(
-            std::begin(axes),
-            std::end(axes),
-            [&expr](auto ax_el)
-            {
-                return ax_el < expr.dimension();
-            }
-        ));
+        XTENSOR_ASSERT(
+            std::all_of(
+                std::begin(axes),
+                std::end(axes),
+                [&expr](auto ax_el)
+                {
+                    return ax_el < expr.dimension();
+                }
+            )
+        );
         return std::move(axes);
     }
 
@@ -471,20 +471,21 @@ namespace xt
      * get_value_type *
      ******************/
 
-    template <class T, class = void_t<>>
-    struct get_value_type
+    template <class T>
+    constexpr auto get_value_type()
     {
-        using type = T;
-    };
+        if constexpr (requires { typename T::value_type; })
+        {
+            return std::type_identity<typename T::value_type>{};
+        }
+        else
+        {
+            return std::type_identity<T>{};
+        }
+    }
 
     template <class T>
-    struct get_value_type<T, void_t<typename T::value_type>>
-    {
-        using type = typename T::value_type;
-    };
-
-    template <class T>
-    using get_value_type_t = typename get_value_type<T>::type;
+    using get_value_type_t = typename decltype(get_value_type<T>())::type;
 
     /**********************
      * get implementation *
@@ -533,81 +534,72 @@ namespace xt
      * has_storage_type implementation *
      ***********************************/
 
-    template <class T, class = void>
-    struct has_storage_type : std::false_type
-    {
-    };
-
     template <class T>
     struct xcontainer_inner_types;
 
     template <class T>
-    struct has_storage_type<T, void_t<typename xcontainer_inner_types<T>::storage_type>>
-        : std::negation<
-              std::is_same<typename std::remove_cv<typename xcontainer_inner_types<T>::storage_type>::type, invalid_type>>
-    {
+    concept has_storage_type_concept = requires {
+        typename xcontainer_inner_types<T>::storage_type;
+        requires !std::is_same_v<
+                     typename std::remove_cv<typename xcontainer_inner_types<T>::storage_type>::type,
+                     invalid_type>;
     };
+
+    template <class T>
+    constexpr bool has_storage_type()
+    {
+        return has_storage_type_concept<T>;
+    }
 
     /*************************************
      * has_data_interface implementation *
      *************************************/
 
-    template <class E, class = void>
-    struct has_data_interface : std::false_type
-    {
-    };
+    template <class E>
+    concept has_data_interface_concept = requires { std::declval<E>().data(); };
 
     template <class E>
-    struct has_data_interface<E, void_t<decltype(std::declval<E>().data())>> : std::true_type
+    constexpr bool has_data_interface()
     {
-    };
+        return has_data_interface_concept<E>;
+    }
 
     template <class E>
-    concept has_data_interface_concept = has_data_interface<E>::value;
-
-    template <class E, class = void>
-    struct has_strides : std::false_type
-    {
-    };
+    concept has_strides_concept = requires { std::declval<E>().strides(); };
 
     template <class E>
-    struct has_strides<E, void_t<decltype(std::declval<E>().strides())>> : std::true_type
+    constexpr bool has_strides()
     {
-    };
-
-    template <class E, class = void>
-    struct has_iterator_interface : std::false_type
-    {
-    };
+        return has_strides_concept<E>;
+    }
 
     template <class E>
-    struct has_iterator_interface<E, void_t<decltype(std::declval<E>().begin())>> : std::true_type
-    {
-    };
+    concept has_iterator_interface_concept = requires { std::declval<E>().begin(); };
 
     template <class E>
-    concept has_iterator_interface_concept = has_iterator_interface<E>::value;
+    constexpr bool has_iterator_interface()
+    {
+        return has_iterator_interface_concept<E>;
+    }
 
     /******************************
      * is_iterator implementation *
      ******************************/
 
-    template <class E, class = void>
-    struct is_iterator : std::false_type
-    {
+    template <typename E>
+    concept iterator_concept = requires {
+        *std::declval<const E>();
+        std::declval<const E>() == std::declval<const E>();
+        std::declval<const E>() != std::declval<const E>();
+        ++(*std::declval<E*>());
+        (*std::declval<E*>())++;
     };
 
     template <class E>
-    struct is_iterator<
-        E,
-        void_t<
-            decltype(*std::declval<const E>(), std::declval<const E>() == std::declval<const E>(), std::declval<const E>() != std::declval<const E>(), ++(*std::declval<E*>()), (*std::declval<E*>())++, std::true_type())>>
-        : std::true_type
+    constexpr bool is_iterator()
     {
-    };
-
-    template <typename E>
-    concept iterator_concept = is_iterator<E>::value;
+        return iterator_concept<E>;
+    }
 
     /*************************
      * conditional type cast *
@@ -739,38 +731,35 @@ namespace xt
      * has_assign_to *
      *****************/
 
-    template <class E1, class E2, class = void>
-    struct has_assign_to : std::false_type
-    {
-    };
+    template <class E1, class E2>
+    concept has_assign_to_concept = requires { std::declval<const E2&>().assign_to(std::declval<E1&>()); };
 
     template <class E1, class E2>
-    struct has_assign_to<E1, E2, void_t<decltype(std::declval<const E2&>().assign_to(std::declval<E1&>()))>>
-        : std::true_type
+    constexpr bool has_assign_to()
     {
-    };
+        return has_assign_to_concept<E1, E2>;
+    }
 
     template <class E1, class E2>
-    constexpr bool has_assign_to_v = has_assign_to<E1, E2>::value;
+    constexpr bool has_assign_to_v = has_assign_to_concept<E1, E2>;
 
     /*************************************
      * overlapping_memory_checker_traits *
      *************************************/
 
-    template <class T, class Enable = void>
-    struct has_memory_address : std::false_type
-    {
-    };
+    template <class T>
+    concept has_memory_address_concept = requires { std::addressof(*std::declval<T>().begin()); };
 
     template <class T>
-    struct has_memory_address<T, void_t<decltype(std::addressof(*std::declval<T>().begin()))>> : std::true_type
+    constexpr bool has_memory_address()
     {
-    };
+        return has_memory_address_concept<T>;
+    }
 
     template <typename T>
-    concept with_memory_address_concept = has_memory_address<std::decay_t<T>>::value;
+    concept with_memory_address_concept = has_memory_address_concept<std::decay_t<T>>;
     template <typename T>
-    concept without_memory_address_concept = !has_memory_address<std::decay_t<T>>::value;
+    concept without_memory_address_concept = !has_memory_address_concept<std::decay_t<T>>;
 
     struct memory_range
     {
@@ -814,7 +803,7 @@ namespace xt
     };
 
     template <class E>
-    struct overlapping_memory_checker_traits<E, std::enable_if_t<has_memory_address<E>::value>>
+    struct overlapping_memory_checker_traits<E, std::enable_if_t<has_memory_address<E>()>>
     {
         static bool check_overlap(const E& expr, const memory_range& dst_range)
         {
@@ -864,23 +853,23 @@ namespace xt
     };
 
     template <class Dst>
-    struct overlapping_memory_checker<Dst, std::enable_if_t<has_memory_address<Dst>::value>>
+    struct overlapping_memory_checker<Dst, std::enable_if_t<has_memory_address<Dst>()>>
         : overlapping_memory_checker_base
     {
         explicit overlapping_memory_checker(const Dst& aDst)
             : overlapping_memory_checker_base(
-                [&]()
-                {
-                    if (aDst.size() == 0)
-                    {
-                        return memory_range();
-                    }
-                    else
-                    {
-                        return memory_range(std::addressof(*aDst.begin()), std::addressof(*aDst.rbegin()));
-                    }
-                }()
-            )
+                  [&]()
+                  {
+                      if (aDst.size() == 0)
+                      {
+                          return memory_range();
+                      }
+                      else
+                      {
+                          return memory_range(std::addressof(*aDst.begin()), std::addressof(*aDst.rbegin()));
+                      }
+                  }()
+              )
         {
         }
     };
@@ -976,44 +965,33 @@ namespace xt
      * get_rank *
      ************/
 
-    template <class E, typename = void>
-    struct get_rank
-    {
-        static constexpr std::size_t value = SIZE_MAX;
+    // Define the requirement
+    template <typename T>
+    concept HasRank = requires {
+        T::rank;  // Checks if T::rank exists as a type nested member
     };
 
     template <class E>
-    struct get_rank<E, decltype((void) E::rank, void())>
+    constexpr std::size_t has_rank()
     {
-        static constexpr std::size_t value = E::rank;
-    };
-
-    /******************
-     * has_fixed_rank *
-     ******************/
+        return HasRank<E>;
+    }
 
     template <class E>
-    struct has_fixed_rank
+    constexpr std::size_t get_rank()
     {
-        using type = std::integral_constant<bool, get_rank<std::decay_t<E>>::value != SIZE_MAX>;
-    };
+        if constexpr (HasRank<std::decay_t<E>>)
+        {
+            return std::decay_t<E>::rank;
+        }
+        return SIZE_MAX;
+    }
 
     template <class E>
-    using has_fixed_rank_t = typename has_fixed_rank<std::decay_t<E>>::type;
-
-    /************
-     * has_rank *
-     ************/
-
-    template <class E, size_t N>
-    struct has_rank
+    constexpr std::size_t has_fixed_rank()
     {
-        using type = std::integral_constant<bool, get_rank<std::decay_t<E>>::value == N>;
-    };
-
-    template <class E, size_t N>
-    using has_rank_t = typename has_rank<std::decay_t<E>, N>::type;
-
+        return get_rank<E>() != SIZE_MAX;
+    }
 }
 
 #endif

--- a/include/xtensor/utils/xutils.hpp
+++ b/include/xtensor/utils/xutils.hpp
@@ -531,54 +531,29 @@ namespace xt
     }
 
     /***********************************
-     * has_storage_type implementation *
-     ***********************************/
+     * container_expression / data_interface_expression / strided_expression / iterable_expression *
+     ************************************************************************************************/
 
     template <class T>
     struct xcontainer_inner_types;
 
     template <class T>
-    concept has_storage_type_concept = requires {
+    concept container_expression = requires {
         typename xcontainer_inner_types<T>::storage_type;
         requires !std::is_same_v<typename std::remove_cv<typename xcontainer_inner_types<T>::storage_type>::type, invalid_type>;
     };
 
     template <class T>
-    constexpr bool has_storage_type()
-    {
-        return has_storage_type_concept<T>;
-    }
-
-    /*************************************
-     * has_data_interface implementation *
-     *************************************/
+    using get_storage_type_t = typename xcontainer_inner_types<T>::storage_type;
 
     template <class E>
-    concept has_data_interface_concept = requires { std::declval<E>().data(); };
+    concept raw_pointer_accessible_expression = requires { std::declval<E>().data(); };
 
     template <class E>
-    constexpr bool has_data_interface()
-    {
-        return has_data_interface_concept<E>;
-    }
+    concept strided_expression = requires { std::declval<E>().strides(); };
 
     template <class E>
-    concept has_strides_concept = requires { std::declval<E>().strides(); };
-
-    template <class E>
-    constexpr bool has_strides()
-    {
-        return has_strides_concept<E>;
-    }
-
-    template <class E>
-    concept has_iterator_interface_concept = requires { std::declval<E>().begin(); };
-
-    template <class E>
-    constexpr bool has_iterator_interface()
-    {
-        return has_iterator_interface_concept<E>;
-    }
+    concept iterable_expression = requires { std::declval<E>().begin(); };
 
     /******************************
      * is_iterator implementation *
@@ -726,38 +701,23 @@ namespace xt
     }
 
     /*****************
-     * has_assign_to *
-     *****************/
+     * assignable_to *
+     ******************/
 
     template <class E1, class E2>
-    concept has_assign_to_concept = requires { std::declval<const E2&>().assign_to(std::declval<E1&>()); };
-
-    template <class E1, class E2>
-    constexpr bool has_assign_to()
-    {
-        return has_assign_to_concept<E1, E2>;
-    }
-
-    template <class E1, class E2>
-    constexpr bool has_assign_to_v = has_assign_to<E1, E2>();
+    concept assignable_expression = requires { std::declval<const E2&>().assign_to(std::declval<E1&>()); };
 
     /*************************************
      * overlapping_memory_checker_traits *
      *************************************/
 
     template <class T>
-    concept has_memory_address_concept = requires { std::addressof(*std::declval<T>().begin()); };
-
-    template <class T>
-    constexpr bool has_memory_address()
-    {
-        return has_memory_address_concept<T>;
-    }
+    concept addressable_expression = requires { std::addressof(*std::declval<T>().begin()); };
 
     template <typename T>
-    concept with_memory_address_concept = has_memory_address_concept<std::decay_t<T>>;
+    concept with_memory_address_concept = addressable_expression<std::decay_t<T>>;
     template <typename T>
-    concept without_memory_address_concept = !has_memory_address_concept<std::decay_t<T>>;
+    concept without_memory_address_concept = !addressable_expression<std::decay_t<T>>;
 
     struct memory_range
     {
@@ -801,7 +761,7 @@ namespace xt
     };
 
     template <class E>
-    struct overlapping_memory_checker_traits<E, std::enable_if_t<has_memory_address<E>()>>
+    struct overlapping_memory_checker_traits<E, std::enable_if_t<addressable_expression<E>>>
     {
         static bool check_overlap(const E& expr, const memory_range& dst_range)
         {
@@ -851,7 +811,7 @@ namespace xt
     };
 
     template <class Dst>
-    struct overlapping_memory_checker<Dst, std::enable_if_t<has_memory_address<Dst>()>>
+    struct overlapping_memory_checker<Dst, std::enable_if_t<addressable_expression<Dst>>>
         : overlapping_memory_checker_base
     {
         explicit overlapping_memory_checker(const Dst& aDst)

--- a/include/xtensor/utils/xutils.hpp
+++ b/include/xtensor/utils/xutils.hpp
@@ -360,16 +360,14 @@ namespace xt
             res[i] = normalize_axis(expr.dimension(), axes[i]);
         }
 
-        XTENSOR_ASSERT(
-            std::all_of(
-                res.begin(),
-                res.end(),
-                [&expr](auto ax_el)
-                {
-                    return ax_el < expr.dimension();
-                }
-            )
-        );
+        XTENSOR_ASSERT(std::all_of(
+            res.begin(),
+            res.end(),
+            [&expr](auto ax_el)
+            {
+                return ax_el < expr.dimension();
+            }
+        ));
 
         return res;
     }
@@ -381,16 +379,14 @@ namespace xt
     normalize_axis(E& expr, C&& axes)
     {
         static_cast<void>(expr);
-        XTENSOR_ASSERT(
-            std::all_of(
-                axes.begin(),
-                axes.end(),
-                [&expr](auto ax_el)
-                {
-                    return ax_el < expr.dimension();
-                }
-            )
-        );
+        XTENSOR_ASSERT(std::all_of(
+            axes.begin(),
+            axes.end(),
+            [&expr](auto ax_el)
+            {
+                return ax_el < expr.dimension();
+            }
+        ));
         return std::forward<C>(axes);
     }
 
@@ -411,16 +407,14 @@ namespace xt
             }
         );
 
-        XTENSOR_ASSERT(
-            std::all_of(
-                res.begin(),
-                res.end(),
-                [&expr](auto ax_el)
-                {
-                    return ax_el < expr.dimension();
-                }
-            )
-        );
+        XTENSOR_ASSERT(std::all_of(
+            res.begin(),
+            res.end(),
+            [&expr](auto ax_el)
+            {
+                return ax_el < expr.dimension();
+            }
+        ));
 
         return res;
     }
@@ -435,16 +429,14 @@ namespace xt
         R res;
         xt::resize_container(res, std::size(axes));
         std::copy(std::begin(axes), std::end(axes), std::begin(res));
-        XTENSOR_ASSERT(
-            std::all_of(
-                res.begin(),
-                res.end(),
-                [&expr](auto ax_el)
-                {
-                    return ax_el < expr.dimension();
-                }
-            )
-        );
+        XTENSOR_ASSERT(std::all_of(
+            res.begin(),
+            res.end(),
+            [&expr](auto ax_el)
+            {
+                return ax_el < expr.dimension();
+            }
+        ));
         return res;
     }
 
@@ -454,16 +446,14 @@ namespace xt
         R&&>
     {
         static_cast<void>(expr);
-        XTENSOR_ASSERT(
-            std::all_of(
-                std::begin(axes),
-                std::end(axes),
-                [&expr](auto ax_el)
-                {
-                    return ax_el < expr.dimension();
-                }
-            )
-        );
+        XTENSOR_ASSERT(std::all_of(
+            std::begin(axes),
+            std::end(axes),
+            [&expr](auto ax_el)
+            {
+                return ax_el < expr.dimension();
+            }
+        ));
         return std::move(axes);
     }
 
@@ -547,7 +537,7 @@ namespace xt
     using get_storage_type_t = typename xcontainer_inner_types<T>::storage_type;
 
     template <class E>
-    concept raw_pointer_accessible_expression = requires { std::declval<E>().data(); };
+    concept data_interface_expression = requires { std::declval<E>().data(); };
 
     template <class E>
     concept strided_expression = requires { std::declval<E>().strides(); };
@@ -816,18 +806,18 @@ namespace xt
     {
         explicit overlapping_memory_checker(const Dst& aDst)
             : overlapping_memory_checker_base(
-                  [&]()
-                  {
-                      if (aDst.size() == 0)
-                      {
-                          return memory_range();
-                      }
-                      else
-                      {
-                          return memory_range(std::addressof(*aDst.begin()), std::addressof(*aDst.rbegin()));
-                      }
-                  }()
-              )
+                [&]()
+                {
+                    if (aDst.size() == 0)
+                    {
+                        return memory_range();
+                    }
+                    else
+                    {
+                        return memory_range(std::addressof(*aDst.begin()), std::addressof(*aDst.rbegin()));
+                    }
+                }()
+            )
         {
         }
     };

--- a/include/xtensor/utils/xutils.hpp
+++ b/include/xtensor/utils/xutils.hpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <tuple>
 #include <type_traits>
@@ -545,25 +546,6 @@ namespace xt
     template <class E>
     concept iterable_expression = requires { std::declval<E>().begin(); };
 
-    /******************************
-     * is_iterator implementation *
-     ******************************/
-
-    template <typename E>
-    concept iterator_concept = requires {
-        *std::declval<const E>();
-        std::declval<const E>() == std::declval<const E>();
-        std::declval<const E>() != std::declval<const E>();
-        ++(*std::declval<E*>());
-        (*std::declval<E*>())++;
-    };
-
-    template <class E>
-    constexpr bool is_iterator()
-    {
-        return iterator_concept<E>;
-    }
-
     /*************************
      * conditional type cast *
      *************************/
@@ -695,19 +677,14 @@ namespace xt
      ******************/
 
     template <class E1, class E2>
-    concept assignable_expression = requires { std::declval<const E2&>().assign_to(std::declval<E1&>()); };
+    concept assignable_to_expression = requires { std::declval<const E2&>().assign_to(std::declval<E1&>()); };
 
     /*************************************
      * overlapping_memory_checker_traits *
      *************************************/
 
     template <class T>
-    concept addressable_expression = requires { std::addressof(*std::declval<T>().begin()); };
-
-    template <typename T>
-    concept with_memory_address_concept = addressable_expression<std::decay_t<T>>;
-    template <typename T>
-    concept without_memory_address_concept = !addressable_expression<std::decay_t<T>>;
+    concept addressable_to_expression = requires { std::addressof(*std::declval<T>().begin()); };
 
     struct memory_range
     {
@@ -751,7 +728,7 @@ namespace xt
     };
 
     template <class E>
-    struct overlapping_memory_checker_traits<E, std::enable_if_t<addressable_expression<E>>>
+    struct overlapping_memory_checker_traits<E, std::enable_if_t<addressable_to_expression<E>>>
     {
         static bool check_overlap(const E& expr, const memory_range& dst_range)
         {
@@ -801,7 +778,7 @@ namespace xt
     };
 
     template <class Dst>
-    struct overlapping_memory_checker<Dst, std::enable_if_t<addressable_expression<Dst>>>
+    struct overlapping_memory_checker<Dst, std::enable_if_t<addressable_to_expression<Dst>>>
         : overlapping_memory_checker_base
     {
         explicit overlapping_memory_checker(const Dst& aDst)

--- a/include/xtensor/views/xbroadcast.hpp
+++ b/include/xtensor/views/xbroadcast.hpp
@@ -124,7 +124,7 @@ namespace xt
      *************************************/
 
     template <xbroadcast_concept E>
-        requires(without_memory_address_concept<E>)
+        requires(!addressable_to_expression<std::decay_t<E>>)
     struct overlapping_memory_checker_traits<E>
     {
         static bool check_overlap(const E& expr, const memory_range& dst_range)

--- a/include/xtensor/views/xdynamic_view.hpp
+++ b/include/xtensor/views/xdynamic_view.hpp
@@ -50,9 +50,9 @@ namespace xt
 
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 8
         static constexpr auto
-            random_instantiation_var_for_gcc8_data_iface = has_data_interface<xdynamic_view<CT, S, L, FST>>();
+            random_instantiation_var_for_gcc8_data_iface = data_interface_expression<xdynamic_view<CT, S, L, FST>>;
         static constexpr auto
-            random_instantiation_var_for_gcc8_has_strides = has_strides<xdynamic_view<CT, S, L, FST>>();
+            random_instantiation_var_for_gcc8_has_strides = strided_expression<xdynamic_view<CT, S, L, FST>>;
 #endif
 
         // TODO: implement efficient stepper specific to the dynamic_view

--- a/include/xtensor/views/xdynamic_view.hpp
+++ b/include/xtensor/views/xdynamic_view.hpp
@@ -50,9 +50,9 @@ namespace xt
 
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 8
         static constexpr auto
-            random_instantiation_var_for_gcc8_data_iface = has_data_interface<xdynamic_view<CT, S, L, FST>>::value;
+            random_instantiation_var_for_gcc8_data_iface = has_data_interface<xdynamic_view<CT, S, L, FST>>();
         static constexpr auto
-            random_instantiation_var_for_gcc8_has_strides = has_strides<xdynamic_view<CT, S, L, FST>>::value;
+            random_instantiation_var_for_gcc8_has_strides = has_strides<xdynamic_view<CT, S, L, FST>>();
 #endif
 
         // TODO: implement efficient stepper specific to the dynamic_view

--- a/include/xtensor/views/xfunctor_view.hpp
+++ b/include/xtensor/views/xfunctor_view.hpp
@@ -93,24 +93,24 @@ namespace xt
         using difference_type = typename xexpression_type::difference_type;
 
         using shape_type = typename xexpression_type::shape_type;
-        using strides_type = xtl::mpl::eval_if_t<
-            has_strides<xexpression_type>,
+        using strides_type = typename std::conditional_t<
+            has_strides<xexpression_type>(),
             detail::expr_strides_type<xexpression_type>,
-            get_strides_type<shape_type>>;
-        using backstrides_type = xtl::mpl::eval_if_t<
-            has_strides<xexpression_type>,
+            get_strides_type<shape_type>>::type;
+        using backstrides_type = typename std::conditional_t<
+            has_strides<xexpression_type>(),
             detail::expr_backstrides_type<xexpression_type>,
-            get_strides_type<shape_type>>;
+            get_strides_type<shape_type>>::type;
 
         using inner_shape_type = typename xexpression_type::inner_shape_type;
-        using inner_strides_type = xtl::mpl::eval_if_t<
-            has_strides<xexpression_type>,
+        using inner_strides_type = typename std::conditional_t<
+            has_strides<xexpression_type>(),
             detail::expr_inner_strides_type<xexpression_type>,
-            get_strides_type<shape_type>>;
-        using inner_backstrides_type = xtl::mpl::eval_if_t<
-            has_strides<xexpression_type>,
+            get_strides_type<shape_type>>::type;
+        using inner_backstrides_type = typename std::conditional_t<
+            has_strides<xexpression_type>(),
             detail::expr_inner_backstrides_type<xexpression_type>,
-            get_strides_type<shape_type>>;
+            get_strides_type<shape_type>>::type;
 
         using bool_load_type = xt::bool_load_type<value_type>;
 

--- a/include/xtensor/views/xfunctor_view.hpp
+++ b/include/xtensor/views/xfunctor_view.hpp
@@ -94,21 +94,21 @@ namespace xt
 
         using shape_type = typename xexpression_type::shape_type;
         using strides_type = typename std::conditional_t<
-            has_strides<xexpression_type>(),
+            strided_expression<xexpression_type>,
             detail::expr_strides_type<xexpression_type>,
             get_strides_type<shape_type>>::type;
         using backstrides_type = typename std::conditional_t<
-            has_strides<xexpression_type>(),
+            strided_expression<xexpression_type>,
             detail::expr_backstrides_type<xexpression_type>,
             get_strides_type<shape_type>>::type;
 
         using inner_shape_type = typename xexpression_type::inner_shape_type;
         using inner_strides_type = typename std::conditional_t<
-            has_strides<xexpression_type>(),
+            strided_expression<xexpression_type>,
             detail::expr_inner_strides_type<xexpression_type>,
             get_strides_type<shape_type>>::type;
         using inner_backstrides_type = typename std::conditional_t<
-            has_strides<xexpression_type>(),
+            strided_expression<xexpression_type>,
             detail::expr_inner_backstrides_type<xexpression_type>,
             get_strides_type<shape_type>>::type;
 

--- a/include/xtensor/views/xrepeat.hpp
+++ b/include/xtensor/views/xrepeat.hpp
@@ -65,7 +65,7 @@ namespace xt
         static constexpr bool is_const = std::is_const<std::remove_reference_t<CT>>::value;
 
         using extract_storage_type = typename std::conditional_t<
-            has_data_interface<xexpression_type>(),
+            data_interface_expression<xexpression_type>,
             detail::expr_storage_type<xexpression_type>,
             make_invalid_type<>>::type;
         using storage_type = std::conditional_t<is_const, const extract_storage_type, extract_storage_type>;

--- a/include/xtensor/views/xrepeat.hpp
+++ b/include/xtensor/views/xrepeat.hpp
@@ -64,10 +64,10 @@ namespace xt
 
         static constexpr bool is_const = std::is_const<std::remove_reference_t<CT>>::value;
 
-        using extract_storage_type = xtl::mpl::eval_if_t<
-            has_data_interface<xexpression_type>,
+        using extract_storage_type = typename std::conditional_t<
+            has_data_interface<xexpression_type>(),
             detail::expr_storage_type<xexpression_type>,
-            make_invalid_type<>>;
+            make_invalid_type<>>::type;
         using storage_type = std::conditional_t<is_const, const extract_storage_type, extract_storage_type>;
     };
 

--- a/include/xtensor/views/xstrided_view_base.hpp
+++ b/include/xtensor/views/xstrided_view_base.hpp
@@ -87,7 +87,8 @@ namespace xt
 
         template <class E, class ST>
         struct provides_data_interface
-            : std::conjunction<has_data_interface<std::decay_t<E>>, std::negation<is_flat_expression_adaptor<ST>>>
+            : std::bool_constant<
+                  has_data_interface<std::decay_t<E>>() && !is_flat_expression_adaptor<ST>::value>
         {
         };
     }
@@ -278,7 +279,7 @@ namespace xt
 
         template <class CT, layout_type L>
         using flat_storage_getter = std::conditional_t<
-            has_data_interface<std::decay_t<CT>>::value,
+            has_data_interface<std::decay_t<CT>>(),
             inner_storage_getter<CT>,
             flat_adaptor_getter<CT, L>>;
 
@@ -654,7 +655,7 @@ namespace xt
     template <class O>
     inline bool xstrided_view_base<D>::has_linear_assign(const O& str) const noexcept
     {
-        return has_data_interface<xexpression_type>::value && str.size() == strides().size()
+        return has_data_interface<xexpression_type>() && str.size() == strides().size()
                && std::equal(str.cbegin(), str.cend(), strides().begin());
     }
 

--- a/include/xtensor/views/xstrided_view_base.hpp
+++ b/include/xtensor/views/xstrided_view_base.hpp
@@ -87,8 +87,7 @@ namespace xt
 
         template <class E, class ST>
         struct provides_data_interface
-            : std::bool_constant<
-                  raw_pointer_accessible_expression<std::decay_t<E>> && !is_flat_expression_adaptor<ST>::value>
+            : std::bool_constant<data_interface_expression<std::decay_t<E>> && !is_flat_expression_adaptor<ST>::value>
         {
         };
     }

--- a/include/xtensor/views/xstrided_view_base.hpp
+++ b/include/xtensor/views/xstrided_view_base.hpp
@@ -87,8 +87,7 @@ namespace xt
 
         template <class E, class ST>
         struct provides_data_interface
-            : std::bool_constant<
-                  has_data_interface<std::decay_t<E>>() && !is_flat_expression_adaptor<ST>::value>
+            : std::bool_constant<has_data_interface<std::decay_t<E>>() && !is_flat_expression_adaptor<ST>::value>
         {
         };
     }

--- a/include/xtensor/views/xstrided_view_base.hpp
+++ b/include/xtensor/views/xstrided_view_base.hpp
@@ -87,7 +87,8 @@ namespace xt
 
         template <class E, class ST>
         struct provides_data_interface
-            : std::bool_constant<has_data_interface<std::decay_t<E>>() && !is_flat_expression_adaptor<ST>::value>
+            : std::bool_constant<
+                  raw_pointer_accessible_expression<std::decay_t<E>> && !is_flat_expression_adaptor<ST>::value>
         {
         };
     }
@@ -278,7 +279,7 @@ namespace xt
 
         template <class CT, layout_type L>
         using flat_storage_getter = std::conditional_t<
-            has_data_interface<std::decay_t<CT>>(),
+            data_interface_expression<std::decay_t<CT>>,
             inner_storage_getter<CT>,
             flat_adaptor_getter<CT, L>>;
 
@@ -654,7 +655,7 @@ namespace xt
     template <class O>
     inline bool xstrided_view_base<D>::has_linear_assign(const O& str) const noexcept
     {
-        return has_data_interface<xexpression_type>() && str.size() == strides().size()
+        return data_interface_expression<xexpression_type> && str.size() == strides().size()
                && std::equal(str.cbegin(), str.cend(), strides().begin());
     }
 

--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -154,7 +154,7 @@ namespace xt
         // If we have no discontiguous slices, we can calculate strides for this view.
         template <class E, class... S>
         struct is_strided_view
-            : std::integral_constant<bool, raw_pointer_accessible_expression<E> && is_strided_slice<S...>()>
+            : std::integral_constant<bool, data_interface_expression<E> && is_strided_slice<S...>()>
         {
         };
 
@@ -309,7 +309,7 @@ namespace xt
         static constexpr bool is_const = std::is_const<std::remove_reference_t<CT>>::value;
 
         using extract_storage_type = typename std::conditional_t<
-            raw_pointer_accessible_expression<xexpression_type>,
+            data_interface_expression<xexpression_type>,
             detail::expr_storage_type<xexpression_type>,
             make_invalid_type<>>::type;
         using storage_type = std::conditional_t<is_const, const extract_storage_type, extract_storage_type>;

--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -129,8 +129,8 @@ namespace xt
         template <class CT, class... S>
         struct is_xscalar_impl<xview<CT, S...>>
         {
-            static constexpr bool value = static_cast<std::ptrdiff_t>(integral_count<S...>())
-                                                  == static_dimension<typename std::decay_t<CT>::shape_type>::value
+            static constexpr bool value = static_cast<std::ptrdiff_t>(integral_count<S...>()
+                                          ) == static_dimension<typename std::decay_t<CT>::shape_type>::value
                                               ? true
                                               : false;
         };
@@ -879,11 +879,11 @@ namespace xt
     template <class CTA, class FSL, class... SL>
     xview<CT, S...>::xview(CTA&& e, FSL&& first_slice, SL&&... slices) noexcept
         : xview(
-              std::integral_constant<bool, has_trivial_strides>{},
-              std::forward<CTA>(e),
-              std::forward<FSL>(first_slice),
-              std::forward<SL>(slices)...
-          )
+            std::integral_constant<bool, has_trivial_strides>{},
+            std::forward<CTA>(e),
+            std::forward<FSL>(first_slice),
+            std::forward<SL>(slices)...
+        )
     {
     }
 
@@ -1266,29 +1266,27 @@ namespace xt
      */
     template <class CT, class... S>
     template <class T>
-    inline auto xview<CT, S...>::strides() const -> const inner_strides_type&
-        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
-    {
-        if (!m_strides_computed)
-        {
-            compute_strides(std::integral_constant<bool, has_trivial_strides>{});
-            m_strides_computed = true;
+    inline auto xview<CT, S...>::strides() const
+        -> const inner_strides_type& requires(data_interface_expression<T>and strided_view_concept<CT, S...>) {
+            if (!m_strides_computed)
+            {
+                compute_strides(std::integral_constant<bool, has_trivial_strides>{});
+                m_strides_computed = true;
+            }
+            return m_strides;
         }
-        return m_strides;
-    }
 
     template <class CT, class... S>
     template <class T>
-    inline auto xview<CT, S...>::backstrides() const -> const inner_strides_type&
-        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
-    {
-        if (!m_strides_computed)
-        {
-            compute_strides(std::integral_constant<bool, has_trivial_strides>{});
-            m_strides_computed = true;
+    inline auto xview<CT, S...>::backstrides() const
+        -> const inner_strides_type& requires(data_interface_expression<T>and strided_view_concept<CT, S...>) {
+            if (!m_strides_computed)
+            {
+                compute_strides(std::integral_constant<bool, has_trivial_strides>{});
+                m_strides_computed = true;
+            }
+            return m_backstrides;
         }
-        return m_backstrides;
-    }
 
     /**
      * Return the pointer to the underlying buffer.
@@ -1699,8 +1697,9 @@ namespace xt
             return xt::value(s, 0);
         };
 
-        auto s = static_cast<diff_type>((std::min) (static_cast<size_type>(std::distance(first, last)),
-                                                    this->dimension()));
+        auto s = static_cast<diff_type>(
+            (std::min)(static_cast<size_type>(std::distance(first, last)), this->dimension())
+        );
         auto first_copy = last - s;
         for (size_type i = 0; i != m_e.dimension(); ++i)
         {

--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -129,8 +129,8 @@ namespace xt
         template <class CT, class... S>
         struct is_xscalar_impl<xview<CT, S...>>
         {
-            static constexpr bool value = static_cast<std::ptrdiff_t>(integral_count<S...>())
-                                                  == static_dimension<typename std::decay_t<CT>::shape_type>::value
+            static constexpr bool value = static_cast<std::ptrdiff_t>(integral_count<S...>()
+                                          ) == static_dimension<typename std::decay_t<CT>::shape_type>::value
                                               ? true
                                               : false;
         };
@@ -879,11 +879,11 @@ namespace xt
     template <class CTA, class FSL, class... SL>
     xview<CT, S...>::xview(CTA&& e, FSL&& first_slice, SL&&... slices) noexcept
         : xview(
-              std::integral_constant<bool, has_trivial_strides>{},
-              std::forward<CTA>(e),
-              std::forward<FSL>(first_slice),
-              std::forward<SL>(slices)...
-          )
+            std::integral_constant<bool, has_trivial_strides>{},
+            std::forward<CTA>(e),
+            std::forward<FSL>(first_slice),
+            std::forward<SL>(slices)...
+        )
     {
     }
 
@@ -1266,29 +1266,27 @@ namespace xt
      */
     template <class CT, class... S>
     template <class T>
-    inline auto xview<CT, S...>::strides() const -> const inner_strides_type&
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
-    {
-        if (!m_strides_computed)
-        {
-            compute_strides(std::integral_constant<bool, has_trivial_strides>{});
-            m_strides_computed = true;
+    inline auto xview<CT, S...>::strides() const
+        -> const inner_strides_type& requires(has_data_interface_concept<T>and strided_view_concept<CT, S...>) {
+            if (!m_strides_computed)
+            {
+                compute_strides(std::integral_constant<bool, has_trivial_strides>{});
+                m_strides_computed = true;
+            }
+            return m_strides;
         }
-        return m_strides;
-    }
 
     template <class CT, class... S>
     template <class T>
-    inline auto xview<CT, S...>::backstrides() const -> const inner_strides_type&
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
-    {
-        if (!m_strides_computed)
-        {
-            compute_strides(std::integral_constant<bool, has_trivial_strides>{});
-            m_strides_computed = true;
+    inline auto xview<CT, S...>::backstrides() const
+        -> const inner_strides_type& requires(has_data_interface_concept<T>and strided_view_concept<CT, S...>) {
+            if (!m_strides_computed)
+            {
+                compute_strides(std::integral_constant<bool, has_trivial_strides>{});
+                m_strides_computed = true;
+            }
+            return m_backstrides;
         }
-        return m_backstrides;
-    }
 
     /**
      * Return the pointer to the underlying buffer.
@@ -1699,8 +1697,9 @@ namespace xt
             return xt::value(s, 0);
         };
 
-        auto s = static_cast<diff_type>((std::min) (static_cast<size_type>(std::distance(first, last)),
-                                                    this->dimension()));
+        auto s = static_cast<diff_type>(
+            (std::min)(static_cast<size_type>(std::distance(first, last)), this->dimension())
+        );
         auto first_copy = last - s;
         for (size_type i = 0; i != m_e.dimension(); ++i)
         {

--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -129,31 +129,32 @@ namespace xt
         template <class CT, class... S>
         struct is_xscalar_impl<xview<CT, S...>>
         {
-            static constexpr bool value = static_cast<std::ptrdiff_t>(integral_count<S...>()
-                                          ) == static_dimension<typename std::decay_t<CT>::shape_type>::value
+            static constexpr bool value = static_cast<std::ptrdiff_t>(integral_count<S...>())
+                                                  == static_dimension<typename std::decay_t<CT>::shape_type>::value
                                               ? true
                                               : false;
         };
 
-        template <class S>
-        struct is_strided_slice_impl : std::true_type
-        {
-        };
+        template <typename S>
+        inline constexpr bool is_strided_slice_impl = true;
+        template <typename T>
+        inline constexpr bool is_strided_slice_impl<xkeep_slice<T>> = false;
+        template <typename T>
+        inline constexpr bool is_strided_slice_impl<xdrop_slice<T>> = false;
 
-        template <class T>
-        struct is_strided_slice_impl<xkeep_slice<T>> : std::false_type
-        {
-        };
+        template <typename S>
+        concept is_strided_slice_concept = is_strided_slice_impl<S>;
 
-        template <class T>
-        struct is_strided_slice_impl<xdrop_slice<T>> : std::false_type
+        template <class... S>
+        constexpr bool is_strided_slice()
         {
-        };
+            return (is_strided_slice_concept<std::decay_t<S>> && ...);
+        }
 
         // If we have no discontiguous slices, we can calculate strides for this view.
         template <class E, class... S>
         struct is_strided_view
-            : std::integral_constant<bool, has_data_interface<E>() && (is_strided_slice_impl<std::decay_t<S>>::value && ...)>
+            : std::integral_constant<bool, has_data_interface<E>() && is_strided_slice<S...>()>
         {
         };
 
@@ -878,11 +879,11 @@ namespace xt
     template <class CTA, class FSL, class... SL>
     xview<CT, S...>::xview(CTA&& e, FSL&& first_slice, SL&&... slices) noexcept
         : xview(
-            std::integral_constant<bool, has_trivial_strides>{},
-            std::forward<CTA>(e),
-            std::forward<FSL>(first_slice),
-            std::forward<SL>(slices)...
-        )
+              std::integral_constant<bool, has_trivial_strides>{},
+              std::forward<CTA>(e),
+              std::forward<FSL>(first_slice),
+              std::forward<SL>(slices)...
+          )
     {
     }
 
@@ -1265,27 +1266,29 @@ namespace xt
      */
     template <class CT, class... S>
     template <class T>
-    inline auto xview<CT, S...>::strides() const
-        -> const inner_strides_type& requires(has_data_interface_concept<T>and strided_view_concept<CT, S...>) {
-            if (!m_strides_computed)
-            {
-                compute_strides(std::integral_constant<bool, has_trivial_strides>{});
-                m_strides_computed = true;
-            }
-            return m_strides;
+    inline auto xview<CT, S...>::strides() const -> const inner_strides_type&
+        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+    {
+        if (!m_strides_computed)
+        {
+            compute_strides(std::integral_constant<bool, has_trivial_strides>{});
+            m_strides_computed = true;
         }
+        return m_strides;
+    }
 
     template <class CT, class... S>
     template <class T>
-    inline auto xview<CT, S...>::backstrides() const
-        -> const inner_strides_type& requires(has_data_interface_concept<T>and strided_view_concept<CT, S...>) {
-            if (!m_strides_computed)
-            {
-                compute_strides(std::integral_constant<bool, has_trivial_strides>{});
-                m_strides_computed = true;
-            }
-            return m_backstrides;
+    inline auto xview<CT, S...>::backstrides() const -> const inner_strides_type&
+        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+    {
+        if (!m_strides_computed)
+        {
+            compute_strides(std::integral_constant<bool, has_trivial_strides>{});
+            m_strides_computed = true;
         }
+        return m_backstrides;
+    }
 
     /**
      * Return the pointer to the underlying buffer.
@@ -1696,9 +1699,8 @@ namespace xt
             return xt::value(s, 0);
         };
 
-        auto s = static_cast<diff_type>(
-            (std::min)(static_cast<size_type>(std::distance(first, last)), this->dimension())
-        );
+        auto s = static_cast<diff_type>((std::min) (static_cast<size_type>(std::distance(first, last)),
+                                                    this->dimension()));
         auto first_copy = last - s;
         for (size_type i = 0; i != m_e.dimension(); ++i)
         {

--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -155,7 +155,7 @@ namespace xt
         struct is_strided_view
             : std::integral_constant<
                   bool,
-                  std::conjunction<has_data_interface<E>, is_strided_slice_impl<std::decay_t<S>>...>::value>
+                  has_data_interface<E>() && (is_strided_slice_impl<std::decay_t<S>>::value && ...)>
         {
         };
 
@@ -228,7 +228,7 @@ namespace xt
         struct is_contiguous_view
             : std::integral_constant<
                   bool,
-                  has_data_interface<E>::value
+                  has_data_interface<E>()
                       && !(
                           E::static_layout == layout_type::column_major
                           && static_cast<std::size_t>(static_dimension<typename E::shape_type>::value) != sizeof...(S)
@@ -309,10 +309,10 @@ namespace xt
 
         static constexpr bool is_const = std::is_const<std::remove_reference_t<CT>>::value;
 
-        using extract_storage_type = xtl::mpl::eval_if_t<
-            has_data_interface<xexpression_type>,
+        using extract_storage_type = typename std::conditional_t<
+            has_data_interface<xexpression_type>(),
             detail::expr_storage_type<xexpression_type>,
-            make_invalid_type<>>;
+            make_invalid_type<>>::type;
         using storage_type = std::conditional_t<is_const, const extract_storage_type, extract_storage_type>;
     };
 
@@ -397,15 +397,15 @@ namespace xt
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = typename xview_shape_type<typename xexpression_type::shape_type, S...>::type;
 
-        using xexpression_inner_strides_type = xtl::mpl::eval_if_t<
-            has_strides<xexpression_type>,
+        using xexpression_inner_strides_type = typename std::conditional_t<
+            has_strides<xexpression_type>(),
             detail::expr_inner_strides_type<xexpression_type>,
-            get_strides_type<shape_type>>;
+            get_strides_type<shape_type>>::type;
 
-        using xexpression_inner_backstrides_type = xtl::mpl::eval_if_t<
-            has_strides<xexpression_type>,
+        using xexpression_inner_backstrides_type = typename std::conditional_t<
+            has_strides<xexpression_type>(),
             detail::expr_inner_backstrides_type<xexpression_type>,
-            get_strides_type<shape_type>>;
+            get_strides_type<shape_type>>::type;
 
         using storage_type = typename inner_types::storage_type;
 
@@ -437,11 +437,11 @@ namespace xt
         using const_stepper = typename iterable_base::const_stepper;
 
         using linear_iterator = std::conditional_t<
-            has_data_interface<xexpression_type>::value && is_strided_view,
+            has_data_interface<xexpression_type>() && is_strided_view,
             std::conditional_t<is_const, typename xexpression_type::const_linear_iterator, typename xexpression_type::linear_iterator>,
             typename iterable_base::linear_iterator>;
         using const_linear_iterator = std::conditional_t<
-            has_data_interface<xexpression_type>::value && is_strided_view,
+            has_data_interface<xexpression_type>() && is_strided_view,
             typename xexpression_type::const_linear_iterator,
             typename iterable_base::const_linear_iterator>;
 

--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -129,8 +129,8 @@ namespace xt
         template <class CT, class... S>
         struct is_xscalar_impl<xview<CT, S...>>
         {
-            static constexpr bool value = static_cast<std::ptrdiff_t>(integral_count<S...>()
-                                          ) == static_dimension<typename std::decay_t<CT>::shape_type>::value
+            static constexpr bool value = static_cast<std::ptrdiff_t>(integral_count<S...>())
+                                                  == static_dimension<typename std::decay_t<CT>::shape_type>::value
                                               ? true
                                               : false;
         };
@@ -154,7 +154,7 @@ namespace xt
         // If we have no discontiguous slices, we can calculate strides for this view.
         template <class E, class... S>
         struct is_strided_view
-            : std::integral_constant<bool, has_data_interface<E>() && is_strided_slice<S...>()>
+            : std::integral_constant<bool, raw_pointer_accessible_expression<E> && is_strided_slice<S...>()>
         {
         };
 
@@ -227,7 +227,7 @@ namespace xt
         struct is_contiguous_view
             : std::integral_constant<
                   bool,
-                  has_data_interface<E>()
+                  data_interface_expression<E>
                       && !(
                           E::static_layout == layout_type::column_major
                           && static_cast<std::size_t>(static_dimension<typename E::shape_type>::value) != sizeof...(S)
@@ -309,7 +309,7 @@ namespace xt
         static constexpr bool is_const = std::is_const<std::remove_reference_t<CT>>::value;
 
         using extract_storage_type = typename std::conditional_t<
-            has_data_interface<xexpression_type>(),
+            raw_pointer_accessible_expression<xexpression_type>,
             detail::expr_storage_type<xexpression_type>,
             make_invalid_type<>>::type;
         using storage_type = std::conditional_t<is_const, const extract_storage_type, extract_storage_type>;
@@ -397,12 +397,12 @@ namespace xt
         using shape_type = typename xview_shape_type<typename xexpression_type::shape_type, S...>::type;
 
         using xexpression_inner_strides_type = typename std::conditional_t<
-            has_strides<xexpression_type>(),
+            strided_expression<xexpression_type>,
             detail::expr_inner_strides_type<xexpression_type>,
             get_strides_type<shape_type>>::type;
 
         using xexpression_inner_backstrides_type = typename std::conditional_t<
-            has_strides<xexpression_type>(),
+            strided_expression<xexpression_type>,
             detail::expr_inner_backstrides_type<xexpression_type>,
             get_strides_type<shape_type>>::type;
 
@@ -436,11 +436,11 @@ namespace xt
         using const_stepper = typename iterable_base::const_stepper;
 
         using linear_iterator = std::conditional_t<
-            has_data_interface<xexpression_type>() && is_strided_view,
+            data_interface_expression<xexpression_type> && is_strided_view,
             std::conditional_t<is_const, typename xexpression_type::const_linear_iterator, typename xexpression_type::linear_iterator>,
             typename iterable_base::linear_iterator>;
         using const_linear_iterator = std::conditional_t<
-            has_data_interface<xexpression_type>() && is_strided_view,
+            data_interface_expression<xexpression_type> && is_strided_view,
             typename xexpression_type::const_linear_iterator,
             typename iterable_base::const_linear_iterator>;
 
@@ -509,79 +509,79 @@ namespace xt
 
         template <class T = xexpression_type>
         storage_type& storage()
-            requires(has_data_interface_concept<T>);
+            requires(data_interface_expression<T>);
 
         template <class T = xexpression_type>
         const storage_type& storage() const
-            requires(has_data_interface_concept<T>);
+            requires(data_interface_expression<T>);
 
         template <class T = xexpression_type>
         linear_iterator linear_begin()
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         linear_iterator linear_end()
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const_linear_iterator linear_begin() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const_linear_iterator linear_end() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const_linear_iterator linear_cbegin() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const_linear_iterator linear_cend() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         reverse_linear_iterator linear_rbegin()
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         reverse_linear_iterator linear_rend()
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const_reverse_linear_iterator linear_rbegin() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const_reverse_linear_iterator linear_rend() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const_reverse_linear_iterator linear_crbegin() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const_reverse_linear_iterator linear_crend() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const inner_strides_type& strides() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const inner_strides_type& backstrides() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         const_pointer data() const
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         pointer data()
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class T = xexpression_type>
         std::size_t data_offset() const noexcept
-            requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>);
+            requires(data_interface_expression<T> and strided_view_concept<CT, S...>);
 
         template <class It>
         inline It data_xbegin_impl(It begin) const noexcept;
@@ -615,7 +615,7 @@ namespace xt
 
         template <class E, class T = xexpression_type>
         void assign_to(xexpression<E>& e, bool force_resize) const
-            requires(has_data_interface_concept<T> and contiguous_view_concept<E, S...>);
+            requires(data_interface_expression<T> and contiguous_view_concept<E, S...>);
 
         template <class E>
         using rebind_t = xview<E, S...>;
@@ -879,11 +879,11 @@ namespace xt
     template <class CTA, class FSL, class... SL>
     xview<CT, S...>::xview(CTA&& e, FSL&& first_slice, SL&&... slices) noexcept
         : xview(
-            std::integral_constant<bool, has_trivial_strides>{},
-            std::forward<CTA>(e),
-            std::forward<FSL>(first_slice),
-            std::forward<SL>(slices)...
-        )
+              std::integral_constant<bool, has_trivial_strides>{},
+              std::forward<CTA>(e),
+              std::forward<FSL>(first_slice),
+              std::forward<SL>(slices)...
+          )
     {
     }
 
@@ -1152,7 +1152,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     inline auto xview<CT, S...>::storage() -> storage_type&
-        requires(has_data_interface_concept<T>)
+        requires(data_interface_expression<T>)
     {
         return m_e.storage();
     }
@@ -1160,7 +1160,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     inline auto xview<CT, S...>::storage() const -> const storage_type&
-        requires(has_data_interface_concept<T>)
+        requires(data_interface_expression<T>)
     {
         return m_e.storage();
     }
@@ -1168,7 +1168,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_begin() -> linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return m_e.storage().begin() + data_offset();
     }
@@ -1176,7 +1176,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_end() -> linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return m_e.storage().begin() + data_offset() + this->size();
     }
@@ -1184,7 +1184,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_begin() const -> const_linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return linear_cbegin();
     }
@@ -1192,7 +1192,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_end() const -> const_linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return linear_cend();
     }
@@ -1200,7 +1200,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_cbegin() const -> const_linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return m_e.storage().cbegin() + data_offset();
     }
@@ -1208,7 +1208,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_cend() const -> const_linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return m_e.storage().cbegin() + data_offset() + this->size();
     }
@@ -1216,7 +1216,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_rbegin() -> reverse_linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return reverse_linear_iterator(linear_end());
     }
@@ -1224,7 +1224,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_rend() -> reverse_linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return reverse_linear_iterator(linear_begin());
     }
@@ -1232,7 +1232,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_rbegin() const -> const_reverse_linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return linear_crbegin();
     }
@@ -1240,7 +1240,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_rend() const -> const_reverse_linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return linear_crend();
     }
@@ -1248,7 +1248,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_crbegin() const -> const_reverse_linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return const_reverse_linear_iterator(linear_end());
     }
@@ -1256,7 +1256,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     auto xview<CT, S...>::linear_crend() const -> const_reverse_linear_iterator
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return const_reverse_linear_iterator(linear_begin());
     }
@@ -1266,27 +1266,29 @@ namespace xt
      */
     template <class CT, class... S>
     template <class T>
-    inline auto xview<CT, S...>::strides() const
-        -> const inner_strides_type& requires(has_data_interface_concept<T>and strided_view_concept<CT, S...>) {
-            if (!m_strides_computed)
-            {
-                compute_strides(std::integral_constant<bool, has_trivial_strides>{});
-                m_strides_computed = true;
-            }
-            return m_strides;
+    inline auto xview<CT, S...>::strides() const -> const inner_strides_type&
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
+    {
+        if (!m_strides_computed)
+        {
+            compute_strides(std::integral_constant<bool, has_trivial_strides>{});
+            m_strides_computed = true;
         }
+        return m_strides;
+    }
 
     template <class CT, class... S>
     template <class T>
-    inline auto xview<CT, S...>::backstrides() const
-        -> const inner_strides_type& requires(has_data_interface_concept<T>and strided_view_concept<CT, S...>) {
-            if (!m_strides_computed)
-            {
-                compute_strides(std::integral_constant<bool, has_trivial_strides>{});
-                m_strides_computed = true;
-            }
-            return m_backstrides;
+    inline auto xview<CT, S...>::backstrides() const -> const inner_strides_type&
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
+    {
+        if (!m_strides_computed)
+        {
+            compute_strides(std::integral_constant<bool, has_trivial_strides>{});
+            m_strides_computed = true;
         }
+        return m_backstrides;
+    }
 
     /**
      * Return the pointer to the underlying buffer.
@@ -1294,7 +1296,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     inline auto xview<CT, S...>::data() const -> const_pointer
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return m_e.data();
     }
@@ -1302,7 +1304,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     inline auto xview<CT, S...>::data() -> pointer
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         return m_e.data();
     }
@@ -1334,7 +1336,7 @@ namespace xt
     template <class CT, class... S>
     template <class T>
     inline std::size_t xview<CT, S...>::data_offset() const noexcept
-        requires(has_data_interface_concept<T> and strided_view_concept<CT, S...>)
+        requires(data_interface_expression<T> and strided_view_concept<CT, S...>)
     {
         if (!m_strides_computed)
         {
@@ -1451,7 +1453,7 @@ namespace xt
     template <class CT, class... S>
     template <class E, class T>
     void xview<CT, S...>::assign_to(xexpression<E>& e, bool force_resize) const
-        requires(has_data_interface_concept<T> and contiguous_view_concept<E, S...>)
+        requires(data_interface_expression<T> and contiguous_view_concept<E, S...>)
     {
         auto& de = e.derived_cast();
         de.resize(shape(), force_resize);
@@ -1697,9 +1699,8 @@ namespace xt
             return xt::value(s, 0);
         };
 
-        auto s = static_cast<diff_type>(
-            (std::min)(static_cast<size_type>(std::distance(first, last)), this->dimension())
-        );
+        auto s = static_cast<diff_type>((std::min) (static_cast<size_type>(std::distance(first, last)),
+                                                    this->dimension()));
         auto first_copy = last - s;
         for (size_type i = 0; i != m_e.dimension(); ++i)
         {

--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -153,9 +153,7 @@ namespace xt
         // If we have no discontiguous slices, we can calculate strides for this view.
         template <class E, class... S>
         struct is_strided_view
-            : std::integral_constant<
-                  bool,
-                  has_data_interface<E>() && (is_strided_slice_impl<std::decay_t<S>>::value && ...)>
+            : std::integral_constant<bool, has_data_interface<E>() && (is_strided_slice_impl<std::decay_t<S>>::value && ...)>
         {
         };
 

--- a/test/test_sfinae.cpp
+++ b/test/test_sfinae.cpp
@@ -20,13 +20,13 @@
 
 namespace xt
 {
-    template <class E, std::enable_if_t<!xt::has_rank_t<E, 2>::value, int> = 0>
+    template <class E, std::enable_if_t<(xt::get_rank<E>() != 2), int> = 0>
     inline size_t sfinae_rank_basic_func(E&&)
     {
         return 0;
     }
 
-    template <class E, std::enable_if_t<xt::has_rank_t<E, 2>::value, int> = 0>
+    template <class E, std::enable_if_t<(xt::get_rank<E>() == 2), int> = 0>
     inline size_t sfinae_rank_basic_func(E&&)
     {
         return 2;
@@ -50,19 +50,19 @@ namespace xt
         EXPECT_TRUE(sfinae_rank_basic_func(2ul * c) == 0ul);
     }
 
-    template <class E, std::enable_if_t<xt::has_rank_t<E, SIZE_MAX>::value, int> = 0>
+    template <class E, std::enable_if_t<(xt::get_rank<E>() == SIZE_MAX), int> = 0>
     inline size_t sfinae_rank_func(E&&)
     {
         return 0;
     }
 
-    template <class E, std::enable_if_t<xt::has_rank_t<E, 1>::value, int> = 0>
+    template <class E, std::enable_if_t<(xt::get_rank<E>() == 1), int> = 0>
     inline size_t sfinae_rank_func(E&&)
     {
         return 1;
     }
 
-    template <class E, std::enable_if_t<xt::has_rank_t<E, 2>::value, int> = 0>
+    template <class E, std::enable_if_t<(xt::get_rank<E>() == 2), int> = 0>
     inline size_t sfinae_rank_func(E&&)
     {
         return 2;
@@ -86,13 +86,13 @@ namespace xt
         EXPECT_TRUE(sfinae_rank_func(2ul * c) == 0ul);
     }
 
-    template <class E, std::enable_if_t<!xt::has_fixed_rank_t<E>::value, int> = 0>
+    template <class E, std::enable_if_t<!xt::has_fixed_rank<E>(), int> = 0>
     inline bool sfinae_fixed_func(E&&)
     {
         return false;
     }
 
-    template <class E, std::enable_if_t<xt::has_fixed_rank_t<E>::value, int> = 0>
+    template <class E, std::enable_if_t<xt::has_fixed_rank<E>(), int> = 0>
     inline bool sfinae_fixed_func(E&&)
     {
         return true;
@@ -116,28 +116,17 @@ namespace xt
         EXPECT_TRUE(sfinae_fixed_func(2ul * c) == false);
     }
 
-    template <class T>
-    struct sfinae_get_rank
-    {
-        static const size_t rank = xt::get_rank<T>::value;
-
-        static size_t value()
-        {
-            return rank;
-        }
-    };
-
     TEST(sfinae, get_rank)
     {
         xt::xtensor<double, 1> A = xt::zeros<double>({2});
         xt::xtensor<double, 2> B = xt::zeros<double>({2, 2});
         xt::xarray<double> C = xt::zeros<double>({2, 2});
 
-        EXPECT_TRUE(sfinae_get_rank<decltype(A)>::value() == 1ul);
-        EXPECT_TRUE(sfinae_get_rank<decltype(B)>::value() == 2ul);
-        EXPECT_TRUE(sfinae_get_rank<decltype(C)>::value() == SIZE_MAX);
-        EXPECT_TRUE(sfinae_get_rank<decltype(2.0 * A)>::value() == SIZE_MAX);
-        EXPECT_TRUE(sfinae_get_rank<decltype(2.0 * B)>::value() == SIZE_MAX);
-        EXPECT_TRUE(sfinae_get_rank<decltype(2.0 * C)>::value() == SIZE_MAX);
+        static_assert(get_rank<decltype(A)>() == 1ul);
+        static_assert(get_rank<decltype(B)>() == 2ul);
+        static_assert(get_rank<decltype(C)>() == SIZE_MAX);
+        static_assert(get_rank<decltype(2.0 * A)>() == SIZE_MAX);
+        static_assert(get_rank<decltype(2.0 * B)>() == SIZE_MAX);
+        static_assert(get_rank<decltype(2.0 * C)>() == SIZE_MAX);
     }
 }

--- a/test/test_xeval.cpp
+++ b/test/test_xeval.cpp
@@ -61,7 +61,7 @@ namespace xt
 
 #define EXPECT_LAYOUT(EXPRESSION, LAYOUT) EXPECT_TRUE((decltype(EXPRESSION)::static_layout == LAYOUT))
 
-#define HAS_DATA_INTERFACE(EXPRESSION) raw_pointer_accessible_expression<std::decay_t<decltype(EXPRESSION)>>
+#define HAS_DATA_INTERFACE(EXPRESSION) data_interface_expression<std::decay_t<decltype(EXPRESSION)>>
 
 #define EXPECT_XARRAY(EXPRESSION) \
     EXPECT_TRUE(!detail::is_array<typename std::decay_t<decltype(EXPRESSION)>::shape_type>::value)

--- a/test/test_xeval.cpp
+++ b/test/test_xeval.cpp
@@ -61,7 +61,7 @@ namespace xt
 
 #define EXPECT_LAYOUT(EXPRESSION, LAYOUT) EXPECT_TRUE((decltype(EXPRESSION)::static_layout == LAYOUT))
 
-#define HAS_DATA_INTERFACE(EXPRESSION) has_data_interface<std::decay_t<decltype(EXPRESSION)>>()
+#define HAS_DATA_INTERFACE(EXPRESSION) raw_pointer_accessible_expression<std::decay_t<decltype(EXPRESSION)>>
 
 #define EXPECT_XARRAY(EXPRESSION) \
     EXPECT_TRUE(!detail::is_array<typename std::decay_t<decltype(EXPRESSION)>::shape_type>::value)

--- a/test/test_xeval.cpp
+++ b/test/test_xeval.cpp
@@ -61,7 +61,7 @@ namespace xt
 
 #define EXPECT_LAYOUT(EXPRESSION, LAYOUT) EXPECT_TRUE((decltype(EXPRESSION)::static_layout == LAYOUT))
 
-#define HAS_DATA_INTERFACE(EXPRESSION) has_data_interface<std::decay_t<decltype(EXPRESSION)>>::value
+#define HAS_DATA_INTERFACE(EXPRESSION) has_data_interface<std::decay_t<decltype(EXPRESSION)>>()
 
 #define EXPECT_XARRAY(EXPRESSION) \
     EXPECT_TRUE(!detail::is_array<typename std::decay_t<decltype(EXPRESSION)>::shape_type>::value)

--- a/test/test_xutils.cpp
+++ b/test/test_xutils.cpp
@@ -124,10 +124,10 @@ namespace xt
 
     TEST(utils, has_data_interface)
     {
-        static_assert(has_data_interface_concept<xarray<int>>);
-        static_assert(has_data_interface_concept<const xarray<int>>);
-        static_assert(has_data_interface_concept<const xtensor<double, 2>>);
-        static_assert(has_data_interface_concept<const xtensor_fixed<double, xshape<3, 4>>>);
+        static_assert(data_interface_expression<xarray<int>>);
+        static_assert(data_interface_expression<const xarray<int>>);
+        static_assert(data_interface_expression<const xtensor<double, 2>>);
+        static_assert(data_interface_expression<const xtensor_fixed<double, xshape<3, 4>>>);
 
         xarray<int> a = xarray<int>::from_shape({3, 4, 5});
         auto f = a + a - 23;
@@ -135,27 +135,27 @@ namespace xt
         auto vv2 = strided_view(v2, {all(), 2});
         auto v3 = strided_view(f, {all(), 2});
 
-        static_assert(has_data_interface_concept<decltype(v2)>);
-        static_assert(has_data_interface_concept<decltype(vv2)>);
-        static_assert(!has_data_interface_concept<decltype(v3)>);
+        static_assert(data_interface_expression<decltype(v2)>);
+        static_assert(data_interface_expression<decltype(vv2)>);
+        static_assert(!data_interface_expression<decltype(v3)>);
     }
 
     TEST(utils, has_storage_type)
     {
-        static_assert(has_storage_type<xarray<int>>());
+        static_assert(container_expression<xarray<int>>);
 
         xarray<int> x, y;
-        static_assert(!has_storage_type<decltype(x + y)>());
-        static_assert(has_storage_type<decltype(view(x, all()))>());
-        static_assert(!has_storage_type<decltype(view(2 * x, all()))>());
+        static_assert(!container_expression<decltype(x + y)>);
+        static_assert(container_expression<decltype(view(x, all()))>);
+        static_assert(!container_expression<decltype(view(2 * x, all()))>);
     }
 
     TEST(utils, has_strides)
     {
-        static_assert(has_strides<xarray<int>>());
-        static_assert(has_strides<const xarray<int>>());
-        static_assert(has_strides<const xtensor<double, 2>>());
-        static_assert(has_strides<const xtensor_fixed<double, xshape<3, 4>>>());
+        static_assert(strided_expression<xarray<int>>);
+        static_assert(strided_expression<const xarray<int>>);
+        static_assert(strided_expression<const xtensor<double, 2>>);
+        static_assert(strided_expression<const xtensor_fixed<double, xshape<3, 4>>>);
 
         xarray<int> a = xarray<int>::from_shape({3, 4, 5});
         auto f = a + a - 23;
@@ -163,12 +163,12 @@ namespace xt
         auto vv2 = strided_view(v2, {all(), 2});
         auto v3 = strided_view(f, {all(), 2});
 
-        static_assert(has_strides<decltype(v2)>());
-        static_assert(has_strides<decltype(vv2)>());
+        static_assert(strided_expression<decltype(v2)>);
+        static_assert(strided_expression<decltype(vv2)>);
 
 #ifndef _MSC_VER
         // TODO fix this test for MSVC 2015!
-        static_assert(has_strides<decltype(v3)>());
+        static_assert(strided_expression<decltype(v3)>);
 #endif
     }
 

--- a/test/test_xutils.cpp
+++ b/test/test_xutils.cpp
@@ -124,14 +124,10 @@ namespace xt
 
     TEST(utils, has_data_interface)
     {
-        bool b = has_data_interface<xarray<int>>::value;
-        EXPECT_TRUE(b);
-        b = has_data_interface<const xarray<int>>::value;
-        EXPECT_TRUE(b);
-        b = has_data_interface<const xtensor<double, 2>>::value;
-        EXPECT_TRUE(b);
-        b = has_data_interface<const xtensor_fixed<double, xshape<3, 4>>>::value;
-        EXPECT_TRUE(b);
+        static_assert(has_data_interface_concept<xarray<int>>);
+        static_assert(has_data_interface_concept<const xarray<int>>);
+        static_assert(has_data_interface_concept<const xtensor<double, 2>>);
+        static_assert(has_data_interface_concept<const xtensor_fixed<double, xshape<3, 4>>>);
 
         xarray<int> a = xarray<int>::from_shape({3, 4, 5});
         auto f = a + a - 23;
@@ -139,39 +135,27 @@ namespace xt
         auto vv2 = strided_view(v2, {all(), 2});
         auto v3 = strided_view(f, {all(), 2});
 
-        b = has_data_interface<decltype(v2)>::value;
-        EXPECT_TRUE(b);
-        b = has_data_interface<decltype(vv2)>::value;
-        EXPECT_TRUE(b);
-        b = has_data_interface<decltype(v3)>::value;
-        EXPECT_FALSE(b);
+        static_assert(has_data_interface_concept<decltype(v2)>);
+        static_assert(has_data_interface_concept<decltype(vv2)>);
+        static_assert(!has_data_interface_concept<decltype(v3)>);
     }
 
     TEST(utils, has_storage_type)
     {
-        bool b = has_storage_type<xarray<int>>::value;
-        EXPECT_TRUE(b);
+        static_assert(has_storage_type<xarray<int>>());
 
         xarray<int> x, y;
-        b = has_storage_type<decltype(x + y)>::value;
-        EXPECT_FALSE(b);
-
-        b = has_storage_type<decltype(view(x, all()))>::value;
-        EXPECT_TRUE(b);
-        b = has_storage_type<decltype(view(2 * x, all()))>::value;
-        EXPECT_FALSE(b);
+        static_assert(!has_storage_type<decltype(x + y)>());
+        static_assert(has_storage_type<decltype(view(x, all()))>());
+        static_assert(!has_storage_type<decltype(view(2 * x, all()))>());
     }
 
     TEST(utils, has_strides)
     {
-        bool b = has_strides<xarray<int>>::value;
-        EXPECT_TRUE(b);
-        b = has_strides<const xarray<int>>::value;
-        EXPECT_TRUE(b);
-        b = has_strides<const xtensor<double, 2>>::value;
-        EXPECT_TRUE(b);
-        b = has_strides<const xtensor_fixed<double, xshape<3, 4>>>::value;
-        EXPECT_TRUE(b);
+        static_assert(has_strides<xarray<int>>());
+        static_assert(has_strides<const xarray<int>>());
+        static_assert(has_strides<const xtensor<double, 2>>());
+        static_assert(has_strides<const xtensor_fixed<double, xshape<3, 4>>>());
 
         xarray<int> a = xarray<int>::from_shape({3, 4, 5});
         auto f = a + a - 23;
@@ -179,15 +163,12 @@ namespace xt
         auto vv2 = strided_view(v2, {all(), 2});
         auto v3 = strided_view(f, {all(), 2});
 
-        b = has_strides<decltype(v2)>::value;
-        EXPECT_TRUE(b);
-        b = has_strides<decltype(vv2)>::value;
-        EXPECT_TRUE(b);
+        static_assert(has_strides<decltype(v2)>());
+        static_assert(has_strides<decltype(vv2)>());
 
 #ifndef _MSC_VER
         // TODO fix this test for MSVC 2015!
-        b = has_strides<decltype(v3)>::value;
-        EXPECT_TRUE(b);
+        static_assert(has_strides<decltype(v3)>());
 #endif
     }
 


### PR DESCRIPTION
# Checklist

- [X] The title and commit message(s) are descriptive.
- [ ] Small commits made to fix your PR have been squashed to avoid history pollution.
- [X] Tests have been added for new features or bug fixes.
- [X] API of new functions and classes are documented.

# Description
With concepts and constexpr the library can be more readable and less reliant on recursion. This PR is the first of hopefully many that will flatten the template structure in xtensor logic without changing public interfaces or functionality. The goal is to make additional optimizations and functionality easier to reason about and implement moving forward. 

Additionally, eliminating recursion should help compile times!
