### PR TITLE
Use namespace runner for codspeed benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -2,7 +2,7 @@ name: CodSpeed
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request: # Allow CodSpeed to trigger backtest performance analysis
 
   workflow_dispatch:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -23,7 +23,7 @@ defaults:
 jobs:
   benchmarks:
     name: Run benchmarks
-    runs-on: namespace-profile-benchmark
+    runs-on: namespace-profile-benchmark;container.privileged=true;container.host-pid-namespace=true
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -2,10 +2,11 @@ name: CodSpeed
 
 on:
   push:
-    branches: [master]
-  pull_request:
-  # Allow CodSpeed to trigger backtest performance analysis
+    branches: [ master ]
+  pull_request: # Allow CodSpeed to trigger backtest performance analysis
+
   workflow_dispatch:
+
 
 permissions:
   contents: read
@@ -22,7 +23,7 @@ defaults:
 jobs:
   benchmarks:
     name: Run benchmarks
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-benchmark
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/include/xtensor/io/xcsv.hpp
+++ b/include/xtensor/io/xcsv.hpp
@@ -66,7 +66,7 @@ namespace xt
             }
 
             size_t last = cell.find_last_not_of(' ');
-            return cell.substr(first, last == std::string::npos ? cell.size() : last + 1);
+            return cell.substr(first, last == std::string::npos ? cell.size() : last - first + 1);
         }
 
         template <>
@@ -91,6 +91,18 @@ namespace xt
         inline int lexical_cast<int>(const std::string& cell)
         {
             return std::stoi(cell);
+        }
+
+        template <>
+        inline signed char lexical_cast<signed char>(const std::string& cell)
+        {
+            return static_cast<signed char>(std::stoi(cell));
+        }
+
+        template <>
+        inline unsigned char lexical_cast<unsigned char>(const std::string& cell)
+        {
+            return static_cast<unsigned char>(std::stoul(cell));
         }
 
         template <>


### PR DESCRIPTION
Use namespace runner for codespeed benchmarks
About performances, we almost cut by half the build and benchmark times with a machine with the same number of cores and the half of RAM.