### PR TITLE
Prevent view creation with underflowed size

### DIFF
--- a/include/xtensor/views/xslice.hpp
+++ b/include/xtensor/views/xslice.hpp
@@ -1058,8 +1058,13 @@ namespace xt
         , m_size(size_type(0))
         , m_step(step)
     {
+        if ((step > 0 && start_val >= stop_val) || (step < 0 && start_val <= stop_val))
+        {
+            m_size = 0;
+            return;
+        }
         size_type n = stop_val - start_val;
-        m_size = n / step + (((n < 0) ^ (step > 0)) && (n % step));
+        m_size = n / step + static_cast<bool>(n % step);
     }
 
     template <class T>

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -226,6 +226,41 @@ namespace xt
         EXPECT_EQ(view0, view1);
     }
 
+    TEST(xview, negative_step)
+    {
+        view_shape_type shape = {3, 4};
+        xarray<double> a(shape);
+        std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
+
+        auto view0 = view(a, 1, range(3, 0, -1));
+        EXPECT_EQ(size_t(1), view0.dimension());
+        EXPECT_EQ(size_t(3), view0.shape(0));
+        EXPECT_EQ(a(1, 3), view0(0));
+        EXPECT_EQ(a(1, 2), view0(1));
+        EXPECT_EQ(a(1, 1), view0(2));
+    }
+
+    TEST(xview, size_zero)
+    {
+        view_shape_type shape = {3, 4};
+        xarray<double> a(shape);
+        std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
+
+        auto view0 = view(a, 1, range(0, 0));
+        EXPECT_EQ(size_t(1), view0.dimension());
+        EXPECT_EQ(size_t(0), view0.shape(0));
+
+        auto view1 = view(a, 1, range(3, 0, 1));
+        EXPECT_EQ(size_t(1), view1.dimension());
+        EXPECT_EQ(size_t(0), view1.shape(0));
+
+        auto view2 = view(a, 1, range(0, 3, -1));
+        EXPECT_EQ(size_t(1), view2.dimension());
+        EXPECT_EQ(size_t(0), view2.shape(0));
+    }
+
     TEST(xview, stored_range)
     {
         view_shape_type shape = {3, 4};


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

When a slice with conditions such as `start > stop && step > 0` (or vice versa) is used to create a view (sliced or strided), the resulting array view can have an enormous size. Accessing its elements then leads to undefined behavior.

Here is a minimal example:

```cpp
#include <iostream>
#include <xtensor/containers/xarray.hpp>
#include <xtensor/views/xview.hpp>

int main()
{
    xt::xarray<int>::shape_type shape = {5};
    xt::xarray<int> a(shape);

    // v := a[3:0:1]
    auto slice = xt::range(3, 0, 1);
    auto v = xt::view(a, slice);

    // Print the shape of v
    for (auto e : v.shape())
    {
        std::cout << e << " ";
    }
    std::cout << std::endl;
}
```

The expected output is `0`, but the actual output is `18446744073709551613`.

The cause of this issue appears to be the size calculation in the `xstepped_range` constructor in `xtensor/include/xtensor/views/xslice.hpp`, shown below:

```cpp
template <class T>
inline xstepped_range<T>::xstepped_range(size_type start_val, size_type stop_val, size_type step) noexcept
    : m_start(start_val)
    , m_size(size_type(0))
    , m_step(step)
{
    size_type n = stop_val - start_val;
    m_size = n / step + (((n < 0) ^ (step > 0)) && (n % step));
}
```

When `start_val` is greater than `stop_val` (or more precisely, when `stop_val - start_val` has the opposite sign from `step`), `m_size` can become negative. This subsequently causes the resulting size to underflow.

One simple way to fix this issue is to clamp `m_size` to a minimum value of `0`:

```cpp
template <class T>
inline xstepped_range<T>::xstepped_range(size_type start_val, size_type stop_val, size_type step) noexcept
    : m_start(start_val)
    , m_size(size_type(0))
    , m_step(step)
{
    size_type n = stop_val - start_val;
    m_size = std::max(n / step + (((n < 0) ^ (step > 0)) && (n % step)), size_type(0));
}
```

Note on terminology: > I used the term "underflow" to describe "integer underflow", the behavior where subtracting from a small unsigned integer results in a huge value.